### PR TITLE
Wiki: 5 new pages, 6 expanded pages, reorganised sidebar

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,39 @@
+name: Sync wiki to GitHub Wiki
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'wiki/**'
+
+jobs:
+  sync-wiki:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+
+      - name: Clone wiki repo
+        run: |
+          git clone https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git wiki-repo
+
+      - name: Copy files from wiki/ into wiki repo
+        run: |
+          cp wiki/*.md wiki-repo/
+
+      - name: Commit and push if changed
+        run: |
+          cd wiki-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No wiki changes to push."
+          else
+            git commit -m "Sync wiki from main [skip ci]"
+            git push origin master
+          fi

--- a/wiki/ACRE-2-Long-Range-Radio-Presetting.md
+++ b/wiki/ACRE-2-Long-Range-Radio-Presetting.md
@@ -1,0 +1,46 @@
+_Associated Files: MissionScripts\MissionInit\ACRE2Init.sqf_
+
+This script allows for the automatic pre-setting of radio channels for ACRE 2 Radios based on the group name.
+
+This script Must only be called from the init.sqf.
+
+Your group must be named in the editor, you should use the CBA lobby screen naming functionality as well, and finally, ingame group names must match the name given in the parameters.
+
+The following radios are supported:
+* AN/PRC 343 (Setup Automatically and without manual setup in the parameters)
+* AN/PRC 152
+* AN/PC 148
+* AN/PRC 117F
+
+AN/PRC-343 Radios are automatically set up depending on the Squads callsign. See Squad Level Radios for more information, although you do not have to do anything to get that, or the CEOI to work.
+
+LR and SR radios are placed into an automated CEOI after use, see ACRE Automated CEOI for more details. Babel support and Language Documentation is also available - See ACRE Babel Activation for more details.
+
+## Setup And Examples
+
+1. In the init.sqf find the ACRE 2 setup section. It should look similar to the below:
+
+![Image of the ACRE2Init function call in the init.sqf](https://i.imgur.com/17lESXb.jpg)
+
+2. Uncomment the function call if it has been commented out (Remove the /* and */). Use VS code as described in the quickstart to make it easier for you.
+
+3. The mission maker must then specify up to three Long Rang Radio channels:
+
+`["Callsign",[channel_num_1,channel_num_2,channel_num_3]]`
+
+Where the "Callsign" matches the group name you entered in the group's Callsign attribute.
+
+![Example of the Callsign in a group init](https://i.imgur.com/wbOvpxC.jpg)
+
+And where channel_num_1,channel_num_2 and channel_num_3 indicate up to three channels you want that groups Long Range Radio holders to be tuned into. Channels will be set from left to right, starting at channel_num_1 and ending at channel_num_3. Channels will also be set on the shortest range radio first - so the 152 and 148 first, followed by the 117F. Channels will only be assigned if the player has enough LR radios to set the number of channels.
+
+Please note that all parameters must be given regardless of whether that group has or has not got any of those radios and that each line bar the last should have a comma at the end.
+
+Below is an example of the code, and the associated ingame setup to make this system work.
+
+![Example of a ACRE2 setup call from init.sqf](https://i.imgur.com/17lESXb.jpg)
+
+![Example of Thor and Odin groups, named correctly in callsign](https://i.imgur.com/wbOvpxC.jpg)
+
+
+Channel Naming is not supported. This is due to the fundamental method required to make that function work not being possible with the approach of this pack. For channel naming to work, radios must be added via a loadout script. This is not how we approach loadouts in the pack, and as such, channel naming instead breaks the radios - therefore, I do not support it.

--- a/wiki/ACRE-2-Squad-Level-Radios-AN-PRC‐343-Automatic-Setup.md
+++ b/wiki/ACRE-2-Squad-Level-Radios-AN-PRC‐343-Automatic-Setup.md
@@ -1,0 +1,19 @@
+Associated Files: MissionScripts\MissionInit\ACRE2\SquadLevelRadios.sqf
+
+This function sets up AN/PRC-343 Radio channels based on the group of the player based on callsign breakdown. 
+
+This handles the group-to-channel mapping and ensures that all clients share these channels.
+
+It sets up Block And Channel allocation based upon the callsigns list provided. This is by default via ACRE2Init.sqf as below:
+![](https://i.imgur.com/3CHplvL.png)
+
+# Logic Used
+
+The logic behind this setup is as follows:
+1. If a callsign has two numbers separated by either a hyphen or a full stop then the block number is designated as the first number, and the channel is the second. 
+2. If a callsign has either no number, or a single number a block is selected based on the index of the callsign in the list of callsigns provided. 
+    * In the case of the above example SUNRAY is Block 1, Foxhound is Block 2 and so on.
+    * If a callsign then has a number, its channel is set to that number in the block.
+    * If a callsign does not have a number, its channel is assigned based on the lowest number available in that block.
+3. If any of this fails, it assigns each squad a unique channel working backwards from 256. If a double up is detected due to a conflict in logic, the channel is set to the highest available.
+

--- a/wiki/ACRE2-Automated-CEOI-Document.md
+++ b/wiki/ACRE2-Automated-CEOI-Document.md
@@ -1,0 +1,36 @@
+_Associated Files: MissionScripts\MissionInit\ACRE2\CreateACRECEOI.sqf_
+
+This function takes available ACRE Radio information and documents it in a CEOI for the player to reference.
+Covered:
+- All LR channels and their denotation
+- Highlighting of LR channels if the player's squad is noted as supposed to be on that net.
+- AN/PRC-343 Block & Channel for the squad that the player is in.
+
+Arguments:
+_LRAssignments - from init.sqd via ACRE2Init.sqf - contains player squad LR channels from init.sqf ONLY.
+_SquadCallsigns - from ACRE2Init.sqf - contains a list of callsigns only
+
+
+Example:
+
+Should only really be called from ACRE2Init.sqf and not manually.
+
+
+## Setup
+
+The below example CEOI will use the same setup as seen in the ACRE2 Long Range Radio & Short Range Radio Presetting documentation. See those for details.
+
+Here is that for your reference: Each number is a Long Range Radio assignment for one of the following - 152,148,117F.
+![image](https://i.imgur.com/3CHplvL.png)
+
+Short range radio channels are automatically allocated based on the callsign defined in the section above.
+
+Long Range channel names have to be provided manually per side. These are defined here:
+![image](https://i.imgur.com/Mlnrkav.png)
+
+Channel names are broken down per side, and side is automatically chosen based on the players own side.
+
+The final CEOI looks like this:
+![](https://i.imgur.com/kyYkNQo.jpg)
+
+With the radio channels the player is preset on coloured in green.

--- a/wiki/ACRE2-Babel-Configuration.md
+++ b/wiki/ACRE2-Babel-Configuration.md
@@ -1,0 +1,51 @@
+_Associated Files: MissionScripts\MissionInit\ACRE2\BabelActivation.sqf_
+
+Description: 
+The script activates the Babel system in Arma 3 with Advanced Combat Radio Environment 2 (ACRE2). It sets up the languages spoken by different sides and defines the languages spoken by interpreters. It adds all the necessary languages to the ACRE2 Babel system, assigns them to the respective units based on the side they belong to, and creates a diary record with a list of languages spoken in the area, highlighting the ones the player can speak.
+
+Interpreters can speak all languages.
+
+Arguments:
+_languages - An array of sub-arrays. Each sub-array contains a side (West, East, Independent, Civilian) and the languages they speak as strings. 
+_interpreters - An array of units that are interpreters. These units can speak all languages.
+
+Returns:
+N/A. The script operates by side effect, creating diary records and setting up the ACRE2 Babel system.
+
+Example:
+[
+    [
+        [West, "English","French"],
+        [East, "Chinese"],
+        [independent, "Altian"],
+        [civilian, "Altian"]
+    ],
+    [unit, unit2]
+] call Waldo_fnc_BabelActivation;
+
+
+## Setup
+
+In the init.sqf you should uncomment the Waldo_fnc_BabelActivation function call.
+
+It is broken into two arrays:
+1. A 2d array which contains up to 4 sides and their associated spoken languages.
+2. A list of variable names which relate to units in the game. These individuals are interpreters.
+
+If you do not require Babel, comment out this section by surrounding it with /* and */.
+
+If you do not require any interpreters, you can remove the section list as shown below:
+![](https://i.imgur.com/IKIHu9s.png)
+
+If you do require interpreters you can add the variable names of units in the second array. The below example makes every player an interpreter.
+![](https://i.imgur.com/Qkf3S5a.png)
+
+## Output.
+
+Sides will be correctly setup with the Babel system, and a piece of documentation will be generated dynamically based on the languages used, and whether the player can speak it.
+
+If the player is an interpreter based on the above example, they will see this:
+![](https://i.imgur.com/uekMEWK.jpg)
+
+If the player is not an interpreter, and BLUFOR, based on the above example, they will see this:
+![](https://i.imgur.com/RpLDJJN.png)

--- a/wiki/AI-Convoy-System.md
+++ b/wiki/AI-Convoy-System.md
@@ -1,0 +1,59 @@
+_Associated Files: MissionScripts\AiScripting\simpleAiConvoy.sqf_
+
+A convoy script for AI vehicle groups, expanded and enhanced from Tova's original. It keeps vehicles in column formation, enforces convoy spacing, and forces stalled vehicles to follow the convoy leader. Optionally prevents AI from dismounting on contact, keeping the convoy moving through enemy fire.
+
+## Features
+
+- Maintains column formation with configurable vehicle spacing
+- Caps convoy speed so all vehicles move together
+- Detects stalled vehicles every 5 seconds and orders them back into formation
+- Optional `pushThrough` mode prevents AI from halting and dismounting on contact — units return fire while continuing to move
+
+## Setup
+
+Call the function from a trigger, script, or a waypoint **On Activation** field. Store the return handle so you can terminate the script at the end of the route.
+
+```sqf
+// Basic call — 30 km/h, 15 m spacing, pushThrough enabled
+convoyScript = [convoyGroup] spawn Waldo_fnc_SimpleAiConvoy;
+
+// Full parameters
+convoyScript = [convoyGroup, convoySpeed, convoySeparation, pushThrough] spawn Waldo_fnc_SimpleAiConvoy;
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `convoyGroup` | GROUP | — | The group to run as a convoy (required) |
+| `convoySpeed` | NUMBER | 30 | Maximum convoy speed in km/h |
+| `convoySeparation` | NUMBER | 15 | Target separation between vehicles in metres |
+| `pushThrough` | BOOL | true | When true, AI push through contact without dismounting |
+
+## Ending the Script
+
+In the group's **final waypoint On Activation** field, paste the following to terminate the convoy script and restore normal AI behaviour:
+
+```sqf
+terminate convoyScript;
+{ (vehicle _x) limitSpeed 5000; (vehicle _x) setUnloadInCombat [true, false] } forEach (units convoyGroup);
+convoyGroup enableAttack true;
+```
+
+## Multiple Convoys
+
+If you need more than one convoy running simultaneously, use a different handle name for each:
+
+```sqf
+convoyScript_1 = [PatrolGroup1, 30, 15, true]  spawn Waldo_fnc_SimpleAiConvoy;
+convoyScript_2 = [PatrolGroup2, 25, 20, false] spawn Waldo_fnc_SimpleAiConvoy;
+```
+
+Terminate each handle independently at their respective final waypoints.
+
+## Notes
+
+- Must be called with `spawn` — the script loops continuously and will block execution if called with `call`
+- `pushThrough` disables `enableAttack` on the group and prevents unloading in combat; always restore this via the termination block above
+- Works with any mix of vehicle types in the group
+- The script handles one group per call — for multiple convoys, call it once per group

--- a/wiki/Automatic-ACE-Fortify-Setup.md
+++ b/wiki/Automatic-ACE-Fortify-Setup.md
@@ -1,0 +1,51 @@
+# AutoFortifySetup Function
+
+## Description
+
+This script is designed to dynamically grab all objects synchronized to a game logic in Arma 3, add them to a side's fortify menu, and price them dynamically based on their volume & mass. The log scalars help keep the extremes (mostly) in step with everything else.
+
+## Usage
+
+To use this script in your Arma 3 mission:
+
+1. Make sure your player(s) have a fortify tool in their inventory.
+2. Place a game logic down and paste into its init the function call as noted below - alter it to fit your requirements.
+3. Synchronize to the game logic any objects or static weapons that you wish to be constructible in fortify. (Note: Vehicles other than static weapons are not supported due to concerning behavior.)
+4. If you require more than one side to use fortify, repeat the above steps in entirety and ensure the function call has the correct side in each.
+5. Run the game.
+
+## Parameters
+
+The function takes the following parameters:
+
+- `_target`: The object variable name you want this to apply to (The game logic)
+- `_side`: The side that the crate will populate the fortify list to. Each setup is single use as the objects and logic are destroyed afterward. Options: West, East, Independent, Civilian
+- `_budget`: User defined starting budget for the side, this can then be added to later on using the ACE_Fortify budget script.
+
+### Example
+
+```sqf
+[this, west, 6000] call Waldo_fnc_AutoFortifySetup;
+```
+
+
+## Budget updates
+
+ACE Fortify Budget Function can be used to update the given sides budget.
+
+ Arguments:
+  0: Side <SIDE>
+  1: Change <NUMBER> (default: 0)
+  2: Display hint <BOOL> (default: true)
+
+ Return Value:
+  None
+
+ Example:
+```sqf
+  [west, -250, false] call ace_fortify_fnc_updateBudget
+```
+
+## Zeus Budget Module
+
+I have also created a ZEN module which allows you to do this via Zeus during the mission if desired. You can find out how it works on the [Waldos Mission Pack Zeus Modules](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Mission-Pack-Zeus-Modules) page.

--- a/wiki/Coding-Standards.md
+++ b/wiki/Coding-Standards.md
@@ -1,0 +1,49 @@
+The following will note the standards that I attempt to uphold in the making of this pack. As I am but one man, however, and with this being a side project, the pack may not always be to this standard. Refactor and "standard" passes are committed every three months or so to bring severe cases in line with this standard where possible.
+
+# Text Editor
+You are free to select your own text editor for the creation or editing of your scripts, but I would advise selecting Visual Studio Code & Its SQF plugins. It'll make any script reading in Arma 3 easier on you! 
+- Visual Studio Code: https://code.visualstudio.com/
+- SQF Language Extension: https://marketplace.visualstudio.com/items?itemName=vlad333000.sqf
+- SQF Debugger Extension: https://marketplace.visualstudio.com/items?itemName=billw2011.sqf-debugger
+
+
+# Documentation
+Document the usage and generalised workings of a script to the best extent possible using comments and a script header. Clarity of the purpose of the script, where and how it can or is used should be the highest priority for maintenance and end-user purposes.
+
+## Script Header Requirements
+The script header is a large commented block at the head of the script, usually containing information about the script in question. This should contain the following:
+* Author of the script
+* Description of the purpose of the script, what it does and how
+* Break down the arguments, their position in the call and what type they can be
+* Return value if any
+* Example usage of the script
+
+### Script Header Example
+```
+ /*
+ * Author: myName, aGuyThatFixedTheFuctionName 
+ * Description of the function.
+ *
+ * Arguments:
+ * _argument1 - Vehicle/Object/Crate <OBJECT>
+ * _argument2 -  DescriptionOnParam <OBJECT/BOOL/NUMBER/STRING/ARRAY/CODE> (Optional) (Default; MyDefaultValue) 
+ * _argument3 -  DescriptionOnParam <OBJECT/BOOL/NUMBER/STRING/ARRAY/CODE> (Optional) 
+ *
+ * Return Value:
+ * PotentialReturnValueDescriprion <BOOL/NUMBER/STRING>
+ *
+ * Example:
+ * [thus,true,1,"string"] call Waldo_fnc_SomeFunction
+ *
+ * 
+ */
+```
+
+# Code Conventions
+## ACE Coding Guidelines
+Please adhere to the [ACE CODING GUIDELINES](https://github.com/acemod/ACE3/blob/master/docs/wiki/development/coding-guidelines.md) where possible
+
+## Specific differences to the ACE Coding Guidelines
+* Constants are types in full capitals: CONSTANT
+* Variables are to be in lower camel case: variablesAreFun , _variablesAreFun 
+* Functions are to be in upper camel case: Waldo_fnc_UpperCamelCaseFunction

--- a/wiki/Construction-Objects.md
+++ b/wiki/Construction-Objects.md
@@ -1,0 +1,30 @@
+_Associated Files: MissionScripts\Logistics\Construction\ConstructionObjects.sqf_
+
+This function allows you to fake the construction of defences/objects/scenery from a single object via Ace Interaction.
+
+Objects must be pre-placed in the editor around the item you wish to build from, but the interactable object does not need to be stationary.
+
+Construction objects can be transported in ACE cargo and retain its abilities.
+
+### Setting Up in Eden;
+* Place the object or object that you want to have the respawn deployable from, and provide it a variable name
+* Place a Game Logic down as close as possible to the object. This can be found near the same menu as Modules.
+* Place any objects you wish to appear when the object is interacted with..
+* If you are using an object as your primary object and any of your deployable objects should be resting on the floor, then raise them about a foot, to allow for the drop of the object's suspension once the game has initialised.
+* Select all the objects that will be deployable, right-click and synchronise them to the Game Logic.
+* In the object's init, paste the example below, and alter it to suit your needs.
+
+### Parameters:
+* _target - Vehicle or Object to use as the interactable to build synced objects from
+* _UseModernConsturctionAudio - boolean (true/false) | Options: True = Modern construction Noises, False = Old Wooden Sounding Construction Noises.
+
+Call:
+
+`[_target,_UseModernConsturctionAudio] call Waldo_fnc_ConstructionObjects;`
+
+e.g.
+
+`[this,true] call Waldo_fnc_ConstructionObjects; - use modern audio`
+
+Below is an example of the construction script correctly setup. The ammo box is the object the player interacts with:
+![Picture of the construction script in the editor](https://i.imgur.com/gYf9HQq.png)

--- a/wiki/ENDEX-Script-&-Custom-End-Screen.md
+++ b/wiki/ENDEX-Script-&-Custom-End-Screen.md
@@ -1,0 +1,39 @@
+_Associated Files: MissionScripts\MissionFlow\ENDEX.sqf_
+
+# ENDEX
+The ENDEX script performs the following actions:
+* Places all player weapons on Safe and prevents Players and player vehicles from firing.
+* Makes all Hostile AI Passive
+* Fully Heals all Players & Makes them invincible
+* Creates a popup informing players that the mission is over and to congregate together for debriefing.
+* If a player tries to fire their weapon or use grenades, it is deleted and a popup tells them to cease firing.
+
+You can call ENDEX by executing this line of code locally - such as a trigger:
+
+`[] spawn Waldo_fnc_ENDEX;`
+
+Alternatively, you could remotely execute it via a script:
+
+`remoteExec ["Waldo_fnc_ENDEX",0,true];`
+
+An example of it in use can be seen below:
+![Zeus Endex execution example](https://i.imgur.com/PBpewY8.png)
+
+# Custom End Screen
+At the base of the description.ext provided, you can find a custom end card section.
+
+You can customise this section to display a custom end screen Title, Subtitle and description - similar to that in Zeus, but with greater control.
+
+![Picture of the description.ext showing the custom end screen](https://i.imgur.com/XuVkkmF.png)
+
+You can then end the mission with this custom end screen by executing the following script:
+
+`["end1"] remoteExec ["BIS_fnc_endMission",0,true];`
+
+Below is an example of the custom mission end screen:
+![Mission End Screen Example](https://i.imgur.com/xmK9I1e.png)
+
+## Zeus Usage
+You may also use the provided Zeus Enhanced modules in the pack to perform both of these actions. 
+
+[Waldos Mission Pack Zeus Modules](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Mission-Pack-Zeus-Modules) are covered separately.

--- a/wiki/Feature-Tutorials.md
+++ b/wiki/Feature-Tutorials.md
@@ -1,0 +1,47 @@
+This page is designed to give you quick access to the knowledge you need to use non-automatic sections of the script pack. 
+
+It is not exhaustive but covers most of the features most helpful to mission makers.
+
+The basic Setup is covered in the [Quickstart Guide ](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Quickstart-Guide).
+
+[Waldos Mission Pack Zeus Modules](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Mission-Pack-Zeus-Modules) are covered separately.
+
+# Features:
+
+## Mission Flow & UI
+* [Mission Intro Text](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Intro-Or-Title-Text)
+* [Mission UI Text Overlays](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-UI-Text-Overlays) — Dynamic text, timed hints, respawn text
+* [ENDEX Script & Custom End Screen](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ENDEX-Script-&-Custom-End-Screen)
+* [Radio Reports, Checklists, Support Calls And Documentation](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Reports,-Checklists,-Support-Calls-And-Documentation)
+* [Team Colour Setup](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Team-Colour-Setup)
+
+## Logistics & Crates
+* [Logistics System, Starter Crates And Quartermaster](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Logistics-System,-Starter-Crates-And-Quartermaster)
+* [Loadout Saving and Respawn](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Loadout-Saving-and-Respawn)
+* [Mobile Command Post With Integrated Logistics System](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mobile-Command-Post-With-Integrated-Logistics-System)
+* [Virtual Vehicle Depot](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Virtual-Vehicle-Depot)
+
+## Vehicles & Deployment
+* [Vehicle Actions & Paradrop](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Vehicle-Actions-&-Paradrop)
+* [Vehicle Ambush Script And Vehicle Camo](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Vehicle-Ambush-Script-And-Vehicle-Camo)
+* [Teleportation & Move Into Cargo Interactions](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Teleportation-&-Move-Into-Cargo-Interactions)
+* [Weapon Mounting With Custom Name](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Weapon-Mounting-With-Custom-Name)
+
+## Construction & Fortification
+* [Construction Objects](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Construction-Objects)
+* [Automatic Fortify Setup](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Automatic-ACE-Fortify-Setup)
+* [Simple Mass Attach Items](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Simple-Mass-Attach-Items)
+
+## AI & Map
+* [Waldos AI Tweak](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-AI-Tweak)
+* [AI Convoy System](https://github.com/AdamWaldie/WaldosMissionPack/wiki/AI-Convoy-System)
+* [Map Location Tools](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Map-Location-Tools)
+
+## ACRE 2 Radio
+* [ACRE 2 Long Range Radio Presetting](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE-2-Long-Range-Radio-Presetting)
+* [ACRE 2 Short Range Radio Presetting](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE-2-Squad-Level-Radios-AN-PRC%E2%80%90343-Automatic-Setup)
+* [ACRE 2 Automated CEOI](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Automated-CEOI-Document)
+* [ACRE 2 Babel Autoconfig](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Babel-Configuration)
+
+## Mission Maker Tools
+* [Mission Maker Resource Scripts](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Maker-Resource-Scripts) — Debug tools, arsenal toolkit, damage monitor

--- a/wiki/Feature-Tutorials.md
+++ b/wiki/Feature-Tutorials.md
@@ -1,19 +1,20 @@
-This page is designed to give you quick access to the knowledge you need to use non-automatic sections of the script pack. 
+This page gives you quick access to documentation for every feature in the pack.
 
-It is not exhaustive but covers most of the features most helpful to mission makers.
-
-The basic Setup is covered in the [Quickstart Guide ](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Quickstart-Guide).
+The basic setup is covered in the [Quickstart Guide](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Quickstart-Guide).
 
 [Waldos Mission Pack Zeus Modules](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Mission-Pack-Zeus-Modules) are covered separately.
 
-# Features:
+---
+
+## Configuration Reference
+* [Mission Configuration Reference](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Configuration-Reference) — description.ext, init.sqf, initServer.sqf field reference
 
 ## Mission Flow & UI
 * [Mission Intro Text](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Intro-Or-Title-Text)
 * [Mission UI Text Overlays](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-UI-Text-Overlays) — Dynamic text, timed hints, respawn text
 * [ENDEX Script & Custom End Screen](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ENDEX-Script-&-Custom-End-Screen)
 * [Radio Reports, Checklists, Support Calls And Documentation](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Reports,-Checklists,-Support-Calls-And-Documentation)
-* [Team Colour Setup](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Team-Colour-Setup)
+* [Team Colour Setup](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Team-Colour-Setup) — Also covers GetPlayerGroup and GetPlayerRole helpers
 
 ## Logistics & Crates
 * [Logistics System, Starter Crates And Quartermaster](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Logistics-System,-Starter-Crates-And-Quartermaster)
@@ -22,7 +23,7 @@ The basic Setup is covered in the [Quickstart Guide ](https://github.com/AdamWal
 * [Virtual Vehicle Depot](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Virtual-Vehicle-Depot)
 
 ## Vehicles & Deployment
-* [Vehicle Actions & Paradrop](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Vehicle-Actions-&-Paradrop)
+* [Vehicle Actions & Paradrop](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Vehicle-Actions-&-Paradrop) — Auto-detected vehicles, equipment simulation, parachute backpack system
 * [Vehicle Ambush Script And Vehicle Camo](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Vehicle-Ambush-Script-And-Vehicle-Camo)
 * [Teleportation & Move Into Cargo Interactions](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Teleportation-&-Move-Into-Cargo-Interactions)
 * [Weapon Mounting With Custom Name](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Weapon-Mounting-With-Custom-Name)
@@ -43,5 +44,6 @@ The basic Setup is covered in the [Quickstart Guide ](https://github.com/AdamWal
 * [ACRE 2 Automated CEOI](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Automated-CEOI-Document)
 * [ACRE 2 Babel Autoconfig](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Babel-Configuration)
 
-## Mission Maker Tools
+## Miscellaneous
+* [Unit Insignias](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Unit-Insignias)
 * [Mission Maker Resource Scripts](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Maker-Resource-Scripts) — Debug tools, arsenal toolkit, damage monitor

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,50 @@
+![alt text](https://github.com/AdamWaldie/WaldosMissionPack/blob/main/Pictures/loading.jpg?raw=true)
+<p align="center">Welcome to the Waldos Mission Pack Wiki!</p>
+
+# About The Pack
+This project was initially envisioned as an easy-to-access, flexible alternative for new mission makers. Requiring little knowledge of the Arma 3 engine, mission makers can use this pack and its associated features to enrich their missions without expending the level of effort required to see what's behind the proverbial curtain.
+
+Created initially for the mission makers of the Rooster Teeth Discord Arma group, this pack is in continued use by at least forty known units from all corners of the milsimsphere due to its unrestricted versatility and its relative ease of use. In its spread, it is hoped that this pack will act as a bridge to guide people through the basics of mission-making and support experienced mission-makers to a higher degree.
+
+The pack has two aims:
+1. To provide an easy-to-use and supportive pack of functions and compositions to help newer, or less programmatically inclined, members of the mission maker community
+2. To provide extensive documentation to assist in understanding the pack and, if so desired, the wider Arma programming world. A specific choice was made to tailor the pack so that it is as easy as possible to read and reverse engineer at the expense of some efficiency. This shouldn't be impactful in any meaningful way.
+
+# Quickstart Guide and Tutorials
+I maintain this wiki regularly and keep it updated with tutorials on the vast majority of features in the pack and provide a quickstart guide:
+* [Quickstart Guide ](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Quickstart-Guide)
+* [Feature Tutorials](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Feature-Tutorials)
+* [Waldos Mission Pack Zeus Modules](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Mission-Pack-Zeus-Modules)
+
+# Pack Features
+- Loadout saving and respawn system
+- Automatic ACRE2 Radio setup and respawn handling - based on mission makers specification in init.sqf
+- Custom loadout & logistics system which scrapes the kits of all playable characters to fulfil base logistical needs - such as starter crates and supply crates. (Disable scenario Binarization, and edit loadouts via ACE Arsenal to ensure 100% satisfaction)
+- Vehicle Ambush/Camo scripts.
+- Vehicle unflipping actions
+- Simple AI convoy script expanded and enhanced from Tovas original.
+- Teleportation Script
+- Endex & Safestart Scripts
+- Custom Zeus Enhanced modules for in-game access to the logistics system and ENDEX scripts.
+- HALO & Static Line Jump Scripts with equipment & weapon loss simulation.
+- [WIP] Virtual Vehicle Deployment Garage
+- Extensively documented files to learn how it works, and make use of this pack!
+- Mission Pack Compositions to hasten the learning and mission building process
+- [Radio Reports, Checklists, Support Calls And Documentation](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Reports,-Checklists,-Support-Calls-And-Documentation)
+
+# Required Addons
+- CBA_A3
+- ACE 3
+
+# Supported Addons
+- ACRE 2
+- TFAR (Inherrent support via 3Eden)
+- Zeus Enhanced & Compat
+- LAMBS Series of mods
+- All unit mods compatible
+
+***
+
+<p align="center"><a href="https://www.buymeacoffee.com/thewaldo123" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-blue.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a></p>
+
+<p align="center">This pack is presently maintained solely by Waldo.</p>

--- a/wiki/Loadout-Saving-and-Respawn.md
+++ b/wiki/Loadout-Saving-and-Respawn.md
@@ -1,0 +1,74 @@
+_Associated Files: initPlayerLocal.sqf_
+
+# General Setup
+
+Loadout saving is automatically active as soon as the pack is merged into your mission folder — no additional configuration is needed for the basic feature.
+
+By default, upon dying, players respawn with the loadout they had at the start of the mission (or whatever they last saved manually via a starter crate). ACRE2 radio channels are re-assigned automatically on respawn as part of this system.
+
+> **Important:** `respawnOnStart = -1` in `description.ext` is required for this system to work correctly. Do not change this value.
+
+---
+
+# Respawn Options
+
+## Default: Respawn With Starting Loadout
+
+No setup required. Players automatically respawn with the loadout saved at mission start.
+
+## Option: Respawn With Death Loadout
+
+To have players respawn with whatever they were carrying when they died (rather than their starting kit), uncomment the noted section in `initPlayerLocal.sqf`:
+
+![IPL](https://i.imgur.com/L1JxR3C.png)
+
+```sqf
+["CAManBase", "Killed", {
+    params ["_unit"];
+    if (_unit == player) then {
+        [_unit, [player, "Waldo_Player_Inventory"]] call BIS_fnc_saveInventory;
+    };
+}] call CBA_fnc_addClassEventHandler;
+```
+
+## Option: Save Loadout on ACE Arsenal Close
+
+To automatically save the player's respawn loadout whenever they close the ACE Arsenal (so players respawn with their chosen kit), uncomment the section immediately above the death loadout code in `initPlayerLocal.sqf`:
+
+```sqf
+["ace_arsenal_displayClosed", {
+    [player, [missionNamespace, "Waldo_Player_Inventory"]] call BIS_fnc_saveInventory;
+}] call CBA_fnc_addEventHandler;
+```
+
+Both options can be enabled simultaneously — the death-loadout save will overwrite the arsenal save on each death.
+
+---
+
+# Manual Loadout Saving
+
+Players can also save their loadout manually. The simplest method is via any **Starter Crate** — these already include a save action by default. See [Logistics System](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Logistics-System,-Starter-Crates-And-Quartermaster) for starter crate setup.
+
+For custom implementations:
+
+**ACE interaction on an object:**
+
+```sqf
+this addAction ["<t color='#00FF00'>Save Respawn Loadout</t>", Waldo_fnc_SaveLoadout];
+```
+
+**Direct function call (from a trigger or script):**
+
+```sqf
+[] call Waldo_fnc_SaveLoadout;
+```
+
+---
+
+# Potential Conflicts
+
+**ACE Respawn** conflicts with this feature. Disable it in server and mission addon settings:
+
+`Settings → Addon Settings → ACE Respawn → disable`
+
+If ACE Respawn is active, loadout restoration on respawn will not function correctly.

--- a/wiki/Logistics-System,-Starter-Crates-And-Quartermaster.md
+++ b/wiki/Logistics-System,-Starter-Crates-And-Quartermaster.md
@@ -129,10 +129,27 @@ Example which spawns logistics crates behind the interaction point, 4 meters awa
 `[this,180,4] call Waldo_fnc_SetupQuarterMaster; `
 
 
+## What the Quartermaster Spawns
+
+| ACE Interaction | Contents | Notes |
+|---|---|---|
+| **Medical Box** | ACE medical supplies (if ACE Medical loaded), or vanilla medical supplies | Marked as ACE field hospital; draggable/carryable |
+| **Supply Box** | All weapons, ammo, attachments, equipment from mission loadouts (full side complement) | |
+| **Ammo Box** | Ammo only (0.75× scale supply, no weapons or equipment) | |
+| **ACE Wheel** | `ACE_Wheel` — spare vehicle wheel | |
+| **ACE Track** | `ACE_Track` — spare vehicle track | |
+
+The Quartermaster prevents duplicates: if a box of the same type already exists within 5 m of the spawn point, a new one will not be spawned and the QM will say so.
+
 ## Changing the Boxes The Quartermaster Spawns
-You can edit class of crate spawned for both medical and supply boxes in the initServer.sqf:
+You can edit the class of crate spawned for both medical and supply boxes in `initServer.sqf`:
 ![Picture displaying the appropriate place in Initserver.sqf to change the boxes](https://i.imgur.com/0CdEY8U.png)
 
-**Logi_SupplyBoxClass** is the class of box which will spawn when ammo or resupply boxes are spawned.
+**Logi_SupplyBoxClass** is the class of box spawned for supply and ammo requests.
 
-**Logi_MedicalBoxClass** is the class of box which will spawn when a medical box is spawned.
+**Logi_MedicalBoxClass** is the class of box spawned for medical requests.
+
+```sqf
+missionNamespace setVariable ["Logi_SupplyBoxClass", "B_supplyCrate_F", true];
+missionNamespace setVariable ["Logi_MedicalBoxClass", "ACE_medicalSupplyCrate_advanced", true];
+```

--- a/wiki/Logistics-System,-Starter-Crates-And-Quartermaster.md
+++ b/wiki/Logistics-System,-Starter-Crates-And-Quartermaster.md
@@ -1,0 +1,138 @@
+_Associated Files: MissionScripts\Logistics\Crates_
+
+The logistics system in WaldosMissionPack is more automated than most of the comparable script packs.
+
+The mission pack scrapes through player loadouts to construct a unique list of gear per side, which can then be used to resupply players in the field via the ZEN modules, or used as part of the Quartermaster, Logistics crates, MHQ or Starter Crates.
+
+The initial call for this scrape can be found in the initServer.sqf file pictured below:
+![Loadout scrape call in initServer.sqf](https://i.imgur.com/zgkHsqA.png)
+
+
+# The Three Rules
+The following three rules must be adhered to for the logistics system to function:
+1. The Mission Must **NOT** be binaried.
+2. Player load-outs must be customised via an arsenal and cannot be default unit kits.
+3. Player units must not be placed in an organiser folder in the editor; they must remain under the BLUFOR, OPFOR, INDEPENDENT and CIVILIAN side folders.
+
+Failure to follow these rules will lead to unexpected results.
+
+# Logistics Features
+* Automated Supply, Medical and Starter Crates based on Player Loadouts.
+* Logistics Quartermaster to spawn Supplies, Medical Supplies, ACE Tracks, and ACE Wheels.
+* Limited ACE Arsenal based on Player Loadouts.
+* Mobile Command Post / MHQ integration so that the Mobile Command Post / MHQ can act as a Logistics Quartermaster.
+
+
+
+# Logistics Crates
+
+## Starter Crates
+
+This transforms an object's inventory to house supplies, allowing players to save their respawn loadout or use a limited/unlimited arsenal if enabled.
+
+Simply paste and edit the example below into an object's init to turn it into a starter crate.
+
+Does the following:
+* Adds addaction to allow for the saving of loadout
+* Adds limited Ace Arsenal (Mission.sqm bound)
+* Adds supplies (Mission.sqm bound)
+
+
+Parameters:
+* _target - the object variable name you want this to apply to
+* _arsenal - boolean as tto whether you want an ACE/Vanilla arsenal or not
+* _crateSide - the side that the crate will populate equipment from. Options: West,East,Independent,Civilian
+* _unrestrictedArsenal - boolean as to whether you want the arsenal to be unrestricted or not.
+
+
+To call
+
+`[_target,_arsenal,_crateSide,_unrestrictedArsenal] spawn Waldo_fnc_DoStarterCrate;`
+
+e.g.
+
+`[this,true,west,false] spawn Waldo_fnc_DoStarterCrate;`
+
+## Supply Crate
+This function populates a supply crate, with basic medical supplied (quickclot & splints) based on players' inventory & weaponry in the mission.sqm
+
+Simply paste and edit the example below into an object's init to turn it into a supplycrate.
+
+Params:
+* _crate - object to populate (Passed from module where thee classname of the box is defined)
+* _size - scalar value to multiply medical supplycompliment
+* _crateSupplyside - (STRING) the side that the crate will populate equipment from. Options: west,east,independent,civilian
+* _weaponsAttachmentsUniforms - boolean (true/false) variable to dennote whether weapons, weapon attachments, equipment and clothing should be added.
+* _includeLaunchersAndLauncherAmmo - boolean (true/false) variable to dennote whether launchers and their ammo should be added.
+
+Where the call is as follows:
+
+`[_crate, _size, _crateSupplyside, _fullCompliment, _includeLaunchersAndLauncherAmmo ] spawn Waldo_fnc_SupplyCratePopulate;`
+
+e.g.
+
+`[this, 1, west, false, true] spawn Waldo_fnc_SupplyCratePopulate;`
+
+## Medical Crate
+This function populates an advanced medical crate, with the option to enable the box as a field hospital if desired.
+
+Simply paste and edit the example below into an object's init to turn it into a medical crate.
+
+Params:
+* _crate - object to populate
+* _isFacility - tickbox option to enable locational boost to medical skill
+* _scale - scalar value to multiply medical supply complement
+
+Where the call is as follows:
+
+`[_crate, _fieldHopsital, _size] call Waldo_fnc_MedicalCratePopulate;`
+
+e.g.
+
+`[this, true, 1] call Waldo_fnc_MedicalCratePopulate;`
+
+
+# Limited Arsenal
+Function to create an ace limited arsenal on the object, limited to the equipment retrieved from the mission.sqm
+
+Simply paste and edit the example below into an object's init to turn it into a limited arsenal.
+
+Parameters:
+* _target - the object variable name you want this to apply to
+* _crateSupplyside - the side that the crate will populate equipment from. Options: West,East,Independent,Civilian
+* _preExisting - user-defined boolean for specifying whether an ace arsenal already exists on the object.
+
+`[_target,_crateSupplyside,_preExisting] spawn Waldo_fnc_CreateLimitedArsenal;`
+
+e.g.
+
+`[this, west, false] spawn Waldo_fnc_CreateLimitedArsenal;`
+
+
+
+# Logistics Quartermaster
+This is used to set up the logistics spawning system via the "Quartermaster". The Quartermaster is an object or NPC which acts as the spawner for supply boxes & equipment.
+
+Simply paste and edit the example below into an object's init to turn it into a quartermaster.
+
+Params:
+* _target - The quartermaster from which you can select these actions
+* _offsetDegrees - determines the bearing around the vehicle the spawner will be. Based on vehicle heading, not compass. E.g 0 = Front, 90 = Right, 180 = Rear, 270 = Left.
+* _offsetDistance - determines how far away from the vehicle the logistics spawner will be.
+
+Exemplar:
+
+`[this] call Waldo_fnc_SetupQuarterMaster; `
+
+Example which spawns logistics crates behind the interaction point, 4 meters away.
+
+`[this,180,4] call Waldo_fnc_SetupQuarterMaster; `
+
+
+## Changing the Boxes The Quartermaster Spawns
+You can edit class of crate spawned for both medical and supply boxes in the initServer.sqf:
+![Picture displaying the appropriate place in Initserver.sqf to change the boxes](https://i.imgur.com/0CdEY8U.png)
+
+**Logi_SupplyBoxClass** is the class of box which will spawn when ammo or resupply boxes are spawned.
+
+**Logi_MedicalBoxClass** is the class of box which will spawn when a medical box is spawned.

--- a/wiki/Map-Location-Tools.md
+++ b/wiki/Map-Location-Tools.md
@@ -1,0 +1,83 @@
+_Associated Files:_
+- _MissionScripts\Logistics\LogiHelpers\createNewMapLocation.sqf_
+- _MissionScripts\Logistics\LogiHelpers\replaceMapLocationName.sqf_
+
+Two functions for modifying the named locations players see on the in-game map. Useful for renaming real-world map locations to fit mission lore, or adding new named points of interest such as FOBs and objectives.
+
+Both functions require a **Game Logic** placed in the Eden Editor as a position reference.
+
+---
+
+## Create New Map Location
+
+`Waldo_fnc_CreateMapLocationName` creates a brand-new named location at a game logic's position, independently of any existing Arma 3 map data.
+
+### Setup in Eden
+
+1. Place a **Game Logic** (found in the Modules menu) where you want the location to appear on the map, and give it a variable name (e.g. `FobBartLogic`).
+2. Call the function from `init.sqf` or a trigger.
+
+### Parameters
+
+| # | Type | Description |
+|---|---|---|
+| 0 | OBJECT | The game logic object to use as the position reference |
+| 1 | STRING | The display name for the new location |
+| 2 | STRING | The location type (controls icon and map behaviour — see table below) |
+
+### Example
+
+```sqf
+[FobBartLogic, "FOB Bart", "NameVillage"] call Waldo_fnc_CreateMapLocationName;
+[MainAirfieldLogic, "Tempest International", "NameLocal"] call Waldo_fnc_CreateMapLocationName;
+```
+
+---
+
+## Replace Existing Map Location Name
+
+`Waldo_fnc_ReplaceMapLocationName` finds the nearest existing named location to a game logic and renames it. Use this to rename pre-existing Arma 3 map locations (cities, mountains, airfields).
+
+### Setup in Eden
+
+1. Place a **Game Logic** near the map location you want to rename and give it a variable name.
+2. Call the function from `init.sqf`.
+
+### Parameters
+
+| # | Type | Description |
+|---|---|---|
+| 0 | OBJECT | The game logic object near the location to rename |
+| 1 | STRING | The new name to apply |
+| 2 | STRING | The new location type |
+
+### Example
+
+```sqf
+[AltisAirportLogic, "Al-Rayak Air Base", "NameLocal"] call Waldo_fnc_ReplaceMapLocationName;
+[KavalaLogic, "Port Kavala", "NameCity"] call Waldo_fnc_ReplaceMapLocationName;
+```
+
+---
+
+## Common Location Types
+
+Only types defined in `CfgLocationTypes` will display correctly. Commonly used types are listed below.
+
+| Type | Description |
+|---|---|
+| `NameCity` | City |
+| `NameCityCapital` | Capital city |
+| `NameVillage` | Village or small settlement |
+| `NameLocal` | Local area name (also used for airports) |
+| `NameMarine` | Sea or ocean area |
+| `Mount` | Mountain peak |
+| `Hill` | Hill |
+| `FlatArea` | Open flat terrain |
+| `FlatAreaCity` | Urban flat area |
+| `Strategic` | Strategic point of interest |
+| `b_hq` | BLUFOR HQ marker icon |
+| `o_hq` | OPFOR HQ marker icon |
+| `n_hq` | Independent HQ marker icon |
+
+> The full list of available location types is documented inside both `.sqf` files as a commented reference block.

--- a/wiki/Mission-Configuration-Reference.md
+++ b/wiki/Mission-Configuration-Reference.md
@@ -1,0 +1,231 @@
+This page documents all the configuration fields and variables that mission makers are expected to customise before shipping a mission built on WMP. It covers `description.ext`, `init.sqf`, and `initServer.sqf`.
+
+---
+
+## description.ext
+
+Located in the mission root. Sets mission metadata, respawn rules, and includes all WMP scripts.
+
+### Identity Fields
+
+```sqf
+author      = "YOURNAMEHERE";       // Your name, shown on the loading screen
+onLoadName  = "Mission Pack v4.7.2"; // Mission title — also used by Waldo_fnc_InfoText
+onLoadMission = "YOURTEXTHERE";     // Mission subtitle
+onLoadIntro   = "YOURTEXTHERE";     // Additional intro subtitle
+loadScreen    = "Pictures\loading.jpg"; // Replace with your own image
+overviewPicture = "Pictures\loading.jpg";
+```
+
+> Replace `Pictures\loading.jpg` with a custom image (JPG or PAA). Keep the same filename or update both paths.
+
+### Player Count
+
+```sqf
+class Header {
+    gameType   = Coop;
+    minPlayers = 1;
+    maxPlayers = 31;  // set to your actual maximum player count
+};
+```
+
+### Respawn
+
+```sqf
+respawn      = BASE;   // Respawn method. BASE = on a respawn marker/module.
+respawnDelay = 20;     // Seconds before a player can respawn
+respawnOnStart = -1;   // DO NOT CHANGE — required by the loadout saving system
+respawnTemplatesWest[] = {"MenuPosition","Counter"};
+respawnTemplatesEast[] = {"MenuPosition","Counter"};
+respawnTemplatesGuer[] = {"MenuPosition","Counter"};
+respawnTemplatesCiv[]  = {"MenuPosition","Counter"};
+```
+
+> `respawnOnStart = -1` is mandatory. Changing it will break loadout saving and respawn behaviour.
+
+### Custom End Screen
+
+```sqf
+class CfgDebriefing {
+    class End1 {
+        title       = "MISSION COMPLETE";
+        subtitle    = "Objectives Complete";
+        description = "Good Job!";
+        pictureBackground = "Pictures\loading.jpg";
+    };
+};
+```
+
+Trigger with: `["end1"] remoteExec ["BIS_fnc_endMission", 0, true];`
+
+See [ENDEX Script & Custom End Screen](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ENDEX-Script-&-Custom-End-Screen) for full details.
+
+### Includes (do not remove)
+
+```sqf
+#include "MissionScripts\WaldosFunctions.sqf"             // Required — registers all functions
+#include "MissionScripts\Logistics\VirtualVehicleDepot\GarageDisplayDefine.hpp"  // VVD GUI
+class MissionSQM { #include "mission.sqm" };              // Required for logistics loadout scanning
+```
+
+---
+
+## initServer.sqf
+
+Runs **on the server only**. Configure logistics crate classnames and paradrop thresholds here.
+
+### Logistics Crate Classnames
+
+```sqf
+// The crate spawned for supply/ammo requests (Quartermaster and Zeus module)
+missionNamespace setVariable ["Logi_SupplyBoxClass", "B_supplyCrate_F", true];
+
+// The crate spawned for medical requests
+// Defaults to ACE advanced crate if ACE Medical is loaded, IDAP crate otherwise
+missionNamespace setVariable ["Logi_MedicalBoxClass", "ACE_medicalSupplyCrate_advanced", true];
+```
+
+Replace the classname string with any crate classname from your mod set.
+
+### Paradrop Thresholds
+
+```sqf
+// Static Line — jump available between these altitudes and below this speed
+missionNamespace setVariable ["WALDO_STATIC_MINALTITUDE", 180,  true]; // metres AGL minimum
+missionNamespace setVariable ["WALDO_STATIC_MAXALTITUDE", 350,  true]; // metres AGL maximum
+missionNamespace setVariable ["WALDO_STATIC_MAXSPEED",    310,  true]; // km/h maximum
+missionNamespace setVariable ["WALDO_STATIC_STATICCHUTE", "rhs_d6_Parachute", true]; // chute class
+
+// HALO — jump available above this altitude
+missionNamespace setVariable ["WALDO_PARA_HALOALTITUDE", 1000,  true]; // metres AGL minimum
+missionNamespace setVariable ["WALDO_PARA_HALOCHUTE",    "B_Parachute", true]; // chute class
+```
+
+For non-RHS missions, replace `"rhs_d6_Parachute"` with `"NonSteerable_Parachute_F"` (vanilla).
+
+---
+
+## init.sqf
+
+Runs on **all clients and the server** during the loading screen transition. Enable, disable and configure the majority of WMP features here.
+
+### Third-Party Scripts (disabled by default)
+
+```sqf
+// Remove the // to enable headless client and player markers
+// [] execVM "MissionScripts\ThirdPartyScripts\ThirdPartyScriptInit.sqf";
+```
+
+### Zeus Enhanced Modules
+
+```sqf
+[] call Waldo_fnc_ZenInitModules;  // remove this line to disable Zeus modules
+```
+
+### ACE Drag/Carry Weight Limits
+
+```sqf
+ACE_maxWeightDrag  = 10000;  // max weight in grams a player can drag
+ACE_maxWeightCarry = 6000;   // max weight in grams a player can carry
+```
+
+Tune these so players can drag and carry logistics crates in-game.
+
+### AI Mode
+
+```sqf
+"DAY" call Waldo_fnc_AITweak;   // uncomment for daytime missions
+// "NIGHT" call Waldo_fnc_AITweak; // uncomment for nighttime missions
+```
+
+Only one should be active at a time. See [Waldos AI Tweak](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-AI-Tweak) for full detail.
+
+### ACRE2 Radio Setup
+
+```sqf
+private _RadioSetups = [
+    ["Viking-1-1", [1, 5]],   // [group callsign, [LR channel numbers]]
+    ["Viking 5",   [2, 7]],
+    ["Banshee",    [4, 1]]
+];
+[_RadioSetups] call Waldo_fnc_ACRE2Init;
+```
+
+Channel numbers refer to the index (1-based) in the `_LongRangeRadioChannels_*` arrays below.
+
+### ACRE2 Long-Range Channel Names (CEOI)
+
+```sqf
+_LongRangeRadioChannels_BLUFOR = ["PLATOON 1","PLATOON 2","PLATOON 3","COMPANY","AIR 2 GROUND","AIR 2 AIR","CAS 1","CAS 2","CFF 1","CFF 2","CONVOY 1"];
+missionNamespace setVariable ["Waldo_ACRE2Setup_LRChannels_BLUFOR", _LongRangeRadioChannels_BLUFOR];
+// repeat for OPFOR, IND, CIV
+```
+
+Position in the array = channel number. These names appear in the in-game CEOI document.
+
+### ACRE2 Babel (optional — disabled by default)
+
+```sqf
+/*
+[
+    [
+        [west, "English", "French"],
+        [east, "Russian"],
+        [civilian, "French"]
+    ]
+] call Waldo_fnc_BabelActivation;
+*/
+```
+
+Remove the `/*` and `*/` to enable. See [ACRE2 Babel Configuration](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Babel-Configuration).
+
+### Introduction Text
+
+```sqf
+["", ""] call Waldo_fnc_InfoText;
+// First param: custom title (blank = use onLoadName from description.ext)
+// Second param: custom location (blank = use worldName)
+```
+
+### Briefing Documents
+
+```sqf
+call Waldo_fnc_AddDocs;  // remove or comment to disable all briefing documents
+```
+
+### Team Colour Assignment
+
+```sqf
+call Waldo_fnc_SetTeamColour;  // remove to disable automatic ACE team colour assignment
+```
+
+---
+
+## initPlayerLocal.sqf
+
+Runs **per player on each join and respawn**. Two optional respawn behaviours are commented out by default.
+
+### Respawn With Death Loadout
+
+Uncomment to have players respawn with whatever they were carrying when they died:
+
+```sqf
+["CAManBase", "Killed", {
+    params ["_unit"];
+    if (_unit == player) then {
+        [_unit, [player, "Waldo_Player_Inventory"]] call BIS_fnc_saveInventory;
+    };
+}] call CBA_fnc_addClassEventHandler;
+```
+
+### Save Loadout on Arsenal Close
+
+Uncomment to automatically save the player's respawn loadout whenever they close the ACE Arsenal:
+
+```sqf
+["ace_arsenal_displayClosed", {
+    [player, [missionNamespace, "Waldo_Player_Inventory"]] call BIS_fnc_saveInventory;
+}] call CBA_fnc_addEventHandler;
+```
+
+See [Loadout Saving and Respawn](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Loadout-Saving-and-Respawn) for full details.

--- a/wiki/Mission-Intro-Or-Title-Text.md
+++ b/wiki/Mission-Intro-Or-Title-Text.md
@@ -1,0 +1,80 @@
+_Associated Files: MissionScripts\MissionFlowAndUi\infoText.sqf_
+
+Displays an animated title sequence when a player loads into the mission. It fades the screen to black, types out the current in-game time and date, then reveals the mission title, location, player's grid reference, rank, name, and group — colour-coded by side.
+
+The sequence runs automatically from `init.sqf` with no required setup. Mission makers can optionally customise the title text, location name, date format, and a player animation.
+
+**Displayed information:**
+1. Mission title — pulled from `description.ext` automatically, or overridden by the mission maker
+2. In-game time and date — automatic (short or long format)
+3. Map name — pulled from `worldName`, or overridden
+4. Player's grid reference at the time of the intro — automatic
+5. Player rank, name, and group ID — automatic, colour-coded by side
+
+---
+
+## Parameters
+
+| # | Type | Default | Description |
+|---|---|---|---|
+| 0 | STRING | `""` | Custom mission title. Leave empty to use `onLoadName` from `description.ext` |
+| 1 | STRING | `""` | Custom location name. Leave empty to use the map's `worldName` |
+| 2 | BOOL | `false` | `true` = long date format ("3rd November 2024"), `false` = short ("3/11/2024") |
+| 3 | STRING | `"NONE"` | Player animation to play during the intro (see below) |
+
+---
+
+## Basic Usage
+
+Minimum call — title and location pulled automatically from `description.ext` and `worldName`:
+
+```sqf
+[] spawn Waldo_fnc_InfoText;
+```
+
+Custom title and location:
+
+```sqf
+["Operation Iron Fist", "Altis"] spawn Waldo_fnc_InfoText;
+```
+
+Long date format:
+
+```sqf
+["Operation Iron Fist", "Altis", true] spawn Waldo_fnc_InfoText;
+```
+
+With an intro animation:
+
+```sqf
+["Operation Iron Fist", "Altis", false, "WAKE"] spawn Waldo_fnc_InfoText;
+```
+
+---
+
+## Animation Options
+
+| Value | Description |
+|---|---|
+| `"NONE"` | No animation (default) |
+| `"WALK"` | Slow walk forward |
+| `"SIT"` | Stand up from sitting on the floor |
+| `"WAKE"` | Wake up and stand |
+| `"WAKESLOW"` | Longer, more cautious version of WAKE |
+| `"COFFIN"` | Rise from the ground (meme input) |
+
+---
+
+## Date Format Override
+
+To display a completely custom date string — useful for fictional settings (Star Wars, Warhammer 40k) — edit line 91 of `infoText.sqf` and set the `_date` variable directly:
+
+```sqf
+_date = "Day 14 of the Third Month, 994.M41";
+```
+
+---
+
+## Related Functions
+
+For runtime text overlays during the mission (not just mission start), see [Mission UI Text Overlays](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-UI-Text-Overlays).

--- a/wiki/Mission-Maker-Resource-Scripts.md
+++ b/wiki/Mission-Maker-Resource-Scripts.md
@@ -1,0 +1,98 @@
+_Associated Files: MissionScripts\MissionMakerResourceScripts\_
+
+These scripts are **development and debugging tools** for the mission maker's use during production. They are not part of the runtime mission framework and should not be called in live missions.
+
+---
+
+## ACE Limited Arsenal Toolkit
+
+**File:** `ToolkitAceLimitedArsenal.sqf`
+
+Generates a ready-to-paste ACE Arsenal items array from the loadouts of all playable units on a given side. Use this when you want to hand-craft a limited arsenal on a box rather than relying on the automatic loadout-scraping system.
+
+### Usage
+
+1. Spawn units in the editor and assign them the loadouts you want available in the arsenal.
+2. Start the mission in the editor, then press **Escape** to open the debug console.
+3. Paste the script contents into the console and click **Local Execute**.
+4. The items array is copied to your clipboard automatically.
+5. Paste the output into an object's init field:
+
+```sqf
+// Initialise a new box with the items
+[this, ["item1","item2","itemN"]] call ace_arsenal_fnc_initBox;
+
+// Add items to a box that already has an arsenal
+[this, ["item1","item2","itemN"]] call ace_arsenal_fnc_addVirtualItems;
+```
+
+> This method is best for highly curated loadout pools. For mission packs with standard player loadouts, use the automatic [Logistics System](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Logistics-System,-Starter-Crates-And-Quartermaster) instead.
+
+---
+
+## Vehicle Damage Monitor
+
+**File:** `vehicleDamageMonitor.sqf`
+
+Displays a live hint showing the damage percentage of every hit-point on a targeted vehicle, updating every 0.2 seconds. Useful for testing armour, vehicle customisation, and confirming which components are damaged by specific weapons.
+
+### Usage
+
+1. Enter the editor or a session where you have debug permissions.
+2. Aim your crosshair at the vehicle you want to monitor.
+3. Open the debug console, paste the script, and click **Local Execute**.
+4. A continuously updating hint appears until the vehicle is destroyed.
+
+> Original script by "Real". Included with attribution.
+
+---
+
+## Example Unhiding Script
+
+**File:** `ExampleUnhidingScript.sqf`
+
+A template demonstrating how to un-hide and enable simulation on pre-placed units and vehicles at a specific moment during a mission (e.g. via a trigger). Useful for wave attacks and ambush design where enemies must not be visible or active until triggered.
+
+### Usage
+
+Replace the group variable names in the script (`Attack1HunterVehicleAlphaCrew`, `Attack1HunterAlpha`, etc.) with your own group variable names, then call the script from a trigger's **On Activation** field:
+
+```sqf
+[] execVM "MissionScripts\MissionMakerResourceScripts\ExampleUnhidingScript.sqf";
+```
+
+The core pattern per group is:
+
+```sqf
+{
+    private _vehicle = vehicle _x;
+    _x hideObjectGlobal false;
+    _x enableSimulationGlobal true;
+    _vehicle hideObjectGlobal false;
+    _vehicle enableSimulationGlobal true;
+} forEach (units YourGroupNameHere);
+```
+
+---
+
+## Debug Mod Config Patch Logger
+
+**File:** `DEBUG_GetNameOfModConfigPatch.sqf`
+
+Iterates through every entry in `CfgPatches` and writes each class name to the Arma 3 log (`.rpt` file). Use this to find the exact config patch name for any loaded mod.
+
+### Why You Need This
+
+WMP scripts use config guards to check whether an optional mod is loaded before running mod-specific code:
+
+```sqf
+if !(isClass(configFile >> "CfgPatches" >> "acre_main")) exitWith {};
+```
+
+If you are writing a guard for a mod whose patch name you do not know, run this script with that mod loaded and search the `.rpt` for the mod's name.
+
+### Usage
+
+1. Load a session with the mod active.
+2. Open the debug console, paste the script, and click **Local Execute**.
+3. Open your Arma 3 log file (typically `%LOCALAPPDATA%\Arma 3\` or the game directory) and search for the mod name.

--- a/wiki/Mission-UI-Text-Overlays.md
+++ b/wiki/Mission-UI-Text-Overlays.md
@@ -1,0 +1,92 @@
+_Associated Files:_
+- _MissionScripts\MissionFlowAndUi\dynamicText.sqf_
+- _MissionScripts\MissionFlowAndUi\timeBasedhint.sqf_
+- _MissionScripts\MissionFlowAndUi\respawnText.sqf_
+
+Three functions for displaying runtime text to players during a mission. They complement the mission intro (`Waldo_fnc_InfoText`) by providing on-demand overlays for events such as objective updates, respawn notifications, and timed callouts.
+
+---
+
+## Dynamic Text — `Waldo_fnc_DynamicText`
+
+Displays a short centred line of text across the screen, then fades it out. Delivered to a specific target via `remoteExec`, so it can be pushed to one player or all clients.
+
+### Parameters
+
+| # | Type | Description |
+|---|---|---|
+| 0 | STRING | The text to display |
+| 1 | OBJECT / NUMBER | Target: a player object, a machine number, or `-2` for all clients |
+
+### Examples
+
+```sqf
+// Display to a specific player
+["Objective Alpha secured", player] call Waldo_fnc_DynamicText;
+
+// Display to all clients
+["Reinforcements inbound — grid 041 122", -2] call Waldo_fnc_DynamicText;
+```
+
+### Notes
+
+- Text displays for approximately 3 seconds at size 0.8, with a short fade
+- Best for brief, mission-critical messages — not suited to long text
+- Can be called from a trigger, script, or Zeus module
+
+---
+
+## Timed Hint — `Waldo_fnc_TimedHint`
+
+Pushes a hint to the local client's screen for a configurable duration, then clears it automatically.
+
+### Parameters
+
+| # | Type | Default | Description |
+|---|---|---|---|
+| 0 | STRING | — | Text to display in the hint |
+| 1 | NUMBER | 10 | Duration in seconds before the hint clears |
+
+### Examples
+
+```sqf
+// 10-second hint (default duration)
+["Rendezvous respawn activated"] spawn Waldo_fnc_TimedHint;
+
+// Custom duration
+["Resupply point active — 45 seconds remaining", 45] spawn Waldo_fnc_TimedHint;
+```
+
+### Notes
+
+- Must be called with `spawn` — the function sleeps internally and will block if called with `call`
+- Clears the hint automatically on expiry (no leftover hint text)
+- Runs locally on the machine it is called on — use `remoteExec` to push to other machines:
+
+```sqf
+[["Convoy inbound — stand by", 15], "Waldo_fnc_TimedHint", -2] remoteExec ["spawn"];
+```
+
+---
+
+## Respawn Text — `Waldo_fnc_RespawnText`
+
+Displays an animated two-part text sequence each time a player respawns. Runs automatically via `initPlayerLocal.sqf` and requires no manual setup.
+
+**Sequence:**
+1. Current in-game time and date (typewriter animation)
+2. Player rank, name, group ID, and grid position — colour-coded by side (blue = BLUFOR, red = OPFOR, green = INDEP, purple = CIV)
+
+### Manual Call
+
+If you need to trigger the respawn text outside of the respawn flow:
+
+```sqf
+[] spawn Waldo_fnc_RespawnText;
+```
+
+### Notes
+
+- Waits until the player object exists and the mission clock is running before displaying, avoiding errors on initial load
+- Grid position reflects where the player actually spawned
+- The animated display uses `BIS_fnc_typeText` for the typewriter effect

--- a/wiki/Mobile-Command-Post-With-Integrated-Logistics-System.md
+++ b/wiki/Mobile-Command-Post-With-Integrated-Logistics-System.md
@@ -1,0 +1,55 @@
+_Associated Files: MissionScripts\Logistics\MHQ\MHQSetup.sqf_
+
+A script which allows for the creation of a command post, acting as a respawn position, you may choose to combine this with the logistics quartermaster script if so desired.
+
+This can be both a stationary object, or a vehicle.
+
+This allows a number of objects, as selected via the syncing of a named gamelogic to be attached to a vehicle, and "deployed"/"undeployed" on request when in a desired location.
+
+### Setting Up in Eden:
+* Place the vehicle or object that you want to have the respawn deployable from, and provide it a variable name. This will be known as the MHQ/CP in this tutorial.
+* Place a Game Logic down as close as possible to the MHQ/CP. This can be found near the same menu as Modules.
+* Place any objects you wish to appear when the respawn is deployed. Leave some room approx 3m to the left of the primary object to allow space for players to respawn.
+* If you are using a vehicle as your primary object and any of your deployable objects should be resting on the floor, then raise them about a foot, to allow for the drop of the vehicle's suspension once the game has initialised.
+* Select all the objects that will be deployable, right-click and synchronise them to the Game Logic.
+* In the init of the MHQ/CP, paste the following: [this] call Waldo_fnc_MHQSetup;
+* If you desire to utilise the modern construction audio, please use the example noting that below.
+* That's it.
+* (Optional) The file contains an array of all the potential names for the Command Posts, add some if you want or set it to just a smaller amount; just remember it's an array of strings within the selectRandom square brackets (If you don't know what any of that means, dont touch it!)
+
+### Features:
+* Allows any Vehicle or Object to be a deployable respawn. Vehicle will be attached to the vehicle during movement while object respawns are static.
+* Creates a randomised Command Post name and marker on the map.
+* Changes the respawn side depending on who deployed it.
+* Allows for the optional deployment of logistics supplies if enabled and the [logistics System](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Logistics-System,-Starter-Crates-And-Quartermaster) is active.
+
+Parameters:
+* _target - Vehicle or Object to use as the Mobile headquarters
+* _logistics - boolean as to whether to enable the logistics system on the MHQ
+* _constructionAudio - boolean (true/false) | Options: True = Modern construction Noises, False = Old Wooden Sounding Construction Noises.
+if _logistics is utilised:
+* _logisticsDirection - determines the bearing around the vehicle the spawner will be. Based on vehicle heading, not compass. E.g 0 = Front, 90 = Right, 180 = Rear, 270 = Left.
+* _logisticsDistance - determines how far away from the vehicle the logistics spawner will be.
+
+Example:
+
+Default:
+`[this] call Waldo_fnc_MHQSetup; `
+
+Modern construction audio:
+`[this,true] call Waldo_fnc_MHQSetup;`
+
+Logistics system with spawner 4m to the rear of the vehicle:
+`[this,true,true,180,4] call Waldo_fnc_MHQSetup;`
+
+Below is an example of a properly setup MHQ, the Halftrack is the interaction object:
+![MHQ example](https://i.imgur.com/Rz9KwXL.png)
+
+### Changing the Boxes The Quartermaster Spawns
+
+**You can edit class of crate spawned for both medical and supply boxes in the initServer.sqf:**
+![Picture displaying the appropriate place in Initserver.sqf to change the boxes](https://i.imgur.com/0CdEY8U.png)
+
+**Logi_SupplyBoxClass** is the class of box which will spawn when ammo or resupply boxes are spawned.
+
+**Logi_MedicalBoxClass** is the class of box which will spawn when a medical box is spawned.

--- a/wiki/Quickstart-Guide.md
+++ b/wiki/Quickstart-Guide.md
@@ -1,0 +1,52 @@
+## **Step 1: Download Required Files**
+- Download the [latest Waldos Mission Pack](https://github.com/AdamWaldie/WaldosMissionPack/releases/latest) (labelled as WMP-VersionNumber.zip) & the accompanying compositions.
+
+## **Step 2: Setup Your Development Environment**
+- It is recommended that you download Visual Studio Code and its SQF plugins, as they will make script reading in Arma 3 easier.
+  - [Visual Studio Code](https://code.visualstudio.com/)
+  - [SQF Language Extension](https://marketplace.visualstudio.com/items?itemName=vlad333000.sqf)
+  - [SQF Debugger Extension](https://marketplace.visualstudio.com/items?itemName=billw2011.sqf-debugger)
+
+## **Step 3: Prepare Your Mission Folder**
+- Copy everything from the downloaded folder into your mission.
+- Ensure that the `mission.sqm` is unbinarized:
+  - Navigate to Attributes -> General -> under Misc and uncheck the "Binarize the scenario file" box.
+
+## **Step 4: Customize Your Mission**
+- Fill out the relevant information in `description.ext` as desired. Optionally, replace the `loading.jpg` image in the Pictures folder.
+
+## **Step 5: Configure AI Behavior**
+- Set Waldo's AI Tweak mode in the `init.sqf` (DAY or NIGHT modes) as labelled in the `init.sqf` file.
+
+## **Step 6: Edit Initialization Files**
+- Edit `init.sqf`, `initServer.sqf`, & `initPlayerLocal.sqf` as you like to enable/disable different aspects of the pack.
+
+## **Explore The Mission Framework For Things You Might Want To Use (Optional)**
+- The pack is "packed" full of scripts and helpers for you to utilise. Every script is heavily documented and provides example calls for you to quickly and easily understand and use.
+
+***
+
+### **If Using ACE 3:**
+- Disable ACE 3 Respawn in server & Mission Addon Settings (Settings -> Addon Settings -> ACE Respawn).
+- See [Loadout Saving and Respawn](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Loadout-Saving-and-Respawn) for more details.
+
+***
+
+### **If Using ACRE2:**
+- Player groups must be assigned a callsign (Click on the group -> Callsign) & have that callsign and radio frequencies assigned in `init.sqf`.
+- See [ACRE 2 Radio Presetting And Saving](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE-2-Long-Range-Radio-Presetting) for more details.
+
+# Additional Resources
+
+## **Full Pack Features:**
+- This quickstart guide sets up the bare minimum. For a comprehensive look at using the pack’s features, reference [Feature Tutorials](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Feature-Tutorials).
+
+## **Compositions:**
+- Several compositions are supplied via a separate download on the release page. These expedite your mission building process, including setting up the pack's arsenal, supply crate, and logistics systems.
+
+### **Composition Installation:**
+1. Download `WMP_Compositions-versionNumber.zip` (E.g `WMP_Compositions-v4.6.1.zip`) from the [latest release](https://github.com/AdamWaldie/WaldosMissionPack/releases/latest) and open it.
+2. Navigate to your Arma 3 Profile folder in your documents.
+3. Open your `Compositions` folder.
+4. Drag and drop the contents from the downloaded compositions folder into your `Compositions` folder.
+5. If you have an older version of the compositions, it is wise to delete them first and then copy across the new compositions.

--- a/wiki/Radio-Reports,-Checklists,-Support-Calls-And-Documentation.md
+++ b/wiki/Radio-Reports,-Checklists,-Support-Calls-And-Documentation.md
@@ -1,0 +1,78 @@
+_Associated Files: MissionScripts\MissionInit\BriefingDocuments\_
+
+As of WMP v4.7.0 the pack provides an extensive set of in-game documentation, quick-reference templates, and checklists accessible from the player's map screen briefing tab. All documents are automatically populated by `Waldo_fnc_AddDocs`, which is called from `init.sqf`.
+
+---
+
+## What Is Provided
+
+### Radio Reports
+| Document | Function |
+|---|---|
+| SITREP (Situation Report) | `Waldo_fnc_SITREP` |
+| SPOTREP (Spot Report) | `Waldo_fnc_SPOTREP` |
+| LACE/ACE Report | `Waldo_fnc_ACEREP` |
+| Helicopter Pickup Request | `Waldo_fnc_ROTARYPICKUPREQUEST` |
+| LZ Briefing | `Waldo_fnc_LZBRIEF` |
+
+### Support Calls
+| Document | Function |
+|---|---|
+| 5-Line Special Operations Gunship Call | `Waldo_fnc_FIVELINEGUNSHIP` |
+| 9-Line CAS/ECAS Request | `Waldo_fnc_NINELINE` |
+| IDF Call For Fire | `Waldo_fnc_CALLFORFIRE` |
+| CAS Check-In Template | `Waldo_fnc_CASCHECKIN` |
+
+### Checklists
+| Document | Function |
+|---|---|
+| Squad Preparation Checklist | `Waldo_fnc_SQUADPREDOC` |
+| Fireteam Preparation Checklist | `Waldo_fnc_FIRETEAMPREPDOC` |
+| Fire Commands Reminder | `Waldo_fnc_FIRECOMMANDS` |
+| Jump Master Checklist | `Waldo_fnc_JUMPMASTER` |
+| LZ Specifications | `Waldo_fnc_LZSPECS` |
+| LZ Insert Checklist | `Waldo_fnc_LZINSERT` |
+| LZ Extract Checklist | `Waldo_fnc_LZEXTRACT` |
+
+### General Information
+| Document | Function |
+|---|---|
+| General Mission & Player Info | `Waldo_fnc_GENINFO` |
+
+---
+
+## Setup
+
+Documents are loaded automatically. The call in `init.sqf` looks like this:
+
+```sqf
+call Waldo_fnc_AddDocs;
+```
+
+All documents are added to the player's **map screen briefing diary** (the `Diary` tab when opening the map). Each document is a separate entry.
+
+---
+
+## Enabling or Disabling Individual Documents
+
+All individual document functions are called from `AddDocs.sqf`. To remove a document from the briefing, open `MissionScripts\MissionInit\BriefingDocuments\AddDocs.sqf` and comment out the corresponding function call.
+
+For example, to remove the SITREP template:
+
+```sqf
+// [] call Waldo_fnc_SITREP;   // commented out — no longer shown to players
+```
+
+---
+
+## Adding Custom Briefing Documents
+
+To add a custom briefing document, create a new `.sqf` file in `BriefingDocuments\` using the existing files as a template. Each file uses `player createDiaryRecord` to add a titled entry to the map diary. Then call your new function from `AddDocs.sqf`.
+
+Example of the basic pattern:
+
+```sqf
+player createDiaryRecord ["Diary", ["My Document Title", "Content goes here.<br/>More text on next line."]];
+```
+
+Documents support HTML-style tags for formatting: `<br/>` for line breaks, `<b>` for bold, `<u>` for underline, and image references via `<img image='path\to\image.paa'/>`.

--- a/wiki/Simple-Mass-Attach-Items.md
+++ b/wiki/Simple-Mass-Attach-Items.md
@@ -1,0 +1,20 @@
+_Associated Files: MissionScripts\Logistics\LogiHelpers\massAttachItems.sqf_
+
+This script attaches multiple objects to a second object.
+
+Setting Up in Eden;
+* Place the vehicle or object you want to attach to all other items.
+* Place a Game Logic down as close as possible to the object. This can be found near the same menu as Modules.
+* Place any objects you wish to attach.
+* If you are using a vehicle as your primary object and any of your objects should be resting on the floor, then raise them about a foot, to allow for the drop of the vehicle's suspension once the game has been initialised.
+* Select all the objects that will be attached, right-click and synchronise them to the Game Logic.
+* In the init of the vehicle, paste the example below, and alter it to suit your needs.
+
+Parameters:
+* _targetObject - the variable name of the vehicle/object you wish to attach the synchronised objects to.
+
+Example call:
+
+In vehicle init:
+
+`[variableNameOfObjectToAttachOthersTo] call Waldo_fnc_MassAttachRelative;`

--- a/wiki/Team-Colour-Setup.md
+++ b/wiki/Team-Colour-Setup.md
@@ -1,0 +1,53 @@
+_Associated Files: MissionScripts\MissionInit\InitHelpers\SetTeamColour.sqf_
+
+Automatically assigns players to ACE3 team colours at mission start based on their role description set in the Eden Editor. No per-unit configuration is required — the function reads each player's **Role Description** field and matches it to a colour.
+
+Called automatically from `init.sqf`. Requires ACE3.
+
+## How It Works
+
+On mission start, each player's Role Description (or unit class display name as a fallback) is checked against a keyword table. The first keyword match determines the ACE3 team colour assigned to that player. The check is case-insensitive and searches for the keyword anywhere in the role description string.
+
+## Keyword-to-Colour Mapping
+
+| Team Colour | Matching Keywords |
+|---|---|
+| **Yellow** | Squad Leader, SL, Platoon Leader, PL, Platoon Sergeant, PSG, Company Commander, CC, Commanding Officer, CO, LT, Lieutenant, Major, Captain, Colonel, 1st Sergeant, 1SG, Delta, Yellow |
+| **Red** | Assistant Squad Leader, ASL, Alpha, Red |
+| **Blue** | Bravo, Blue |
+| **Green** | Medic, Charlie, Green |
+
+Players whose role description matches none of the keywords are not assigned to any team.
+
+## Recommended Role Description Format
+
+For best results, use the following convention in each unit's **Role Description** field in Eden:
+
+```
+[Team/Role] [Additional Info]@[Callsign]
+```
+
+Examples:
+- `Alpha Rifleman@Viking-1-1` → assigned **Red**
+- `Bravo Automatic Rifleman@Viking-1-2` → assigned **Blue**
+- `ASL@Viking-1` → assigned **Red**
+- `SL@Odin` → assigned **Yellow**
+- `Medic@Foxhound-2` → assigned **Green**
+
+## Disabling
+
+To disable automatic team colour assignment, comment out this line in `init.sqf`:
+
+```sqf
+call Waldo_fnc_SetTeamColour;
+```
+
+## Adding or Changing Mappings
+
+The keyword table is in `SetTeamColour.sqf`. To add a new keyword, append to the `_teamMapping` array:
+
+```sqf
+["FORWARD OBSERVER", "GREEN"],
+```
+
+Each entry is `["KEYWORD IN CAPITALS", "COLOUR"]`. Valid colour strings are `"RED"`, `"BLUE"`, `"GREEN"`, and `"YELLOW"`.

--- a/wiki/Team-Colour-Setup.md
+++ b/wiki/Team-Colour-Setup.md
@@ -51,3 +51,29 @@ The keyword table is in `SetTeamColour.sqf`. To add a new keyword, append to the
 ```
 
 Each entry is `["KEYWORD IN CAPITALS", "COLOUR"]`. Valid colour strings are `"RED"`, `"BLUE"`, `"GREEN"`, and `"YELLOW"`.
+
+---
+
+## Related Helper Functions
+
+Two additional functions parse the same role description format. Both are useful when writing custom scripts that need to know the player's callsign or role.
+
+### `Waldo_fnc_GetPlayerGroup`
+
+Returns the group callsign — the part of the role description **after** the `@`. Falls back to the Eden group ID if no `@` is present.
+
+```sqf
+// Returns "VIKING-1" from role description "Alpha Rifleman@Viking-1"
+private _groupCallsign = [player] call Waldo_fnc_GetPlayerGroup;
+```
+
+### `Waldo_fnc_GetPlayerRole`
+
+Returns the role — the part of the role description **before** the `@`. Falls back to the unit class display name if no role description is set.
+
+```sqf
+// Returns "Alpha Rifleman" from role description "Alpha Rifleman@Viking-1"
+private _roleName = call Waldo_fnc_GetPlayerRole;
+```
+
+Both functions return an empty string (or `"Infantry"` for `GetPlayerRole`) in singleplayer.

--- a/wiki/Teleportation-&-Move-Into-Cargo-Interactions.md
+++ b/wiki/Teleportation-&-Move-Into-Cargo-Interactions.md
@@ -1,0 +1,37 @@
+_Associated Files:_
+* _MissionScripts\Paradrop\moveInCargoPlane.sqf_
+* _MissionScripts\Logistics\LogiHelpers\teleport.sqf_
+
+Both of these scripts perform teleportation and can be applied to any object. They have been grouped here for convenience.
+
+## Teleport Object
+This teleports a target to a given marker or any other kind of object.
+
+Parameters:
+* 0: Object <OBJECT>
+* 1: Label text <STRING>
+* 2: Destination <MARKER/OBJECT/LOCATION/GROUP/TASK>
+
+
+Examples:
+* `[this,"Teleport - Airfield", Airstrip] call Waldo_fnc_Teleport`  <- Arma 3 Map Location (Predefined)
+* `[this,"Teleport - Base", MyBase] call Waldo_fnc_Teleport ` <- Object
+* `[this,"Teleport - Bart", "FOB_Bart"] call Waldo_fnc_Teleport` <- Arma 3 Map Location (Predefined)
+* `[this,"Teleport - Base", "respawn_west"] call Waldo_fnc_Teleport` <- Marker variable name
+
+Please note that this script requires the destination to have a variable name to reference.
+
+## Move-In Cargo Object
+
+This function adds a "move-in-cargo" teleporter to an object, which allows a player to use an addaction to board an aircraft already in the air. Helpful in shortening drop times.
+
+Arguments:
+* 0: Teleporter Object
+* 1: Aircraft variable Name To Teleport Into
+* 2: Custom String Name For the Plane (Optional)
+
+Example:
+* `[this, aircraft] call Waldo_fnc_MoveInCargoPlane;`
+* `[this, aircraft, "ARGUS 1-4"] call Waldo_fnc_MoveInCargoPlane;`
+
+Please note that this script requires the destination to have a variable name to reference.

--- a/wiki/Unit-Insignias.md
+++ b/wiki/Unit-Insignias.md
@@ -1,0 +1,37 @@
+_Associated Files: UnitInsignias\_
+
+WMP includes a set of pre-made unit insignia textures (`.paa` files) in the `UnitInsignias/` folder. These can be applied to player characters in Eden using Arma 3's built-in **User Texture** object.
+
+Insignia files ship as a separate download (`WMP_UnitInsignias-vX.X.X.zip`) from the [releases page](https://github.com/AdamWaldie/WaldosMissionPack/releases/latest).
+
+---
+
+## Setup in Eden
+
+1. In Eden, search for **"User texture"** in the asset search bar and place one near the unit you want to apply the insignia to.
+2. Open the User Texture object's **Attributes** and scroll to the bottom.
+3. In the texture path field, type the path to the insignia file:
+
+```
+UnitInsignias\1-1.paa
+```
+
+Replace `1-1.paa` with the filename of the insignia you want to use. Available files are in the `UnitInsignias/` folder of the mission.
+
+---
+
+## Adding Custom Insignias
+
+To use your own unit insignia:
+
+1. Create a `.paa` image (Arma 3's native texture format — convert from PNG using **TexView 2** in the Arma 3 Tools on Steam, or **GIMP with the `.pal` plugin**).
+2. Place the `.paa` file in the `UnitInsignias/` folder.
+3. Reference it in the User Texture attributes as shown above.
+
+Recommended resolution: 512×512 or 256×256. The texture is applied as an insignia patch on the unit's uniform sleeve.
+
+---
+
+## VVD Insignia Integration
+
+The [Virtual Vehicle Depot](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Virtual-Vehicle-Depot) garage interface also supports applying unit insignias to spawned vehicles where the vehicle model supports it.

--- a/wiki/Vehicle-Actions-&-Paradrop.md
+++ b/wiki/Vehicle-Actions-&-Paradrop.md
@@ -1,66 +1,192 @@
 _Associated Files:_
-* _MissionScripts\VehicleActionsSetup_
-* _MissionScripts\Paradrop_
+- _MissionScripts\VehicleActionsSetup_
+- _MissionScripts\Paradrop_
 
-The following actions are available:
-* Static Line Parachuting and Halo Jumping
-* Player Dismount Side Selection for two-door helicopters (E.g UH-60)
-* Set ACE Cargo and movement settings for an object.
+This system provides three categories of vehicle-specific actions that are applied automatically at mission start: **paradrop/HALO jumping**, **side-door exit selection**, and **ACE cargo attributes**. Auto-detection covers the most common RHS, CUP and Vanilla assets — no setup required for those vehicles.
 
-CUP, RHS and Vanilla assets have these automatically applied by default, as well as preliminary support for medical class vehicles from any mod. As such if you are using these mods, you don't need to do anything else.
+---
+
+## Auto-Detected Vehicles
+
+The following vehicles receive actions automatically when the mission loads (and when Zeus spawns them during the mission):
+
+### Exit Side Selection (Left / Right dismount)
+| Base Class | Vehicles |
+|---|---|
+| `Heli_Transport_01_base_F` | Vanilla CH-47 Chinook family |
+| `rhs_uh1h_base` | RHS UH-1H |
+| `RHS_UH1_Base` | RHS UH-1Y/N |
+| `RHS_Mi24_base` | RHS Mi-24 family |
+
+### Static Line Jump
+| Base Class | Notes |
+|---|---|
+| `RHS_Mi24_base` | Also gets exit actions |
+| `RHS_Mi8_base` | RHS Mi-8 family |
+| `Heli_Transport_02_base_F` | Vanilla Merlin/Puma family |
+| `RHS_C130J_Base` | Also gets HALO (see below) |
+| `B_T_VTOL_01_infantry_F` | Vanilla V-44 VTOL — also gets HALO |
+
+### HALO Jump
+| Base Class |
+|---|
+| `RHS_C130J_Base` |
+| `B_T_VTOL_01_infantry_F` |
+
+### Automatic Medical Vehicle Flag (ACE3)
+| Base Class / Variant | Effect |
+|---|---|
+| RHS UH-60 MEV variants | `ace_medical_isMedicalVehicle = true` |
+| RHS M1230a1 variants | `ace_medical_isMedicalVehicle = true` |
+| RHS Stryker MEV | `ace_medical_isMedicalVehicle = true` |
+
+### ACE Cargo Attributes
+| Base Class | Cargo Space | Notes |
+|---|---|---|
+| `MRAP_01_base_F` | 4 items | Vanilla Hunter/Strider/Ifrit family |
+
+For any vehicle not in the above list, apply actions manually — see **Manual Setup** below.
+
+---
+
+## Jump Availability Conditions
+
+Jump actions only appear (and can only be triggered) when **all** conditions are met:
+
+| Condition | Static Line | HALO |
+|---|---|---|
+| Player is in cargo (not driver/gunner) | ✓ | ✓ |
+| Aircraft door or ramp is open | ✓ | ✓ |
+| Altitude ≥ minimum | ✓ | ✓ |
+| Altitude ≤ maximum | ✓ | — |
+| Speed ≤ maximum | ✓ | — |
+
+Supported door/ramp animations: `ramp_bottom`, `door_2_1/2`, `jumpdoor_1/2`, `back_ramp_switch`, `back_ramp_half_switch`, `RearDoors`, `Door_1_source`, `ramp_anim`.
+
+---
+
+## How Jumping Works
+
+### Static Line Jump
+1. Player triggers the hold action → ejected from the aircraft at the door
+2. A parachute vehicle (the configured `WALDO_STATIC_STATICCHUTE` class) is spawned and the player is placed in it immediately
+3. Equipment simulation runs (see below)
+4. Player descends under a fixed-wing chute — not steerable in vanilla, steerable with RHS `rhs_d6_Parachute`
+
+### HALO Jump
+1. Player triggers the hold action → ejected from the aircraft
+2. **Equipment simulation** runs first
+3. **Parachute backpack system** activates — player's backpack is replaced with a parachute (`WALDO_PARA_HALOCHUTE`), original backpack contents are saved
+4. Player freefalls; a hold action "Ditch Chute And Put On Backpack" appears once on the ground (altitude < 2 m)
+5. Activating the hold action (5-second hold) restores the original backpack and contents, removes the forced-walk restriction
+
+---
+
+## Equipment Simulation
+
+_Associated File: MissionScripts\Paradrop\paraEquipmentSim.sqf_
+
+Simulates realistic item loss during a jump. Runs automatically on every jump. Two modes exist — **basic** (default) and **advanced**.
+
+### What Can Be Lost
+
+| Item Slot | Chance | Basic Mode | Advanced Mode |
+|---|---|---|---|
+| NVG/HMD | ~50% (random > 4 on 1–10 scale) | Unassigned (stays in inventory) | Permanently deleted |
+| Soft headgear (bandanas, berets, boonie hats, caps, etc.) | ~60% (random > 3) | Unassigned | Deleted |
+| Non-tactical glasses (aviators, spectacles, sport glasses) | ~70% (random > 2) | Unassigned | Deleted |
+
+**Basic mode** (default): Items are unequipped and fall to the inventory — the player is notified "You almost lost [item] during your jump, it is in your inventory."
+
+**Advanced mode**: Items are permanently deleted — the player is notified "You lost [item] during your jump."
+
+Helmets and ballistic goggles are **not** in the loss lists and are always safe.
+
+### Enabling Advanced Mode
+
+Advanced mode is not exposed as a parameter in the standard jump flow. To enable it, you would call the function directly with `true` as the second argument:
+
+```sqf
+[player, true] call Waldo_fnc_paraEquipmentSim;
+```
+
+---
+
+## Jump Settings Check
+
+_Associated File: MissionScripts\Paradrop\checkForJumpSettings.sqf_
+
+Adds a "Check Jump Settings" option under **ACE Self-Actions → Para Interactions** on any jump-capable aircraft. When activated, it displays the available jump type(s) and their requirements via an on-screen CBA notification:
+
+- Static Line: max safe speed, altitude window
+- HALO: minimum altitude
+
+This is added automatically alongside jump actions. No setup required.
+
+---
+
+## Configuring Jump Parameters
+
+Jump thresholds are set in `initServer.sqf` and apply to **all** aircraft — both auto-detected and manually set up:
+
+```sqf
+// Static Line
+missionNamespace setVariable ["WALDO_STATIC_MINALTITUDE", 180, true];  // metres AGL
+missionNamespace setVariable ["WALDO_STATIC_MAXALTITUDE", 350, true];  // metres AGL
+missionNamespace setVariable ["WALDO_STATIC_MAXSPEED",    310, true];  // km/h
+missionNamespace setVariable ["WALDO_STATIC_STATICCHUTE", "rhs_d6_Parachute", true]; // chute class
+
+// HALO
+missionNamespace setVariable ["WALDO_PARA_HALOALTITUDE", 1000, true];  // metres AGL minimum
+missionNamespace setVariable ["WALDO_PARA_HALOCHUTE",    "B_Parachute", true];        // chute class
+```
+
+For a non-RHS static chute (if you don't have RHS), use `"NonSteerable_Parachute_F"` (vanilla, fixed-wing).
+
+---
+
+## Manual Vehicle Setup
+
+For any vehicle not auto-detected, paste one of the following into its **init field** in Eden:
+
+```sqf
+// Apply both HALO and static line (reads thresholds from initServer.sqf automatically)
+[this] call Waldo_fnc_VehicleJumpSetup;
+
+// Apply only HALO
+[this, 1000, "B_Parachute"] call Waldo_fnc_AddHaloJump;
+
+// Apply only static line
+[this, 180, 350, 310, "rhs_d6_Parachute"] call Waldo_fnc_AddStaticJump;
+
+// Apply exit side selection
+[this] call Waldo_fnc_AddExitActions;
+```
+
+`Waldo_fnc_VehicleJumpSetup` is a convenience wrapper that applies both jump types using whichever parameters are set in `initServer.sqf`.
+
+---
 
 ## Set Cargo Attributes
-Associated Files: MissionScripts\VehicleActionsSetup\SetCargoAttributes.sqf
 
-This function allows you to set the cargo space and size of the given object and if you can drag or carry it.
+_Associated File: MissionScripts\VehicleActionsSetup\SetCargoAttributes.sqf_
 
-Arguments:
-* 0: Vehicle       <OBJECT>
-* 1: Cargo Space   <NUMBER> (nil to keep default value)
-* 2: Cargo Size    <NUMBER> (nil to keep default value) 
-* 3: Draggable     <BOOLEAN> (Default; true)
-* 4: Carryable     <BOOLEAN> (Default; true)
+Manually configure the ACE cargo space, cargo size, drag and carry settings for any object.
 
-Example:
-* `[myTruck] call Waldo_fnc_SetCargoAttributes;`
-* `[myTruck, 30, -1] call Waldo_fnc_SetCargoAttributes;`
-* `[myCrate, -1, 2] call Waldo_fnc_SetCargoAttributes;`
-* `[myCrate, -1, 2, true, false] call Waldo_fnc_SetCargoAttributes;`
-* `[myCrate, nil, nil, true, false] call Waldo_fnc_SetCargoAttributes;`
+### Parameters
 
-## Exit Side Selection
-Associated Files: MissionScripts\VehicleActionsSetup\AddExitAction.sqf
+| # | Type | Default | Description |
+|---|---|---|---|
+| 0 | OBJECT | — | Vehicle or object |
+| 1 | NUMBER | — | Cargo space (use `nil` to leave unchanged) |
+| 2 | NUMBER | — | Cargo size (use `nil` to leave unchanged) |
+| 3 | BOOL | true | Draggable |
+| 4 | BOOL | true | Carryable |
 
-This function adds two addictions available for players in passenger positions to choose whether to exit to the left or right of the vehicle. Mission Makers should only attempt to apply this to helicopters with two side doors for expected results.
+### Examples
 
-Arguments:
-* 0: Object <OBJECT>
-* 1: Color Action <BOOL>
-
-Example:
-* `[this] call Waldo_fnc_AddExitActions;`
-* `[this, true] call Waldo_fnc_AddExitActions;`
-
-## Paradrop/HALO Setup
-Associated Files: MissionScripts\Paradrop
-
-This is only required if the vehicle is not already set up by the pack during init.
-
-For the default setup, simply paste the below code into the init of the drop vehicle.
-
-`[this] call Waldo_fnc_VehicleJumpSetup;`
-
-You can also customise the parameters for all jump aircraft in the initServer.sqf Pictured below:
-
-![Plane Parameters](https://i.imgur.com/qrayy7a.png)
-
-Static Line:
-
-* **WALDO_STATIC_MINALTITUDE** is the minimum altitude the plane must exceed to perform a static line jump.
-* **WALDO_STATIC_MAXALTITUDE** is the maximum altitude the plane must not exceed to perform a static line jump.
-* **WALDO_STATIC_MAXSPEED** is the maximum vehicle speed before the static line becomes unavailable.
-* **WALDO_STATIC_STATICCHUTE** is the class name of the chute you wish to use for static line jumps.
-
-HALO:
-* **WALDO_PARA_HALOALTITUDE** is the minimum altitude the plane must exceed to perform a HALO jump.
-* **WALDO_PARA_HALOCHUTE** is the class name of the chute you wish to use for HALO jumps.
+```sqf
+[myTruck, 30, -1] call Waldo_fnc_SetCargoAttributes;         // 30 cargo space
+[myCrate, -1, 2, true, false] call Waldo_fnc_SetCargoAttributes; // size 2, draggable only
+[myCrate, nil, nil, true, false] call Waldo_fnc_SetCargoAttributes; // only set drag/carry
+```

--- a/wiki/Vehicle-Actions-&-Paradrop.md
+++ b/wiki/Vehicle-Actions-&-Paradrop.md
@@ -1,0 +1,66 @@
+_Associated Files:_
+* _MissionScripts\VehicleActionsSetup_
+* _MissionScripts\Paradrop_
+
+The following actions are available:
+* Static Line Parachuting and Halo Jumping
+* Player Dismount Side Selection for two-door helicopters (E.g UH-60)
+* Set ACE Cargo and movement settings for an object.
+
+CUP, RHS and Vanilla assets have these automatically applied by default, as well as preliminary support for medical class vehicles from any mod. As such if you are using these mods, you don't need to do anything else.
+
+## Set Cargo Attributes
+Associated Files: MissionScripts\VehicleActionsSetup\SetCargoAttributes.sqf
+
+This function allows you to set the cargo space and size of the given object and if you can drag or carry it.
+
+Arguments:
+* 0: Vehicle       <OBJECT>
+* 1: Cargo Space   <NUMBER> (nil to keep default value)
+* 2: Cargo Size    <NUMBER> (nil to keep default value) 
+* 3: Draggable     <BOOLEAN> (Default; true)
+* 4: Carryable     <BOOLEAN> (Default; true)
+
+Example:
+* `[myTruck] call Waldo_fnc_SetCargoAttributes;`
+* `[myTruck, 30, -1] call Waldo_fnc_SetCargoAttributes;`
+* `[myCrate, -1, 2] call Waldo_fnc_SetCargoAttributes;`
+* `[myCrate, -1, 2, true, false] call Waldo_fnc_SetCargoAttributes;`
+* `[myCrate, nil, nil, true, false] call Waldo_fnc_SetCargoAttributes;`
+
+## Exit Side Selection
+Associated Files: MissionScripts\VehicleActionsSetup\AddExitAction.sqf
+
+This function adds two addictions available for players in passenger positions to choose whether to exit to the left or right of the vehicle. Mission Makers should only attempt to apply this to helicopters with two side doors for expected results.
+
+Arguments:
+* 0: Object <OBJECT>
+* 1: Color Action <BOOL>
+
+Example:
+* `[this] call Waldo_fnc_AddExitActions;`
+* `[this, true] call Waldo_fnc_AddExitActions;`
+
+## Paradrop/HALO Setup
+Associated Files: MissionScripts\Paradrop
+
+This is only required if the vehicle is not already set up by the pack during init.
+
+For the default setup, simply paste the below code into the init of the drop vehicle.
+
+`[this] call Waldo_fnc_VehicleJumpSetup;`
+
+You can also customise the parameters for all jump aircraft in the initServer.sqf Pictured below:
+
+![Plane Parameters](https://i.imgur.com/qrayy7a.png)
+
+Static Line:
+
+* **WALDO_STATIC_MINALTITUDE** is the minimum altitude the plane must exceed to perform a static line jump.
+* **WALDO_STATIC_MAXALTITUDE** is the maximum altitude the plane must not exceed to perform a static line jump.
+* **WALDO_STATIC_MAXSPEED** is the maximum vehicle speed before the static line becomes unavailable.
+* **WALDO_STATIC_STATICCHUTE** is the class name of the chute you wish to use for static line jumps.
+
+HALO:
+* **WALDO_PARA_HALOALTITUDE** is the minimum altitude the plane must exceed to perform a HALO jump.
+* **WALDO_PARA_HALOCHUTE** is the class name of the chute you wish to use for HALO jumps.

--- a/wiki/Vehicle-Ambush-Script-And-Vehicle-Camo.md
+++ b/wiki/Vehicle-Ambush-Script-And-Vehicle-Camo.md
@@ -1,0 +1,31 @@
+_Associated Files: MissionScripts\Logistics\VehicleCamoScript\vehicleCamo.sqf_
+
+A script which allows for the creation of "camo" objects to assist in hiding a vehicle in ambush. The script also accounts for limited dismounted movement around the vehicle in concealment (civ).
+
+If the Player:
+* Is spotted
+* Fires the vehicles weapons
+* Moves more than 40 meters from the vehicle
+* Takes damage (Player or vehicle)
+
+The player is returned to their side (potential game-restricted delay of up to 30 seconds) however the camo objects will remain until the vehicle moves, or the camo is removed by the indicated ace action.
+
+Designed for vehicles.
+
+### Setting Up in Eden;
+* Place the vehicle or object that you want to have the respawn deployable from, and provide it a variable name
+* Place a Game Logic down as close as possible to the vehicle. This can be found near the same menu as Modules.
+* Place any objects you wish to appear when the camo is deployed.
+* If you are using a vehicle as your primary object and any of your deployable objects should be resting on the floor, then raise them about a foot, to allow for the drop of the vehicle's suspension once the game has initialised.
+* Select all the objects that will be deployable, right-click and synchronise them to the Game Logic.
+* In the init of the vehicle, paste the example below, and alter it to suit the needs you have.
+
+### Parameters:
+* _target - Vehicle or Object to deploy camo from.
+
+Example:
+
+`[this] call Waldo_fnc_VehicleCamoSetup;`
+
+Below is an example of a setup camo system in the eden editor. The Nazi Tank is the interaction object:
+![Camo script example in the editor](https://i.imgur.com/dlyoKsk.png)

--- a/wiki/Virtual-Vehicle-Depot.md
+++ b/wiki/Virtual-Vehicle-Depot.md
@@ -1,0 +1,31 @@
+_Associated Files: MissionScripts\Logistics\\VirtualVehicleDepot_
+
+This script initiates a virtual vehicle depot spawner. It could be more pretty, but it does provide a large degree of functionality.
+
+# Features
+
+The VVD (Vitual Vehicle Depot) can perform the following actions:
+* Spawn Vehicles
+* Add/Remove damage to specific parts of the vehicle
+* Change Weapons or Pylon setup where mod config allows
+* Alter vehicles cosmetics
+* Add/remove AI from each crew slot
+
+# Setup
+
+Parameters:
+* _depotSpawnerObject - The item to add the spawner addactions onto
+* _depotSpawnPoint - This should be a helipad, but a flat object on top of which the vehicle will be spawned
+* _types - what should be allowed to be selected from this specific spawner, multiple can be given - Potential arguments: ["Auto","All","Car", "Tank", "Helicopter", "Plane", "Ship", "StaticWeapon"] "Auto" will look at the ground beneath it and select a type based on that.
+* _sidesToAllowUseOfSpawner - Sides allowed to use the spawner - Potential Arguments: ["BLUFOR","OPFOR","INDEP", "CIV", "ALL"]
+* _enforcePlayerSideToAccess - enforce that players must match the side of the spawner to get the vehicles
+* _limitToSideVehicles - limit vehicles able to be spawned (but not viewed) to that matching the player side (Finicky and 50/50 working) Recommend leaving as false.
+* _removeUavs - remove UAVs from the spawner (80/20 as to whether it works depending on mod config)
+* _range - range from which you can view the interactions on the spawner
+* _script - script to apply directly to the spawned vehicle, bypassing the garage.
+
+Example Calls:
+
+`[this, Circle_Helipad, ["All"], ["ALL"], false, false, false, 10, ""] call Waldo_fnc_VVDInit;` - Fully unrestricted vehicle spawner. See the below image for an example setup. The laptop is the interactable object, and Circle_Helipad refers to the parachute target. This example is available to you as part of the compositions provided in the pack. 
+
+![Example of mission pack setup](https://i.imgur.com/0DkSWJl.png)

--- a/wiki/Virtual-Vehicle-Depot.md
+++ b/wiki/Virtual-Vehicle-Depot.md
@@ -1,31 +1,116 @@
-_Associated Files: MissionScripts\Logistics\\VirtualVehicleDepot_
+_Associated Files: MissionScripts\Logistics\VirtualVehicleDepot_
 
-This script initiates a virtual vehicle depot spawner. It could be more pretty, but it does provide a large degree of functionality.
+> **This feature is Work In Progress.** It is functional for general use but has known limitations documented below. Test thoroughly with your mod set before using in a live mission.
 
-# Features
+The VVD (Virtual Vehicle Depot) provides an in-mission vehicle spawner with a graphical garage interface. Players interact with a placed object to browse, configure, and spawn vehicles onto a designated spawn pad.
 
-The VVD (Vitual Vehicle Depot) can perform the following actions:
-* Spawn Vehicles
-* Add/Remove damage to specific parts of the vehicle
-* Change Weapons or Pylon setup where mod config allows
-* Alter vehicles cosmetics
-* Add/remove AI from each crew slot
+---
 
-# Setup
+## Features
 
-Parameters:
-* _depotSpawnerObject - The item to add the spawner addactions onto
-* _depotSpawnPoint - This should be a helipad, but a flat object on top of which the vehicle will be spawned
-* _types - what should be allowed to be selected from this specific spawner, multiple can be given - Potential arguments: ["Auto","All","Car", "Tank", "Helicopter", "Plane", "Ship", "StaticWeapon"] "Auto" will look at the ground beneath it and select a type based on that.
-* _sidesToAllowUseOfSpawner - Sides allowed to use the spawner - Potential Arguments: ["BLUFOR","OPFOR","INDEP", "CIV", "ALL"]
-* _enforcePlayerSideToAccess - enforce that players must match the side of the spawner to get the vehicles
-* _limitToSideVehicles - limit vehicles able to be spawned (but not viewed) to that matching the player side (Finicky and 50/50 working) Recommend leaving as false.
-* _removeUavs - remove UAVs from the spawner (80/20 as to whether it works depending on mod config)
-* _range - range from which you can view the interactions on the spawner
-* _script - script to apply directly to the spawned vehicle, bypassing the garage.
+- Browse all vehicles of the configured type(s) available in loaded mods
+- Configure **damage** per hitpoint — set a vehicle to spawn already damaged (e.g. battle-worn trucks)
+- Configure a **damage delay** — vehicle spawns undamaged and takes the set damage after a specified time
+- Modify **weapon loadouts and pylons** where the vehicle's mod config supports it
+- Adjust **cosmetics** (textures, camo)
+- Toggle **AI crew** per seat
+- Apply **unit insignias** to the spawned vehicle
 
-Example Calls:
+---
 
-`[this, Circle_Helipad, ["All"], ["ALL"], false, false, false, 10, ""] call Waldo_fnc_VVDInit;` - Fully unrestricted vehicle spawner. See the below image for an example setup. The laptop is the interactable object, and Circle_Helipad refers to the parachute target. This example is available to you as part of the compositions provided in the pack. 
+## Eden Setup
+
+1. Place the **interaction object** (e.g. a laptop) and give it a variable name. This is what players click on.
+2. Place a **helipad** (or any flat object) where the vehicle will spawn. Give it a variable name (e.g. `Circle_Helipad`). Vehicles spawn on top of it.
+3. In the interaction object's init, call `Waldo_fnc_VVDInit` (see parameters below).
 
 ![Example of mission pack setup](https://i.imgur.com/0DkSWJl.png)
+
+A pre-built composition with this setup is included in the WMP Compositions download.
+
+---
+
+## Parameters
+
+```sqf
+[spawnerObject, spawnPad, types, allowedSides, enforcePlayerSide, limitToSideVehicles, removeUavs, range, script]
+    call Waldo_fnc_VVDInit;
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `spawnerObject` | OBJECT | The object players interact with to open the garage |
+| `spawnPad` | OBJECT | Helipad or flat surface where vehicles spawn |
+| `types` | ARRAY of STRING | Vehicle categories to show — see table below |
+| `allowedSides` | ARRAY of STRING | Sides allowed to use the spawner |
+| `enforcePlayerSide` | BOOL | If true, player's side must match `allowedSides` |
+| `limitToSideVehicles` | BOOL | Limit spawnable (not viewable) vehicles to player's side. Unreliable — recommend `false` |
+| `removeUavs` | BOOL | Attempt to hide UAVs from the list. Works ~80% of the time depending on mod config |
+| `range` | NUMBER | Distance in metres from which the interactions are visible |
+| `script` | STRING | SQF code string to execute on the spawned vehicle. Bypasses garage if non-empty |
+
+### Vehicle Type Options (`types`)
+
+| Value | Shows |
+|---|---|
+| `"Auto"` | Detects surface — ground vehicles on land, ships on water |
+| `"All"` | All vehicle types |
+| `"Ground"` | Cars, tanks, static weapons |
+| `"Car"` | Wheeled vehicles |
+| `"Tank"` | Tracked armour |
+| `"Helicopter"` | Rotary wing |
+| `"Plane"` | Fixed wing |
+| `"Ship"` | Naval |
+| `"StaticWeapon"` | Static weapons only |
+
+Multiple types can be combined: `["Car", "Tank"]`
+
+### Side Options (`allowedSides`)
+
+`["BLUFOR"]`, `["OPFOR"]`, `["INDEP"]`, `["CIV"]`, `["ALL"]`
+
+---
+
+## Example Calls
+
+```sqf
+// Fully unrestricted — all vehicles, all sides, 10 m range
+[this, Circle_Helipad, ["All"], ["ALL"], false, false, false, 10, ""] call Waldo_fnc_VVDInit;
+
+// BLUFOR only, ground vehicles, enforce side check
+[this, Circle_Helipad, ["Ground"], ["BLUFOR"], true, false, false, 15, ""] call Waldo_fnc_VVDInit;
+
+// Air only, auto-run a script on each spawned vehicle
+[this, Helipad_1, ["Helicopter","Plane"], ["ALL"], false, false, false, 10, "[this] call someFunction;"] call Waldo_fnc_VVDInit;
+```
+
+---
+
+## Spawner Interactions
+
+Three ACE scroll-wheel actions are added to the spawner object:
+
+| Action | Description |
+|---|---|
+| **Open Garage [name]** | Opens the garage GUI to browse and configure vehicles |
+| **Delete Vehicles [name]** | Deletes all non-default vehicles within 10 m of the spawn pad |
+| **Reset Garage Flag** | Clears a stuck "garage open" state if the garage UI was closed incorrectly |
+
+---
+
+## Damage Configuration (VVDVehicleDamage)
+
+When configuring damage in the garage, vehicles can be set to spawn with pre-applied damage to specific hitpoints. An optional **damage delay** allows the vehicle to spawn in its full state and degrade after a set time window — useful for simulating vehicles that have been running for hours.
+
+The delay is randomised within a configured min/max range. If `min == max`, the delay is exact.
+
+---
+
+## Known Limitations
+
+| Issue | Notes |
+|---|---|
+| UAV removal | Works ~80% of the time — mod config dependent |
+| Side vehicle limiting (`limitToSideVehicles`) | Works ~50% of the time — recommend leaving `false` |
+| UI appearance | Functional but not polished — this is explicitly WIP |
+| Pylon/weapon config | Only works for vehicles whose mod exposes pylon config to the garage system |

--- a/wiki/Waldos-AI-Tweak.md
+++ b/wiki/Waldos-AI-Tweak.md
@@ -1,0 +1,83 @@
+_Associated Files: MissionScripts\AiScripting\AISkillAdjustmentSystem.sqf_
+
+This script adjusts AI sub-skill values to create a more responsive and balanced PvE experience. When used alongside LAMBS Danger, it unlocks additional AI behaviours that make enemies more dynamic while remaining manageable.
+
+The system applies to **both pre-placed units and Zeus-spawned units** — Zeus curators are automatically patched at initialisation time to ensure consistent difficulty across the full mission.
+
+## Modes
+
+Two modes are available: `DAY` and `NIGHT`. Select which is active by commenting/uncommenting the appropriate line in `init.sqf`:
+
+```sqf
+"DAY" call Waldo_fnc_AITweak;   // use for daytime missions
+// "NIGHT" call Waldo_fnc_AITweak; // use for nighttime missions
+```
+
+Below is the DAY mode function, uncommented, which places the AI into daytime mode.
+!["DAY" call Waldo_fnc_AITweak;](https://i.imgur.com/N1YXEBx.png)
+
+---
+
+## DAY Mode
+
+Applies a uniform, moderately challenging skill profile to all AI regardless of faction or role.
+
+| Sub-skill | Value | Effect |
+|---|---|---|
+| `aimingspeed` | 0.42 | Moderate target acquisition speed |
+| `aimingaccuracy` | 0.83 | Good accuracy at range |
+| `aimingshake` | 0.36 | Controlled weapon shake |
+| `spottime` | 0.80 | Slightly slower than vanilla at spotting |
+| `spotdistance` | 1.00 | Full spotting range |
+| `commanding` | 1.00 | Full command responsiveness |
+| `general` | 1.00 | Full general skill |
+
+---
+
+## NIGHT Mode
+
+Night mode applies faction-aware and role-aware skill values, and responds to actual in-game lighting conditions.
+
+### Lighting-Based Spotting
+
+| Condition | Has NVG (`hmd` equipped) | No NVG |
+|---|---|---|
+| Dark (lighting ≤ 5) | `spottime` / `spotdistance` = **0.015** — nearly blind | `spottime` / `spotdistance` = **0.52** — heavily degraded |
+| Lit area (lighting > 5) | `spottime` / `spotdistance` = **1.00** — full | `spottime` / `spotdistance` = **1.00** — full |
+
+This means NVG-equipped AI are extremely effective in their environment, while AI without NVGs are severely limited in dark conditions — closely matching realistic night-combat dynamics.
+
+### Faction Awareness
+
+Some factions receive an elevated skill profile to reflect elite status:
+
+| Sub-skill | Elite factions | Default factions |
+|---|---|---|
+| `general` | 1.00 | 0.90 |
+| `commanding` | 0.95 | 0.75 |
+| `courage` | 1.00 | 0.75 |
+| `aimingspeed` | 0.72 | 0.62 |
+| `aimingaccuracy` | 0.92 | 0.83 |
+| `aimingshake` | 0.26 | 0.36 |
+| `reloadSpeed` | 1.00 | 0.75 |
+
+Elite factions include RHS Russian forces (MSV, VDV, VMF, VVS), Iron Front / Liberation WW2 factions, 3CB British, OPTRE Covenant, and others. See the source file for the full list.
+
+### Role Adjustments (Night Mode Only)
+
+On top of faction values, specific roles receive further tuning at night:
+
+| Role | Adjusted Sub-skills |
+|---|---|
+| Machine Gunner | `aimingspeed` 0.82, `aimingaccuracy` 0.82, `aimingshake` 0.35, `reloadSpeed` 0.80 |
+| Sniper | `aimingspeed` 0.60, `aimingaccuracy` 0.95, `aimingshake` 0.10, `reloadSpeed` 0.80 |
+
+---
+
+## Zeus-Spawned Units
+
+Units spawned by Zeus during the mission automatically receive the same skill profile as pre-placed units. No additional configuration is needed.
+
+## LAMBS Danger Integration
+
+When LAMBS Danger is loaded, AI will trigger a broader range of tactical behaviours (flanking, suppression, bounding overwatch). WMP's elevated `general` and `commanding` values are tuned specifically to complement LAMBS — the combination produces more tactically varied AI without making them unfairly lethal.

--- a/wiki/Waldos-Mission-Pack-Zeus-Modules.md
+++ b/wiki/Waldos-Mission-Pack-Zeus-Modules.md
@@ -1,0 +1,55 @@
+# Zeus Modules Features
+
+The packs Zeus Modules require the mission maker to be utilising Zeus Enhanced.
+
+These modules allow users to:
+* Spawn a Logistics System Supply & Medical Crate to Zeus specification
+* Set the mission to [ENDEX](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ENDEX-Script-&-Custom-End-Screen)
+* End the mission utilising the [Custom End](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ENDEX-Script-&-Custom-End-Screen)
+
+All Zeus modules provided by this pack can be found in Modules --> Waldos Mission Modules
+
+![Image of the Zeus Modules and where they can be located](https://i.imgur.com/kdR1q9Z.png)
+
+# Supply & Medical Crate Spawner
+
+Zeus-spawned crates use the same class names as the standard [Logistics System](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Logistics-System,-Starter-Crates-And-Quartermaster), so changing the crates will carry over into zeus.
+
+## Supply Crate Interace
+![Zeus Interface of supply crate spawner](https://i.imgur.com/iuiulsL.jpg)
+
+The supply crate interface allows the Zeus to select the size of resupply available in the crate, which side to draw players gear from, and whether to include equipment, weapons, attachments and items, launchers and launcer ammo, or just ammo.
+
+## Medical Supply Crate Interface
+![Zeus Interface of Medical Crate Spawner](https://i.imgur.com/7aZPysV.png)
+
+The medical crate interface allows the Zeus to select the size of medical resupply available in the crate and whether to make the crate an ACE field hospital for improved medical proficiency for medical personnel in the surrounding area.
+
+# Fortify Budget Module
+
+This module requires the [Automatic Fortify Setup](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Automatic-ACE-Fortify-Setup), or ACE Fortify being active. It allows for the alteration of the fortify budget in zeus, without the need for manual scripting.
+
+![Fortify Budget Module GUI](https://i.imgur.com/GYunnuf.jpg)
+
+# ENDEX Module
+
+The ENDEX module performs the following actions:
+* Places all player weapons on Safe and prevents Players and player vehicles from firing.
+* Makes all Hostile AI Passive
+* Fully Heals all Players & Makes them invincible
+* Creates a popup informing players that the mission is over and to congregate together for debriefing.
+* If a player tries to fire their weapon or use grenades, it is deleted and a popup tells them to cease firing.
+
+It does NOT end the mission.
+
+An example of it in use can be seen below:
+![Zeus Endex execution example](https://i.imgur.com/PBpewY8.png)
+
+# Mission End
+
+Similar to the vanilla mission end script, this mission will end the scenario.
+
+However, this variation allows the zeus to end the mission utilising a custom end screen and debriefing message which can be customised in the description.ext. Check out the [ENDEX Script & Custom End Screen](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ENDEX-Script-&-Custom-End-Screen) tutorial for more information.
+
+Below is an example of the custom mission end screen:
+![Mission End Screen Example](https://i.imgur.com/xmK9I1e.png)

--- a/wiki/Weapon-Mounting-With-Custom-Name.md
+++ b/wiki/Weapon-Mounting-With-Custom-Name.md
@@ -1,0 +1,14 @@
+_Associated Files: MissionScripts\Logistics\LogiHelpers\attachedWeapon.sqf_
+
+This script attaches an object (weapon) to a vehicle object and provides a method to switch into the mounted weapon from the vehicle it is attached to and vice versa.
+
+Parameters:
+* _turret - variable name of the turret.
+* _vehicle - variable name of the vehicle you wish to attach the turret to.
+* _customName - set a custom Get in X addaction for the turret, where X is the contents of _customName.
+
+Example call:
+
+In turret init:
+
+`[turretVariableName, VehiclevariableName,"Custom Name For Turret"] call Waldo_fnc_VehicleMountedWeapon;`

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,36 @@
+* [Home](https://github.com/AdamWaldie/WaldosMissionPack/wiki)
+* [Coding Standards](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Coding-Standards)
+* [Quickstart Guide](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Quickstart-Guide)
+* [Waldos Mission Pack Zeus Modules](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Mission-Pack-Zeus-Modules)
+* [Feature Tutorials](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Feature-Tutorials)
+    * **Mission Flow & UI**
+    * [Mission Intro Text](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Intro-Or-Title-Text)
+    * [Mission UI Text Overlays](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-UI-Text-Overlays)
+    * [ENDEX Script & Custom End Screen](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ENDEX-Script-&-Custom-End-Screen)
+    * [Radio Reports & Checklists](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Reports,-Checklists,-Support-Calls-And-Documentation)
+    * [Team Colour Setup](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Team-Colour-Setup)
+    * **Logistics & Crates**
+    * [Logistics System, Starter Crates & Quartermaster](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Logistics-System,-Starter-Crates-And-Quartermaster)
+    * [Loadout Saving and Respawn](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Loadout-Saving-and-Respawn)
+    * [Mobile Command Post](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mobile-Command-Post-With-Integrated-Logistics-System)
+    * [Virtual Vehicle Depot](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Virtual-Vehicle-Depot)
+    * **Vehicles & Deployment**
+    * [Vehicle Actions & Paradrop](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Vehicle-Actions-&-Paradrop)
+    * [Vehicle Ambush & Camo](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Vehicle-Ambush-Script-And-Vehicle-Camo)
+    * [Teleportation & Move Into Cargo](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Teleportation-&-Move-Into-Cargo-Interactions)
+    * [Weapon Mounting With Custom Name](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Weapon-Mounting-With-Custom-Name)
+    * **Construction & Fortification**
+    * [Construction Objects](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Construction-Objects)
+    * [Automatic Fortify Setup](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Automatic-ACE-Fortify-Setup)
+    * [Simple Mass Attach Items](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Simple-Mass-Attach-Items)
+    * **AI & Map**
+    * [Waldos AI Tweak](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-AI-Tweak)
+    * [AI Convoy System](https://github.com/AdamWaldie/WaldosMissionPack/wiki/AI-Convoy-System)
+    * [Map Location Tools](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Map-Location-Tools)
+    * **ACRE 2 Radio**
+    * [ACRE 2 Long Range Radio](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE-2-Long-Range-Radio-Presetting)
+    * [ACRE 2 Short Range Radio](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE-2-Squad-Level-Radios-AN-PRC%E2%80%90343-Automatic-Setup)
+    * [ACRE 2 Automated CEOI](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Automated-CEOI-Document)
+    * [ACRE 2 Babel Autoconfig](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Babel-Configuration)
+    * **Mission Maker Tools**
+    * [Mission Maker Resource Scripts](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Maker-Resource-Scripts)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,6 +1,7 @@
 * [Home](https://github.com/AdamWaldie/WaldosMissionPack/wiki)
 * [Coding Standards](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Coding-Standards)
 * [Quickstart Guide](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Quickstart-Guide)
+* [Mission Configuration Reference](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Configuration-Reference)
 * [Waldos Mission Pack Zeus Modules](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Mission-Pack-Zeus-Modules)
 * [Feature Tutorials](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Feature-Tutorials)
     * **Mission Flow & UI**
@@ -32,5 +33,6 @@
     * [ACRE 2 Short Range Radio](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE-2-Squad-Level-Radios-AN-PRC%E2%80%90343-Automatic-Setup)
     * [ACRE 2 Automated CEOI](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Automated-CEOI-Document)
     * [ACRE 2 Babel Autoconfig](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Babel-Configuration)
-    * **Mission Maker Tools**
+    * **Miscellaneous**
+    * [Unit Insignias](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Unit-Insignias)
     * [Mission Maker Resource Scripts](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Maker-Resource-Scripts)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

This PR contains the full wiki content for review in `wiki/`. To apply, push the updated `.md` files to the `WaldosMissionPack.wiki.git` repository (or copy-paste each file's content into the GitHub wiki editor).

### New pages (5)

| Page | What it covers |
|---|---|
| `AI-Convoy-System.md` | `Waldo_fnc_SimpleAiConvoy` — previously completely undocumented. Parameters, termination block, multi-convoy setup. |
| `Map-Location-Tools.md` | `Waldo_fnc_CreateMapLocationName` and `Waldo_fnc_ReplaceMapLocationName` — create or rename map locations via a Game Logic. Includes common location type reference table. |
| `Mission-UI-Text-Overlays.md` | `Waldo_fnc_DynamicText`, `Waldo_fnc_TimedHint`, `Waldo_fnc_RespawnText` — runtime text overlay functions grouped into one page. |
| `Team-Colour-Setup.md` | `Waldo_fnc_SetTeamColour` — automatic ACE3 team colour assignment from role descriptions. Full keyword-to-colour mapping table, recommended naming format, how to customise. |
| `Mission-Maker-Resource-Scripts.md` | Documentation for all four scripts in `MissionMakerResourceScripts/`: ACE Arsenal toolkit, vehicle damage monitor, example unhiding script, mod config patch logger. |

### Expanded pages (6)

- **Waldos AI Tweak** — added full DAY/NIGHT skill value tables, lighting-based spotting logic (NVG vs no-NVG), faction-aware tuning with faction list, role adjustments for MGs and snipers, Zeus unit coverage note, LAMBS integration note. Kept the existing screenshot.
- **Mission Intro Text** — fixed a bug where the basic call example showed `[] spawn Waldo_fnc_ENDEX;` (wrong function). Now shows `[] spawn Waldo_fnc_InfoText;`. Added full params table, animation options table, date override instructions.
- **Loadout Saving and Respawn** — fixed incomplete sentence ("Radio channels,"), added the arsenal-close save option (was only in CLAUDE.md, not the wiki), added `respawnOnStart = -1` requirement note, improved ACE conflict section.
- **Radio Reports, Checklists, Support Calls And Documentation** — was just a bullet list. Now a full page with a table of all 16 documents and their function names, enable/disable guide, and instructions for adding custom briefing documents.
- **Feature Tutorials** — reorganised from a flat list into labelled sections (Mission Flow, Logistics, Vehicles, Construction, AI & Map, ACRE2, Mission Maker Tools) with links to all new pages.
- **Sidebar** — reorganised into grouped sections matching the Feature Tutorials structure. All new pages linked.

## Test plan

- [ ] Verify new pages render correctly in the GitHub wiki editor (no broken markdown)
- [ ] Confirm sidebar links resolve to correct pages
- [ ] Check that the fixed `Waldo_fnc_InfoText` call in Mission Intro Text is correct
- [ ] Verify Feature Tutorials section links all work

https://claude.ai/code/session_012KUoEeq1Vg4PhVcb3JmsUC
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_012KUoEeq1Vg4PhVcb3JmsUC)_