### PR TITLE
Surface Waldos Economy Systems in the wiki and raise its ease of use

### DIFF
--- a/init.sqf
+++ b/init.sqf
@@ -34,6 +34,8 @@ that do not use it pay no cost. You can also enable it without editing this file
 To pre-configure the economy from the editor (a bundled LOW/MEDIUM/HIGH preset, a full exported
 config string, or commitment mode) without opening Zeus, see the "Waldos Economy Systems"
 setup block in initServer.sqf.
+
+Full guide (easiest path first): https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Economy-Systems
 */
 Waldo_Economy_Enable = false;
 if (Waldo_Economy_Enable) then {

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -26,6 +26,7 @@ I maintain this wiki regularly and keep it updated with tutorials on the vast ma
 - Teleportation Script
 - Endex & Safestart Scripts
 - Custom Zeus Enhanced modules for in-game access to the logistics system and ENDEX scripts.
+- [Waldos Economy Systems](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Economy-Systems) - a pub-Zeus Resource / Research / Build / Buy economy suite with Ground Command, run live from the Zeus menu. Drop a preset composition and you have a working RTS-style economy in seconds.
 - HALO & Static Line Jump Scripts with equipment & weapon loss simulation.
 - [WIP] Virtual Vehicle Deployment Garage
 - Extensively documented files to learn how it works, and make use of this pack!

--- a/wiki/Waldos-Economy-Systems-Setup-And-Configuration.md
+++ b/wiki/Waldos-Economy-Systems-Setup-And-Configuration.md
@@ -4,15 +4,15 @@ This page covers every way to enable and configure [Waldos Economy Systems](http
 
 ## 1. Enable the suite
 
-It is **off by default**, so missions that don't use it pay no performance cost. Turn it on either way:
+It is **off by default**, so missions that don't use it pay no performance cost. Turn it on whichever way is easiest for you:
 
-* **In `init.sqf`:**
+* **Easiest — drop a composition** (Eden compositions list, category _Waldos Mission Pack Compositions_). No scripting, no init fields:
+  * `[WMP] Waldos Economy Systems - Low / Medium / High Preset` — boots the suite **and** loads a ready-made economy. This is the fastest way to a playable economy; start with **Low** if you're new to it.
+  * `[WMP] Waldos Economy Systems` — boots the suite only, so you configure it yourself (live in Zeus or via the files below).
+* **Or set one flag in `init.sqf`:**
   ```sqf
   Waldo_Economy_Enable = true;   // init.sqf then runs: [] spawn Waldo_fnc_EcoInit;
   ```
-* **Or drop a composition** (Eden compositions list, category _Waldos Mission Pack Compositions_):
-  * `[WMP] Waldos Economy Systems` — boots the suite, configure it yourself.
-  * `[WMP] Waldos Economy Systems - Low / Medium / High Preset` — boots **and** loads a ready-made economy.
 
 Place only one Economy Systems object per mission.
 

--- a/wiki/Waldos-Economy-Systems.md
+++ b/wiki/Waldos-Economy-Systems.md
@@ -22,13 +22,18 @@ This is the hub page. Each system has its own tutorial:
 | Build | Construct and upgrade buildings that produce resources, store them, boost speeds, or reveal enemies. |
 | Buy | Purchase vehicles at a terminal; they appear at a configured drop point. |
 
-## Quick start
+## Quick start — pick your effort level
 
-1. Enable the suite — set `Waldo_Economy_Enable = true;` in `init.sqf`, **or** place a `[WMP] Waldos Economy Systems` composition (a preset variant gives you a working economy instantly).
-2. Open Zeus — a new **Waldos Economy Systems** root appears in the Zeus tree.
-3. Configure live, or pre-author everything in `economyConfig.sqf` so it loads automatically.
+You never have to touch a script to use this suite. Pick the path that suits you:
 
-See **[Setup & Configuration](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Economy-Systems-Setup-And-Configuration)** for the full walkthrough.
+* **Easiest (≈30 seconds, no scripting, no Eden setup).** In the Eden Editor, open the **Compositions** list (category _Waldos Mission Pack Compositions_) and drag in
+  **`[WMP] Waldos Economy Systems - Low / Medium / High Preset`**. That single object boots the suite **and** loads a ready-made, balanced economy for NATO/CSAT/AAF. Play the mission — it just works. (Start with **Low** if you're new to it.)
+* **Live in Zeus (one flag).** Set `Waldo_Economy_Enable = true;` in `init.sqf` (or drop the plain `[WMP] Waldos Economy Systems` composition). Open Zeus — a new **Waldos Economy Systems** root appears in the tree, and you build the whole economy live with menus and dialogs. No editor objects required.
+* **Bake in your own (full control).** Configure it live in Zeus, hit **Export** to copy a config string, and paste it into `Waldo_Economy_ConfigString` in `initServer.sqf` — or hand-author everything in `economyConfig.sqf`. It then loads automatically every time the mission runs, for every player including JIP.
+
+> **Tip:** place only **one** Economy Systems object (composition or flag) per mission.
+
+See **[Setup & Configuration](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Economy-Systems-Setup-And-Configuration)** for the full walkthrough of all three paths.
 
 ## Architecture (for scripters)
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -20,6 +20,14 @@
     * [Vehicle Ambush & Camo](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Vehicle-Ambush-Script-And-Vehicle-Camo)
     * [Teleportation & Move Into Cargo](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Teleportation-&-Move-Into-Cargo-Interactions)
     * [Weapon Mounting With Custom Name](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Weapon-Mounting-With-Custom-Name)
+    * **Economy, Research & Base Building**
+    * [Waldos Economy Systems](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Economy-Systems)
+    * [— Setup & Configuration](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Economy-Systems-Setup-And-Configuration)
+    * [— Resource System](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Economy-Systems-Resource-System)
+    * [— Research System](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Economy-Systems-Research-System)
+    * [— Build System](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Economy-Systems-Build-System)
+    * [— Buy System](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Economy-Systems-Buy-System)
+    * [— Ground Command & Tools](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Economy-Systems-Ground-Command-And-Tools)
     * **Construction & Fortification**
     * [Construction Objects](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Construction-Objects)
     * [Automatic Fortify Setup](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Automatic-ACE-Fortify-Setup)


### PR DESCRIPTION
## Why

The Waldos Economy Systems wiki pages existed but were **unreachable from navigation** — the per-page `_Sidebar.md` had no Economy section at all, and the wiki `Home.md` never mentioned the suite. To anyone browsing the wiki, the economy systems effectively had no entries. This makes them discoverable and leads with the lowest-effort setup path.

## What changed (this commit)

- **`wiki/_Sidebar.md`** — added an **Economy, Research & Base Building** section linking the hub page and all six sub-pages (Setup, Resource, Research, Build, Buy, Ground Command), matching the ordering already in `Feature-Tutorials.md`.
- **`wiki/Home.md`** — added the economy suite to *Pack Features* with a link to the hub page.
- **`wiki/Waldos-Economy-Systems.md`** — reworked *Quick start* into three clearly-tiered effort levels, leading with the **~30-second, no-scripting preset composition** path.
- **`wiki/Waldos-Economy-Systems-Setup-And-Configuration.md`** — reordered the *Enable the suite* section so the easiest path (preset composition) comes first, ahead of the script flag.
- **`init.sqf`** — added a wiki-guide link to the economy comment block so makers can jump to the tutorial from the point of contact.

All sidebar link targets verified to exist; both Python validators pass (`sqf_validator.py`, `config_style_checker.py`). On merge to `main`, `wiki-sync.yml` pushes these into the live GitHub Wiki.

> Note: this branch is also ahead of `main` with the previously-developed economy suite itself, so the full diff against `main` includes that prior work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NniTZth2yoieN8KLtatdxy)_