### PR TITLE
Add Zeus module: Loadout Save Point

### DIFF
--- a/MissionScripts/WaldosFunctions.sqf
+++ b/MissionScripts/WaldosFunctions.sqf
@@ -220,6 +220,12 @@ class CfgFunctions
             class FortifyBudgetModule {
                 file = "MissionScripts\ZenModules\Zen_fortifyBudgetModule.sqf";
             };
+            class ZenLoadoutSaveModule {
+                file = "MissionScripts\ZenModules\Zen_loadoutSaveModule.sqf";
+            };
+            class ZenAddLoadoutSaveAction {
+                file = "MissionScripts\ZenModules\Zen_loadoutSaveSetup.sqf";
+            };
         };
         class Paradrop {
             class AddHaloJump {

--- a/MissionScripts/ZenModules/Zen_initModules.sqf
+++ b/MissionScripts/ZenModules/Zen_initModules.sqf
@@ -53,3 +53,11 @@ if !(isClass(configFile >> "CfgPatches" >> "zen_main")) exitWith {};
     },
     "\z\ACE\addons\fortify\ui\hammer_ca.paa"
 ] call zen_custom_modules_fnc_register;
+
+["Waldos Mission Modules", "Loadout Save Point",
+    {
+        params ["_modulePos", "_objectPos"];
+        [_modulePos, _objectPos] call Waldo_fnc_ZenLoadoutSaveModule;
+    },
+    "\A3\ui_f\data\map\vehicleicons\iconMan_ca.paa"
+] call zen_custom_modules_fnc_register;

--- a/MissionScripts/ZenModules/Zen_loadoutSaveModule.sqf
+++ b/MissionScripts/ZenModules/Zen_loadoutSaveModule.sqf
@@ -1,0 +1,35 @@
+/*
+ * Author: Waldo
+ * Zeus module to add a "Save Respawn Loadout" action to a target object.
+ * If no object is selected a default supply box is spawned at the module position.
+ * JIP compatible — action is re-applied automatically to players who join late.
+ *
+ * Arguments:
+ * 0: modulePos <POSITION>
+ * 1: objectPos <OBJECT>
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [getPos logic, cursorObject] call Waldo_fnc_ZenLoadoutSaveModule;
+ */
+
+params ["_modulePos", "_objectPos"];
+
+private _target = objNull;
+
+if (!isNull _objectPos) then {
+    _target = _objectPos;
+} else {
+    private _crateClass = missionNamespace getVariable ["Logi_SupplyBoxClass", "B_supplyCrate_F"];
+    _target = _crateClass createVehicle _modulePos;
+
+    [{
+        _this call ace_zeus_fnc_addObjectToCurator;
+    }, _target] call CBA_fnc_execNextFrame;
+};
+
+// Execute on all current clients and re-execute for every JIP player.
+// Using _target as the JIP ID ties the entry to the object lifetime.
+[_target] remoteExec ["Waldo_fnc_ZenAddLoadoutSaveAction", 0, _target];

--- a/MissionScripts/ZenModules/Zen_loadoutSaveSetup.sqf
+++ b/MissionScripts/ZenModules/Zen_loadoutSaveSetup.sqf
@@ -1,0 +1,35 @@
+/*
+ * Author: Waldo
+ * Adds the "Save Respawn Loadout" addAction to the given object on the local machine.
+ * Called via remoteExec (including JIP) from Waldo_fnc_ZenLoadoutSaveModule.
+ *
+ * Arguments:
+ * 0: target <OBJECT> - Object to receive the action
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [someBox] call Waldo_fnc_ZenAddLoadoutSaveAction;
+ */
+
+params ["_target"];
+
+if (isNull _target) exitWith {};
+if !(hasInterface) exitWith {};
+
+// Prevent duplicate actions if the module is placed on the same object more than once.
+// This variable is intentionally local — each machine tracks its own state.
+if (_target getVariable ["Waldo_LoadoutSaveActionAdded", false]) exitWith {};
+_target setVariable ["Waldo_LoadoutSaveActionAdded", true];
+
+_target addAction [
+    "<t color='#00FF00'>Save Respawn Loadout</t>",
+    Waldo_fnc_SaveLoadout,
+    nil,
+    1.5,
+    true,
+    true,
+    "",
+    "true"
+];


### PR DESCRIPTION
## Summary

- Adds a new **Loadout Save Point** entry to the "Waldos Mission Modules" Zeus menu
- When placed on an existing object, attaches the "Save Respawn Loadout" action to it
- When placed on empty space, spawns a default supply box (respects `Logi_SupplyBoxClass` if set) and attaches the action
- **JIP compatible** — uses `remoteExec` with the target object as the persistence ID, so players who join late automatically receive the action

## New files

| File | Purpose |
|---|---|
| `Zen_loadoutSaveModule.sqf` | Module entry point — resolves target object or spawns box, fires remoteExec |
| `Zen_loadoutSaveSetup.sqf` | `remoteExec` target — adds `addAction` on the local machine once per object |

## Modified files

- `WaldosFunctions.sqf` — registers `Waldo_fnc_ZenLoadoutSaveModule` and `Waldo_fnc_ZenAddLoadoutSaveAction`
- `Zen_initModules.sqf` — registers "Loadout Save Point" in the Zeus module menu

## Test plan

- [ ] Place module on empty space → default supply box spawns with green "Save Respawn Loadout" action
- [ ] Place module on an existing object (vehicle, crate, etc.) → action appears on that object, object is not replaced
- [ ] Use the action as a player → loadout saves, hint "Respawn Loadout Updated!" appears, respawn uses saved kit
- [ ] Have a player join after module placement (JIP) → action is present on the object for them
- [ ] Place module twice on the same object → only one action appears (no duplicates)
- [ ] Mission without Zeus Enhanced loaded → `Zen_initModules.sqf` exits silently, no errors

https://claude.ai/code/session_0132jGc5MCHCBuaaqBFMj5em

---
_Generated by [Claude Code](https://claude.ai/code/session_0132jGc5MCHCBuaaqBFMj5em)_