### PR TITLE
docs: wiki pages for Safestart, Diagnostics, Tasks/Objectives & AAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ to utilise critical systems of arma 3. Now, it is in continued use by at least f
 - Vehicle unflipping actions
 - Simple AI convoy script expanded and enhanced from Tovas original.
 - Teleportation Script
-- Endex & Safestart Scripts
-- Custom Zeus Enhanced modules for in-game access to the logistics system and ENDEX scripts.
+- Endex & Safestart Scripts - including an automatic After-Action Report (duration, KIA/WIA, vehicle losses, friendly fire, objectives, top fraggers) in the ENDEX popup.
+- Script-driven Tasks/Objectives helpers - JIP-safe BIS task wrappers with automatic map markers that also feed the After-Action Report.
+- Mission Diagnostics - a read-only server-side config sanity check that warns about the most common WMP misconfigurations at mission start.
+- Custom Zeus Enhanced modules for in-game access to the logistics system, ENDEX & Safestart scripts.
 - Waldos Economy Systems - a pub-Zeus Resource / Research / Build / Buy economy suite with Ground Command, run live from the Zeus menu.
 - HALO & Static Line Jump Scripts with equipment & weapon loss simulation.
 - [WIP] Virtual Vehicle Deployment Garage

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ to utilise critical systems of arma 3. Now, it is in continued use by at least f
 - Waldos Economy Systems - a pub-Zeus Resource / Research / Build / Buy economy suite with Ground Command, run live from the Zeus menu.
 - HALO & Static Line Jump Scripts with equipment & weapon loss simulation.
 - [WIP] Virtual Vehicle Deployment Garage
+- Bundled (optional, off by default) third-party scripts - Werthles' Headless Client kit and aeroson's dynamic player markers - wired through a single clean entry point.
 - Extensively documented files to learn how it works, and make use of this pack!
 - Mission Pack Compositions to hasten the learning and mission building process
 - Auto-generated cover/loading screen - the title and version are rendered programmatically from description.ext and kept in sync on every push and release.

--- a/wiki/Construction-Objects.md
+++ b/wiki/Construction-Objects.md
@@ -1,30 +1,49 @@
-_Associated Files: MissionScripts\Logistics\Construction\ConstructionObjects.sqf_
+_Associated Files: `MissionScripts\Logistics\Construction\ConstructionObjects.sqf`, `Waldo_fnc_ConstructionObjects`_
 
-This function allows you to fake the construction of defences/objects/scenery from a single object via Ace Interaction.
+# Construction Objects
 
-Objects must be pre-placed in the editor around the item you wish to build from, but the interactable object does not need to be stationary.
+Fakes the **construction of defences, objects or scenery** from a single interaction object via an ACE timed action. Pre-place the objects you want "built" (hidden at mission start); when a player runs the build action on the interaction object, those objects appear with a construction sound and progress bar. It's a lightweight way to let players raise a sandbag wall, a checkpoint, an FOB, or any prop set on demand — without the full Eden/ACE base-building flow.
 
-Construction objects can be transported in ACE cargo and retain its abilities.
+The interaction object can be **carried in ACE cargo** and keeps its build ability after being moved, so you can haul a "build kit" crate to where you need it.
 
-### Setting Up in Eden;
-* Place the object or object that you want to have the respawn deployable from, and provide it a variable name
-* Place a Game Logic down as close as possible to the object. This can be found near the same menu as Modules.
-* Place any objects you wish to appear when the object is interacted with..
-* If you are using an object as your primary object and any of your deployable objects should be resting on the floor, then raise them about a foot, to allow for the drop of the object's suspension once the game has initialised.
-* Select all the objects that will be deployable, right-click and synchronise them to the Game Logic.
-* In the object's init, paste the example below, and alter it to suit your needs.
+## Requirements
 
-### Parameters:
-* _target - Vehicle or Object to use as the interactable to build synced objects from
-* _UseModernConsturctionAudio - boolean (true/false) | Options: True = Modern construction Noises, False = Old Wooden Sounding Construction Noises.
+* **ACE3** — the action uses the ACE interaction menu and progress bar. The function silently exits if ACE is not loaded.
 
-Call:
+## Parameters
 
-`[_target,_UseModernConsturctionAudio] call Waldo_fnc_ConstructionObjects;`
+| # | Parameter | Type | Default | Purpose |
+|---|---|---|---|---|
+| 0 | Target | Object | — | The object players interact with to build the synced objects. |
+| 1 | Modern audio | Bool | `false` | `true` = modern construction sounds; `false` = older "wooden" construction sounds. |
 
-e.g.
+## Setup in Eden
 
-`[this,true] call Waldo_fnc_ConstructionObjects; - use modern audio`
+1. Place the **interaction object** (e.g. an ammo box) and give it a variable name.
+2. Place a **Game Logic** as close as possible to it (near the Modules menu).
+3. Place every object you want to appear when built, positioned where it should end up.
+4. If a built object should rest on the ground, raise it ~1 ft to allow for any suspension/physics settling once the mission loads.
+5. Select all the buildable objects, right-click → **Synchronise** them to the Game Logic.
+6. In the interaction object's **init field**, call the function:
 
-Below is an example of the construction script correctly setup. The ammo box is the object the player interacts with:
+```sqf
+[this, true] call Waldo_fnc_ConstructionObjects;   // modern construction audio
+```
+
+The synced objects start hidden and are revealed (with sound + progress bar) when a player completes the build action.
+
+## Examples
+
+```sqf
+[this] call Waldo_fnc_ConstructionObjects;        // old wooden-sounding construction audio
+[this, true] call Waldo_fnc_ConstructionObjects;  // modern construction audio
+```
+
+Below is an example of the construction script correctly set up. The ammo box is the object the player interacts with:
 ![Picture of the construction script in the editor](https://i.imgur.com/gYf9HQq.png)
+
+## See also
+
+* [Mobile Command Post](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mobile-Command-Post-With-Integrated-Logistics-System) — deploy/tear-down command post using the same synced-Logic pattern
+* [Automatic Fortify Setup](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Automatic-ACE-Fortify-Setup) — full ACE Fortify base-building
+* [Simple Mass Attach Items](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Simple-Mass-Attach-Items)

--- a/wiki/ENDEX-Script-&-Custom-End-Screen.md
+++ b/wiki/ENDEX-Script-&-Custom-End-Screen.md
@@ -1,4 +1,4 @@
-_Associated Files: MissionScripts\MissionFlow\ENDEX.sqf_
+_Associated Files: `MissionScripts\MissionFlowAndUi\ENDEX.sqf`, `aarTrack.sqf`, `aarWound.sqf`, `Waldo_fnc_ENDEX`, `Waldo_fnc_AARTrack`_
 
 # ENDEX
 The ENDEX script performs the following actions:
@@ -7,6 +7,7 @@ The ENDEX script performs the following actions:
 * Fully Heals all Players & Makes them invincible
 * Creates a popup informing players that the mission is over and to congregate together for debriefing.
 * If a player tries to fire their weapon or use grenades, it is deleted and a popup tells them to cease firing.
+* Shows an **After-Action Report** in the ENDEX popup when mission tracking is running (see below).
 
 You can call ENDEX by executing this line of code locally - such as a trigger:
 
@@ -18,6 +19,24 @@ Alternatively, you could remotely execute it via a script:
 
 An example of it in use can be seen below:
 ![Zeus Endex execution example](https://i.imgur.com/PBpewY8.png)
+
+# After-Action Report (AAR)
+The ENDEX popup also shows an **After-Action Report** summarising how the mission went. You do not need to configure anything — tracking starts automatically from `initServer.sqf` via `[] call Waldo_fnc_AARTrack`, which registers a single lightweight `EntityKilled` mission event handler (negligible overhead, no per-frame loops). If tracking never ran, ENDEX simply omits the AAR block.
+
+The report includes (each line is omitted when its tally is empty):
+
+| Line | Source |
+|---|---|
+| **Duration** | Time since mission start. |
+| **KIA** per side | Infantry killed, tallied by the dead unit's side. |
+| **Player losses** | Human players killed. |
+| **Vehicles lost** per side | Vehicles destroyed, tallied by the vehicle's side. |
+| **WIA** per side | Unique wounded — **requires ACE medical** (counts each unit's first unconsciousness once). |
+| **Friendly fire** | Kills where the shooter and victim share a side. |
+| **Objective summary** | Tasks created/resolved with [Waldo_fnc_CreateObjective / SetObjectiveState](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Tasks-And-Objectives). |
+| **Top fraggers** | Leaderboard of enemy kills scored by human players. |
+
+WIA tracking relies on an `ace_unconscious` listener registered in `init.sqf`; if ACE medical is not loaded, the WIA line is simply absent. The objective summary populates automatically when you drive objectives through the [Tasks / Objectives](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Tasks-And-Objectives) helpers.
 
 # Custom End Screen
 At the base of the description.ext provided, you can find a custom end card section.

--- a/wiki/Feature-Tutorials.md
+++ b/wiki/Feature-Tutorials.md
@@ -12,7 +12,9 @@ The basic setup is covered in the [Quickstart Guide](https://github.com/AdamWald
 ## Mission Flow & UI
 * [Mission Intro Text](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Intro-Or-Title-Text)
 * [Mission UI Text Overlays](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-UI-Text-Overlays) — Dynamic text, timed hints, respawn text
-* [ENDEX Script & Custom End Screen](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ENDEX-Script-&-Custom-End-Screen)
+* [ENDEX Script & Custom End Screen](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ENDEX-Script-&-Custom-End-Screen) — Also covers the After-Action Report shown in the ENDEX popup
+* [Safestart](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Safestart) — Freeze players at mission start; lift to go live (timer + Zeus modules)
+* [Tasks / Objectives](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Tasks-And-Objectives) — Script-driven, JIP-safe task helpers with auto map markers
 * [Radio Reports, Checklists, Support Calls And Documentation](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Reports,-Checklists,-Support-Calls-And-Documentation)
 * [Team Colour Setup](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Team-Colour-Setup) — Also covers GetPlayerGroup and GetPlayerRole helpers
 
@@ -54,5 +56,6 @@ The basic setup is covered in the [Quickstart Guide](https://github.com/AdamWald
 * [ACRE 2 Babel Autoconfig](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Babel-Configuration)
 
 ## Miscellaneous
+* [Mission Diagnostics](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Diagnostics) — Server-side config sanity check; warns about the common WMP misconfigurations
 * [Unit Insignias](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Unit-Insignias)
 * [Mission Maker Resource Scripts](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Maker-Resource-Scripts) — Debug tools, arsenal toolkit, damage monitor

--- a/wiki/Feature-Tutorials.md
+++ b/wiki/Feature-Tutorials.md
@@ -48,6 +48,7 @@ The basic setup is covered in the [Quickstart Guide](https://github.com/AdamWald
 * [Waldos AI Tweak](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-AI-Tweak)
 * [AI Convoy System](https://github.com/AdamWaldie/WaldosMissionPack/wiki/AI-Convoy-System)
 * [Map Location Tools](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Map-Location-Tools)
+* [Headless Client & Player Markers](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Third-Party-Scripts-Headless-Client-And-Player-Markers) — bundled third-party scripts (Werthles HC, aeroson markers), disabled by default
 
 ## ACRE 2 Radio
 * [ACRE 2 Long Range Radio Presetting](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE-2-Long-Range-Radio-Presetting)

--- a/wiki/Mission-Configuration-Reference.md
+++ b/wiki/Mission-Configuration-Reference.md
@@ -103,6 +103,33 @@ missionNamespace setVariable ["WALDO_PARA_HALOCHUTE",    "B_Parachute", true]; /
 
 For non-RHS missions, replace `"rhs_d6_Parachute"` with `"NonSteerable_Parachute_F"` (vanilla).
 
+### Safestart
+
+Freezes all players at mission start until you go live. Auto-starts by default.
+
+```sqf
+missionNamespace setVariable ["Waldo_SafeStart_Confine", true, true];   // safe-zone confinement on/off
+missionNamespace setVariable ["Waldo_SafeStart_Radius", 75, true];      // per-player radius (metres)
+missionNamespace setVariable ["Waldo_SafeStart_ZoneMarker", "", true];  // marker name for one shared zone (else per-player anchor)
+missionNamespace setVariable ["Waldo_SafeStart_AutoStart", true, true]; // false = start the mission live
+```
+
+See [Safestart](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Safestart) for the go-live API and Zeus modules.
+
+### Mission Diagnostics
+
+Runs a read-only server-side configuration sanity check at mission start and reports common WMP misconfigurations to the RPT log (prefixed `[WMP DIAG]`).
+
+```sqf
+missionNamespace setVariable ["Waldo_RunDiagnostics", true, true];  // false = silence it for a shipping mission
+```
+
+See [Mission Diagnostics](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Diagnostics).
+
+### After-Action Report Tracking
+
+`initServer.sqf` calls `[] call Waldo_fnc_AARTrack;` to start lightweight event-driven tracking (duration, KIA, vehicle losses, friendly fire, fraggers) so the ENDEX popup can show an After-Action Report. Remove the line to disable the report. See [ENDEX & After-Action Report](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ENDEX-Script-&-Custom-End-Screen).
+
 ---
 
 ## init.sqf

--- a/wiki/Mission-Configuration-Reference.md
+++ b/wiki/Mission-Configuration-Reference.md
@@ -143,6 +143,8 @@ Runs on **all clients and the server** during the loading screen transition. Ena
 // [] execVM "MissionScripts\ThirdPartyScripts\ThirdPartyScriptInit.sqf";
 ```
 
+See [Headless Client & Player Markers](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Third-Party-Scripts-Headless-Client-And-Player-Markers) for the options inside that file.
+
 ### Zeus Enhanced Modules
 
 ```sqf

--- a/wiki/Mission-Diagnostics.md
+++ b/wiki/Mission-Diagnostics.md
@@ -1,0 +1,54 @@
+_Associated Files: `initServer.sqf`, `MissionScripts\MissionFlowAndUi\runDiagnostics.sqf`, `Waldo_fnc_RunDiagnostics`_
+
+# Mission Diagnostics
+
+Mission Diagnostics is a server-side configuration sanity check that runs once at mission start (just after the loadout scan) and reports the most common WaldosMissionPack misconfigurations. It is **read-only** — it never changes mission state and never throws — so it is safe to leave on while building, and easy to silence for a shipping mission.
+
+Output goes to the **RPT log**, with every line prefixed `[WMP DIAG]`. Any **warning** is also echoed to admins/host on screen via `systemChat`, so you see problems without digging through the log. Informational lines (e.g. how many items each side's loadout scrape produced) stay in the RPT to avoid spam.
+
+## What it checks
+
+| Check | Warns when |
+|---|---|
+| **Required mods** | CBA_A3 or ACE3 are not detected. |
+| **Per-side loadout scrape** | A side has playable slots but its scraped loadout is empty — the classic symptom of vanilla loadouts (not edited with ACE Arsenal) or a **binarized** `mission.sqm`. Also warns if there are no playable units at all. |
+| **Crate classnames** | `Logi_SupplyBoxClass` / `Logi_MedicalBoxClass` is not a valid `CfgVehicles` class. |
+| **Paradrop thresholds** | Static-line min altitude is not below max altitude, or max speed is not greater than 0. |
+| **Parachute classes** | `WALDO_STATIC_STATICCHUTE` / `WALDO_PARA_HALOCHUTE` is not a valid `CfgVehicles` class (usually a missing mod). |
+| **ACRE2 LR channels** | Long-range channel arrays are empty (informational only, and only when ACRE2 is loaded). |
+
+It finishes with a one-line summary of how many warnings were raised.
+
+## Enabling / disabling
+
+It is **on by default**. A documented block in `initServer.sqf` controls it:
+
+```sqf
+// Set to false to silence diagnostics for a shipping mission:
+missionNamespace setVariable ["Waldo_RunDiagnostics", true, true];
+```
+
+Leave it on during development to catch problems early; set it to `false` before you ship if you'd rather keep the RPT clean.
+
+## Reading the output
+
+Open your `*.rpt` file (or watch the on-screen admin messages) and search for `[WMP DIAG]`. For example:
+
+```
+[WMP DIAG] INFO: Running WaldosMissionPack configuration diagnostics...
+[WMP DIAG] INFO: BLUFOR loadout pool: 142 unique items.
+[WMP DIAG] WARN: OPFOR has playable units but its scraped loadout is empty. Edit unit loadouts with ACE Arsenal and disable mission binarization.
+[WMP DIAG] 1 configuration warning(s) raised - see RPT log for details.
+```
+
+The function also **returns** the number of warnings raised, if you want to call it yourself:
+
+```sqf
+private _warnings = [] call Waldo_fnc_RunDiagnostics;
+```
+
+## See also
+
+* [Logistics System, Starter Crates And Quartermaster](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Logistics-System,-Starter-Crates-And-Quartermaster) — the loadout scrape these checks validate
+* [Mission Configuration Reference](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Configuration-Reference) — all `initServer.sqf` fields
+* [Vehicle Actions & Paradrop](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Vehicle-Actions-&-Paradrop) — the paradrop thresholds these checks validate

--- a/wiki/Safestart.md
+++ b/wiki/Safestart.md
@@ -1,0 +1,75 @@
+_Associated Files: `initServer.sqf`, `MissionScripts\MissionFlowAndUi\safeStart.sqf`, `safeStartTimer.sqf`, `safeStartApply.sqf`, `Waldo_fnc_SafeStart`, `Waldo_fnc_SafeStartTimer`_
+
+# Safestart
+
+Safestart freezes every player at the start of a mission so people can load in, sort kit and get organised before anyone can shoot. It is the reversible mirror of the [ENDEX](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ENDEX-Script-&-Custom-End-Screen) script — turn it on to hold the mission, lift it to go live.
+
+While Safestart is active:
+* All weapons are placed on safe (ACE), and **every** shot, thrown grenade, launcher round, underbarrel round and crewed vehicle weapon round is deleted — firing just shows a red **"Hold Fire!"** prompt.
+* Players take and deal **no damage**.
+* Players are **confined to a safe zone** (they are pulled back if they try to leave).
+* An on-screen **banner** is shown, with a live go-live countdown when a timer is running.
+* **JIP and respawning players are re-frozen automatically**, so latecomers can't skip it.
+
+The freeze runs on its own variables, so it never clashes with ENDEX.
+
+## Auto-start (the default)
+
+Safestart starts automatically from `initServer.sqf`. A documented block there exposes the options:
+
+```sqf
+missionNamespace setVariable ["Waldo_SafeStart_Confine", true, true];   // safe-zone confinement on/off
+missionNamespace setVariable ["Waldo_SafeStart_Radius", 75, true];      // per-player radius (metres)
+missionNamespace setVariable ["Waldo_SafeStart_ZoneMarker", "", true];  // marker name for one shared zone (else per-player anchor)
+missionNamespace setVariable ["Waldo_SafeStart_AutoStart", true, true]; // false = start the mission live (no safestart)
+```
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `Waldo_SafeStart_AutoStart` | `true` | `false` = mission starts live, no Safestart. |
+| `Waldo_SafeStart_Confine` | `true` | `false` = freeze weapons/damage but let players move freely. |
+| `Waldo_SafeStart_Radius` | `75` | Confinement radius in metres around each player's start position. |
+| `Waldo_SafeStart_ZoneMarker` | `""` | Set to a marker name to confine everyone to **one shared zone** (the marker's position and size) instead of a per-player radius. |
+
+## Going live & the scripting API
+
+The API is **server-authoritative** — it is safe to call from a client, it forwards to the server for you.
+
+```sqf
+[true]  call Waldo_fnc_SafeStart;        // activate the freeze
+[false] call Waldo_fnc_SafeStart;        // go live (admin overrule; also cancels any countdown)
+[300]   call Waldo_fnc_SafeStartTimer;   // go live automatically in 300 seconds (banner shows the clock)
+```
+
+`Waldo_fnc_SafeStartTimer` makes sure Safestart is active, then publishes the go-live time so every player's banner shows a live countdown, and lifts the freeze automatically when it expires. Calling it again restarts/extends the timer. An admin can overrule a running countdown at any time with `[false] call Waldo_fnc_SafeStart`.
+
+## Zeus usage
+
+Three modules are registered under **"Waldos Mission Modules"** in the Zeus menu:
+
+| Module | Action |
+|---|---|
+| **Safestart - Activate** | Freezes the mission (`[true] call Waldo_fnc_SafeStart`). |
+| **Safestart - Go Live (Lift)** | Lifts the freeze and cancels any countdown. |
+| **Safestart - Start Go-Live Countdown** | Prompts for a number of minutes, then starts the auto go-live timer. |
+
+[Waldos Mission Pack Zeus Modules](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Mission-Pack-Zeus-Modules) are covered separately.
+
+## Examples
+
+```sqf
+// Hold the mission, then auto go-live 5 minutes later from a trigger:
+[300] call Waldo_fnc_SafeStartTimer;
+
+// Confine everyone to one shared zone called "startzone" instead of per-player radii (initServer.sqf):
+missionNamespace setVariable ["Waldo_SafeStart_ZoneMarker", "startzone", true];
+
+// Ship a mission that starts live, but keep the Zeus modules available to freeze later (initServer.sqf):
+missionNamespace setVariable ["Waldo_SafeStart_AutoStart", false, true];
+```
+
+## See also
+
+* [ENDEX Script & Custom End Screen](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ENDEX-Script-&-Custom-End-Screen) — the matching mission-end freeze
+* [Mission Configuration Reference](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Configuration-Reference) — all `initServer.sqf` fields
+* [Waldos Mission Pack Zeus Modules](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Mission-Pack-Zeus-Modules)

--- a/wiki/Simple-Mass-Attach-Items.md
+++ b/wiki/Simple-Mass-Attach-Items.md
@@ -1,20 +1,39 @@
-_Associated Files: MissionScripts\Logistics\LogiHelpers\massAttachItems.sqf_
+_Associated Files: `MissionScripts\Logistics\LogiHelpers\massAttachItems.sqf`, `Waldo_fnc_MassAttachRelative`_
 
-This script attaches multiple objects to a second object.
+# Simple Mass Attach Items
 
-Setting Up in Eden;
-* Place the vehicle or object you want to attach to all other items.
-* Place a Game Logic down as close as possible to the object. This can be found near the same menu as Modules.
-* Place any objects you wish to attach.
-* If you are using a vehicle as your primary object and any of your objects should be resting on the floor, then raise them about a foot, to allow for the drop of the vehicle's suspension once the game has been initialised.
-* Select all the objects that will be attached, right-click and synchronise them to the Game Logic.
-* In the init of the vehicle, paste the example below, and alter it to suit your needs.
+Attaches a whole group of editor-placed objects to one "parent" object in a single call, keeping each item's **relative position** to the parent. Use it to bolt scenery, cargo, decoration or props onto a vehicle (or any object) so they travel with it — sandbags on a truck, jerry cans on a quad, crates lashed to a boat, and so on.
 
-Parameters:
-* _targetObject - the variable name of the vehicle/object you wish to attach the synchronised objects to.
+Objects are gathered automatically by a synced **Game Logic**, so you never list classnames or offsets by hand: place the props where you want them, sync them, and call the function.
 
-Example call:
+## Parameters
 
-In vehicle init:
+| # | Parameter | Type | Purpose |
+|---|---|---|---|
+| 0 | Target object | Object | Variable name of the object everything is attached **to**. |
 
-`[variableNameOfObjectToAttachOthersTo] call Waldo_fnc_MassAttachRelative;`
+## Setup in Eden
+
+1. Place the **parent** object (vehicle or object) you want everything attached to.
+2. Place a **Game Logic** as close as possible to the parent (found near the Modules menu).
+3. Place every object you want attached, positioned where it should end up.
+4. If the parent is a vehicle and a prop should rest on the ground, raise it ~1 ft to allow for the vehicle's suspension settling once the mission loads.
+5. Select all the props, right-click → **Synchronise** them to the Game Logic.
+6. In the **parent object's init field**, call the function:
+
+```sqf
+[this] call Waldo_fnc_MassAttachRelative;
+```
+
+The script finds the nearest Logic to the parent, reads everything synced to it, and attaches each object at its current relative position.
+
+## Notes
+
+* Attachment uses `BIS_fnc_attachToRelative`, so objects keep the exact offset/rotation you placed them at.
+* For a single **mannable** weapon with get-in actions, use [Weapon Mounting With Custom Name](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Weapon-Mounting-With-Custom-Name) instead — this function is for static/decorative attachments.
+
+## See also
+
+* [Weapon Mounting With Custom Name](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Weapon-Mounting-With-Custom-Name)
+* [Mobile Command Post](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mobile-Command-Post-With-Integrated-Logistics-System) — also uses the synced-Logic pattern for deployable objects
+* [Construction Objects](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Construction-Objects)

--- a/wiki/Tasks-And-Objectives.md
+++ b/wiki/Tasks-And-Objectives.md
@@ -1,0 +1,65 @@
+_Associated Files: `MissionScripts\MissionFlowAndUi\createObjective.sqf`, `setObjectiveState.sqf`, `Waldo_fnc_CreateObjective`, `Waldo_fnc_SetObjectiveState`_
+
+# Tasks / Objectives
+
+A thin, JIP-safe wrapper over Arma's BIS task framework for mission makers who like to drive objectives from **SQF or triggers** rather than the Eden / Zeus task modules (those remain the GUI option). It creates assigned tasks, optionally drops a persistent map marker at the destination, and tidies the marker away when the task resolves.
+
+Both helpers are **server-authoritative** — calling them on a client forwards to the server automatically, so joining players always see the correct task state.
+
+As a bonus, every objective created or resolved through these helpers is recorded in the **After-Action Report** objective ledger, so the [ENDEX](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ENDEX-Script-&-Custom-End-Screen) debrief can show an objective summary with no extra work.
+
+## Creating an objective
+
+```sqf
+["secure_lz", west, "Secure the LZ", "Clear and hold the landing zone.", getMarkerPos "lz1"]
+    call Waldo_fnc_CreateObjective;
+```
+
+`Waldo_fnc_CreateObjective` parameters:
+
+| # | Parameter | Type | Default | Purpose |
+|---|---|---|---|---|
+| 0 | Task ID | String | — (required) | Unique id, used to update the task later. |
+| 1 | Owner | Side / Group / Object / Array | `west` | Who receives the task. |
+| 2 | Title | String | `"New Task"` | Short task title (also used as the marker label). |
+| 3 | Description | String | `""` | Longer task description. |
+| 4 | Destination | Array / Object / String | `[]` | Map position or object for the task waypoint (`[]` = none). |
+| 5 | State | String | `"ASSIGNED"` | Initial state: `CREATED`, `ASSIGNED`, `SUCCEEDED`, etc. |
+| 6 | Create marker | Bool | `true` | Drop a persistent `mil_objective` map marker at the destination. |
+| 7 | Task type | String | `""` | Task icon type (`""` = default icon). |
+
+## Resolving an objective
+
+```sqf
+["secure_lz", "SUCCEEDED"] call Waldo_fnc_SetObjectiveState;
+```
+
+`Waldo_fnc_SetObjectiveState` parameters:
+
+| # | Parameter | Type | Default | Purpose |
+|---|---|---|---|---|
+| 0 | Task ID | String | — (required) | The id you passed to `Waldo_fnc_CreateObjective`. |
+| 1 | State | String | `"SUCCEEDED"` | New state: `SUCCEEDED` / `FAILED` / `CANCELED` / `ASSIGNED` / `CREATED`. |
+
+When the state becomes `SUCCEEDED`, `FAILED` or `CANCELED`, the helper-created map marker is removed automatically.
+
+## Example
+
+```sqf
+// In a trigger / script — create the task when the mission starts:
+["destroy_radar", east, "Destroy the Radar", "Knock out the coastal radar site.", getMarkerPos "radar1"]
+    call Waldo_fnc_CreateObjective;
+
+// Later, in the radar's "killed" event or another trigger:
+["destroy_radar", "SUCCEEDED"] call Waldo_fnc_SetObjectiveState;
+```
+
+## Notes
+
+* The map marker is named `Waldo_obj_<taskId>` internally — it is created only if a destination position is given and **Create marker** is left on.
+* These helpers are a convenience layer, not a replacement: for click-and-drag objectives use the Eden **Create Task** modules or the Zeus task tools.
+
+## See also
+
+* [ENDEX Script & Custom End Screen](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ENDEX-Script-&-Custom-End-Screen) — the After-Action Report reads the objective ledger these helpers maintain
+* [Mission UI Text Overlays](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-UI-Text-Overlays) — on-screen text to accompany objectives

--- a/wiki/Teleportation-&-Move-Into-Cargo-Interactions.md
+++ b/wiki/Teleportation-&-Move-Into-Cargo-Interactions.md
@@ -1,37 +1,64 @@
-_Associated Files:_
-* _MissionScripts\Paradrop\moveInCargoPlane.sqf_
-* _MissionScripts\Logistics\LogiHelpers\teleport.sqf_
+_Associated Files: `MissionScripts\Logistics\LogiHelpers\teleport.sqf` (`Waldo_fnc_Teleport`), `MissionScripts\Paradrop\moveInCargoPlane.sqf` (`Waldo_fnc_MoveInCargoPlane`)_
 
-Both of these scripts perform teleportation and can be applied to any object. They have been grouped here for convenience.
+# Teleportation & Move-Into-Cargo Interactions
 
-## Teleport Object
-This teleports a target to a given marker or any other kind of object.
+Two small "get me there" helpers, grouped here for convenience. Both add a scroll-wheel **addAction** to an object:
 
-Parameters:
-* 0: Object <OBJECT>
-* 1: Label text <STRING>
-* 2: Destination <MARKER/OBJECT/LOCATION/GROUP/TASK>
+* **Teleport** — move whoever uses the action to a marker, object, location, group or task.
+* **Move-Into-Cargo** — board an aircraft that is already airborne, so jumpers don't have to wait through a long taxi/climb.
 
+---
 
-Examples:
-* `[this,"Teleport - Airfield", Airstrip] call Waldo_fnc_Teleport`  <- Arma 3 Map Location (Predefined)
-* `[this,"Teleport - Base", MyBase] call Waldo_fnc_Teleport ` <- Object
-* `[this,"Teleport - Bart", "FOB_Bart"] call Waldo_fnc_Teleport` <- Arma 3 Map Location (Predefined)
-* `[this,"Teleport - Base", "respawn_west"] call Waldo_fnc_Teleport` <- Marker variable name
+## Teleport Object — `Waldo_fnc_Teleport`
 
-Please note that this script requires the destination to have a variable name to reference.
+Adds a green **"Teleport"** (or custom-labelled) action to an object that moves the user to a destination. The destination can be almost anything with a position; for markers, locations and tasks the Z height is treated as ground level (0).
 
-## Move-In Cargo Object
+### Parameters
 
-This function adds a "move-in-cargo" teleporter to an object, which allows a player to use an addaction to board an aircraft already in the air. Helpful in shortening drop times.
+| # | Parameter | Type | Default | Purpose |
+|---|---|---|---|---|
+| 0 | Object | Object | — | The object the action is added to (often `this`). |
+| 1 | Label | String | `"Teleport"` | Text shown in the scroll-wheel action. |
+| 2 | Destination | Marker / Object / Location / Group / Task | the object itself | Where the user is teleported to. |
 
-Arguments:
-* 0: Teleporter Object
-* 1: Aircraft variable Name To Teleport Into
-* 2: Custom String Name For the Plane (Optional)
+The destination must have a **variable name** (or be a named marker/location) so it can be referenced.
 
-Example:
-* `[this, aircraft] call Waldo_fnc_MoveInCargoPlane;`
-* `[this, aircraft, "ARGUS 1-4"] call Waldo_fnc_MoveInCargoPlane;`
+### Examples
 
-Please note that this script requires the destination to have a variable name to reference.
+```sqf
+[this, "Teleport - Airfield", Airstrip]      call Waldo_fnc_Teleport;  // Arma map Location object
+[this, "Teleport - Base", MyBase]            call Waldo_fnc_Teleport;  // a placed object
+[this, "Teleport - Bart", "FOB_Bart"]        call Waldo_fnc_Teleport;  // predefined map location name
+[this, "Teleport - Base", "respawn_west"]    call Waldo_fnc_Teleport;  // marker variable name
+```
+
+---
+
+## Move-Into-Cargo Object — `Waldo_fnc_MoveInCargoPlane`
+
+Adds a **"Board Into _X_"** action to an object that moves the user straight into the cargo of a named aircraft — even one already in the air. Useful for cutting paradrop wait times: spawn/fly the aircraft, and let jumpers board it from the ground via this teleporter.
+
+### Parameters
+
+| # | Parameter | Type | Default | Purpose |
+|---|---|---|---|---|
+| 0 | Teleporter | Object | — | The object the action is added to (often `this`). |
+| 1 | Aircraft | Object | — | Variable name of the aircraft to board. |
+| 2 | Custom name | String | `"Plane"` | Text shown in the **"Board Into _X_"** action. |
+
+The aircraft must have a **variable name** to be referenced.
+
+### Examples
+
+```sqf
+[this, aircraft] call Waldo_fnc_MoveInCargoPlane;               // "Board Into Plane"
+[this, aircraft, "ARGUS 1-4"] call Waldo_fnc_MoveInCargoPlane;  // "Board Into ARGUS 1-4"
+```
+
+---
+
+## See also
+
+* [Vehicle Actions & Paradrop](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Vehicle-Actions-&-Paradrop) — the HALO / static-line jump system you'd board the aircraft for
+* [Map Location Tools](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Map-Location-Tools) — create named map locations to teleport to
+* [Mobile Command Post](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mobile-Command-Post-With-Integrated-Logistics-System)

--- a/wiki/Third-Party-Scripts-Headless-Client-And-Player-Markers.md
+++ b/wiki/Third-Party-Scripts-Headless-Client-And-Player-Markers.md
@@ -1,0 +1,83 @@
+_Associated Files: `MissionScripts\ThirdPartyScripts\ThirdPartyScriptInit.sqf`, `WerthlesHeadless.sqf` (Werthles' Headless Kit), `player_markers.sqf` (aeroson)_
+
+# Third-Party Scripts: Headless Client & Player Markers
+
+WMP bundles two well-known community scripts for mission makers who want them, kept separate from the pack's own systems and **disabled by default**. They are loaded through a single tidy entry point so the main `init.sqf` stays clean.
+
+> **Attribution:** these are third-party scripts included unmodified in spirit — the **Headless Kit is by Werthles** (v2.3) and **player markers are by aeroson** (v2.7.1, "Dynamic Player Markers"). WMP only provides the wiring to call them. Please credit the original authors.
+
+## Enabling them
+
+They are off by default. In `init.sqf`, uncomment the loader line:
+
+```sqf
+// Remove the // to enable headless client and/or player markers
+[] execVM "MissionScripts\ThirdPartyScripts\ThirdPartyScriptInit.sqf";
+```
+
+`ThirdPartyScriptInit.sqf` is a "hollow" launcher: inside it, each script's own call line is commented out. Open the file and uncomment whichever you want to use. This keeps third-party setup in one place instead of cluttering `init.sqf`.
+
+---
+
+## Player Markers (aeroson)
+
+Draws dynamic map markers for players (and optionally AI), showing driver/pilot, vehicle name and passenger count, with click-to-expand passenger lists. **Best used when ACE map markers are not an option** for your group.
+
+Inside `ThirdPartyScriptInit.sqf`, uncomment and tune the call:
+
+```sqf
+0 = ["players"] execVM "MissionScripts\ThirdPartyScripts\player_markers.sqf";
+```
+
+### Options
+
+| Option | Effect |
+|---|---|
+| `"players"` | Show players. |
+| `"ais"` | Show AI. |
+| `"allsides"` | Show all sides, not just the player's own side. |
+| `"all"` | Enable all of the above. |
+| `"stop"` | Stop the script. |
+
+You can combine options, e.g. `["players", "ais"] execVM "...player_markers.sqf";`. Calling the script again replaces the previous run; `["stop"]` halts it. Markers are created **locally** on each client.
+
+---
+
+## Headless Client (Werthles' Headless Kit)
+
+Offloads AI groups onto one or more **Headless Client** instances to ease server load, splitting AI groups evenly across the available HCs. Runs in **multiplayer only**.
+
+### Requirements
+
+* A **Headless Client** entity in the mission (a virtual HC slot), and a server/host able to connect headless clients.
+
+### Enabling
+
+Inside `ThirdPartyScriptInit.sqf`, uncomment the call (recommended to leave the parameters as shipped):
+
+```sqf
+[true, 30, false, true, 30, 10, true, []] execVM "MissionScripts\ThirdPartyScripts\WerthlesHeadless.sqf";
+```
+
+### Parameters
+
+| # | Default | Meaning |
+|---|---|---|
+| 0 | `true` | Run recurrently (keep redistributing AI over time). |
+| 1 | `30` | Seconds between each redistribution check. |
+| 2 | `false` | Debug available to everyone (`true`) or admin only (`false`). |
+| 3 | `true` | Use the advanced AI-distribution method. |
+| 4 | `30` | Start delay (seconds) before the first run. |
+| 5 | `10` | Pause between each `setGroupOwner` (longer aids syncing). |
+| 6 | `true` | Print a setup report. |
+| 7 | `[]` | Extra "bad name" substrings — groups/units whose name contains one of these are ignored and never transferred. |
+
+Detailed documentation lives in the header of `WerthlesHeadless.sqf` itself. For most missions the defaults above are a sensible starting point.
+
+---
+
+## See also
+
+* [Mission Configuration Reference](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Configuration-Reference) — where the loader line lives in `init.sqf`
+* [Waldos AI Tweak](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-AI-Tweak) — AI skill tuning that works alongside headless offloading
+* [AI Convoy System](https://github.com/AdamWaldie/WaldosMissionPack/wiki/AI-Convoy-System)

--- a/wiki/Vehicle-Ambush-Script-And-Vehicle-Camo.md
+++ b/wiki/Vehicle-Ambush-Script-And-Vehicle-Camo.md
@@ -1,31 +1,51 @@
-_Associated Files: MissionScripts\Logistics\VehicleCamoScript\vehicleCamo.sqf_
+_Associated Files: `MissionScripts\Logistics\VehicleCamoScript\vehicleCamo.sqf`, `Waldo_fnc_VehicleCamoSetup` (script by Val & Waldo)_
 
-A script which allows for the creation of "camo" objects to assist in hiding a vehicle in ambush. The script also accounts for limited dismounted movement around the vehicle in concealment (civ).
+# Vehicle Ambush / Vehicle Camo
 
-If the Player:
-* Is spotted
-* Fires the vehicles weapons
-* Moves more than 40 meters from the vehicle
-* Takes damage (Player or vehicle)
+Lets a crew **conceal a vehicle for an ambush** by deploying a set of "camo" objects (foliage, netting, scenery) over it on demand, via an ACE action. While concealed, the crew may dismount and move a short distance around the vehicle disguised as civilians — until something blows the ambush.
 
-The player is returned to their side (potential game-restricted delay of up to 30 seconds) however the camo objects will remain until the vehicle moves, or the camo is removed by the indicated ace action.
+## How the concealment breaks
 
-Designed for vehicles.
+The player is automatically returned to their own side (with a potential engine-imposed delay of up to ~30 seconds) if they:
 
-### Setting Up in Eden;
-* Place the vehicle or object that you want to have the respawn deployable from, and provide it a variable name
-* Place a Game Logic down as close as possible to the vehicle. This can be found near the same menu as Modules.
-* Place any objects you wish to appear when the camo is deployed.
-* If you are using a vehicle as your primary object and any of your deployable objects should be resting on the floor, then raise them about a foot, to allow for the drop of the vehicle's suspension once the game has initialised.
-* Select all the objects that will be deployable, right-click and synchronise them to the Game Logic.
-* In the init of the vehicle, paste the example below, and alter it to suit the needs you have.
+* Are **spotted** by the enemy
+* **Fire the vehicle's weapons**
+* Move **more than 40 m** from the vehicle
+* Take **damage** (player or vehicle)
 
-### Parameters:
-* _target - Vehicle or Object to deploy camo from.
+The camo objects themselves **remain in place** until the vehicle moves, or the crew removes them with the provided ACE action — so breaking concealment doesn't instantly un-hide the vehicle.
 
-Example:
+## Requirements
 
-`[this] call Waldo_fnc_VehicleCamoSetup;`
+* **ACE3** — the deploy/remove actions use the ACE interaction menu. The function silently exits if ACE is not loaded.
+* Designed for **vehicles**.
 
-Below is an example of a setup camo system in the eden editor. The Nazi Tank is the interaction object:
+## Parameters
+
+| # | Parameter | Type | Purpose |
+|---|---|---|---|
+| 0 | Target | Object | The vehicle (or object) the camo is deployed from. |
+
+## Setup in Eden
+
+1. Place the **vehicle** and give it a variable name.
+2. Place a **Game Logic** as close as possible to it (near the Modules menu).
+3. Place every object you want to appear when the camo is deployed.
+4. If a camo object should rest on the ground, raise it ~1 ft to allow for the vehicle's suspension settling once the mission loads.
+5. Select all the camo objects, right-click → **Synchronise** them to the Game Logic.
+6. In the vehicle's **init field**, call the function:
+
+```sqf
+[this] call Waldo_fnc_VehicleCamoSetup;
+```
+
+The synced objects start hidden and are revealed (and attached) when the crew deploys the camo via the ACE action.
+
+Below is an example of a camo system set up in the Eden editor — the tank is the interaction object:
 ![Camo script example in the editor](https://i.imgur.com/dlyoKsk.png)
+
+## See also
+
+* [Simple Mass Attach Items](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Simple-Mass-Attach-Items) — attach static objects to a vehicle permanently
+* [Construction Objects](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Construction-Objects)
+* [Waldos AI Tweak](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-AI-Tweak) — tune how easily AI spot your ambush

--- a/wiki/Weapon-Mounting-With-Custom-Name.md
+++ b/wiki/Weapon-Mounting-With-Custom-Name.md
@@ -1,14 +1,47 @@
-_Associated Files: MissionScripts\Logistics\LogiHelpers\attachedWeapon.sqf_
+_Associated Files: `MissionScripts\Logistics\LogiHelpers\attachedWeapon.sqf`, `Waldo_fnc_VehicleMountedWeapon`_
 
-This script attaches an object (weapon) to a vehicle object and provides a method to switch into the mounted weapon from the vehicle it is attached to and vice versa.
+# Weapon Mounting With Custom Name
 
-Parameters:
-* _turret - variable name of the turret.
-* _vehicle - variable name of the vehicle you wish to attach the turret to.
-* _customName - set a custom Get in X addaction for the turret, where X is the contents of _customName.
+Attaches a separate weapon/turret object to a vehicle and wires up "Get In" / "Return" actions so a player can hop between the carrier and the mounted weapon without it counting as a normal turret seat. Handy for a static gun bolted to a truck bed, a mortar on a trailer, or any field-expedient mounted weapon.
 
-Example call:
+The action label is customisable, so the scroll-wheel option can read **"Get In M2"**, **"Get In Mortar"** or whatever you like, instead of a generic prompt.
 
-In turret init:
+## What it sets up
 
-`[turretVariableName, VehiclevariableName,"Custom Name For Turret"] call Waldo_fnc_VehicleMountedWeapon;`
+* Attaches the turret to the vehicle at its **relative** position (so it rides along correctly).
+* Adds a **"Get In _name_"** action both on the turret (when stood next to it) and from inside the vehicle.
+* Adds a **"Return To Main Vehicle"** action on the turret to move back into the carrier.
+* On ACE, claims the turret (`ace_common_fnc_claim`) so other mods' interactions don't hijack it, and blocks the stray *Unmount / Turn left / Turn right* engine actions that some mods (e.g. IFA3) inject.
+
+## Parameters
+
+| # | Parameter | Type | Default | Purpose |
+|---|---|---|---|---|
+| 0 | Turret | Object | — | Variable name of the weapon/turret object to mount. |
+| 1 | Vehicle | Object | — | Variable name of the carrier vehicle. |
+| 2 | Custom name | String | `"Turret"` | Text shown in the **"Get In _X_"** action. |
+
+## Setup in Eden
+
+1. Place the **vehicle** and give it a variable name (e.g. `truck1`).
+2. Place the **weapon/turret** object and give it a variable name (e.g. `mountedM2`).
+3. Position the turret roughly where it should ride — it is attached at that relative offset.
+4. In the **turret's init field**, call the function:
+
+```sqf
+[mountedM2, truck1, "M2 Browning"] call Waldo_fnc_VehicleMountedWeapon;
+```
+
+## Example
+
+```sqf
+// A static gun mounted on a technical, labelled "DShK":
+[gunObject, technical1, "DShK"] call Waldo_fnc_VehicleMountedWeapon;
+```
+
+Players see **"Get In DShK"** on both the gun and the truck, and **"Return To Main Vehicle"** while manning it.
+
+## See also
+
+* [Simple Mass Attach Items](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Simple-Mass-Attach-Items) — attach decorative/cargo objects to a vehicle
+* [Vehicle Actions & Paradrop](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Vehicle-Actions-&-Paradrop)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -38,6 +38,7 @@
     * [Waldos AI Tweak](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-AI-Tweak)
     * [AI Convoy System](https://github.com/AdamWaldie/WaldosMissionPack/wiki/AI-Convoy-System)
     * [Map Location Tools](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Map-Location-Tools)
+    * [Headless Client & Player Markers](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Third-Party-Scripts-Headless-Client-And-Player-Markers)
     * **ACRE 2 Radio**
     * [ACRE 2 Long Range Radio](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE-2-Long-Range-Radio-Presetting)
     * [ACRE 2 Short Range Radio](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE-2-Squad-Level-Radios-AN-PRC%E2%80%90343-Automatic-Setup)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -7,7 +7,9 @@
     * **Mission Flow & UI**
     * [Mission Intro Text](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Intro-Or-Title-Text)
     * [Mission UI Text Overlays](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-UI-Text-Overlays)
-    * [ENDEX Script & Custom End Screen](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ENDEX-Script-&-Custom-End-Screen)
+    * [ENDEX & After-Action Report](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ENDEX-Script-&-Custom-End-Screen)
+    * [Safestart](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Safestart)
+    * [Tasks / Objectives](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Tasks-And-Objectives)
     * [Radio Reports & Checklists](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Reports,-Checklists,-Support-Calls-And-Documentation)
     * [Team Colour Setup](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Team-Colour-Setup)
     * **Logistics & Crates**
@@ -42,6 +44,7 @@
     * [ACRE 2 Automated CEOI](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Automated-CEOI-Document)
     * [ACRE 2 Babel Autoconfig](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Babel-Configuration)
     * **Miscellaneous**
+    * [Mission Diagnostics](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Diagnostics)
     * [Cover / Loading Screen Generation](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Cover-Loading-Screen-Generation)
     * [Unit Insignias](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Unit-Insignias)
     * [Mission Maker Resource Scripts](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Maker-Resource-Scripts)


### PR DESCRIPTION
## Why

Several shipped features had working code, in-file headers and `CLAUDE.md` entries, but **no wiki page and no README coverage** — so mission makers couldn't discover them from the documented entry points. Safestart was the most obvious example (called out directly), but the gap also covered Mission Diagnostics, the Tasks/Objectives helpers, and the After-Action Report.

## What changed (documentation only — no code touched)

**New wiki pages**
- `Safestart` — overview, `initServer.sqf` auto-start options, the go-live scripting API (`Waldo_fnc_SafeStart` / `SafeStartTimer`), and the three Zeus modules.
- `Mission-Diagnostics` — what the `[WMP DIAG]` check validates, how to read the RPT output, the enable/disable flag.
- `Tasks-And-Objectives` — `Waldo_fnc_CreateObjective` / `SetObjectiveState` parameter tables and examples.

**Updated pages**
- `ENDEX-Script-&-Custom-End-Screen` — added an **After-Action Report** section (duration, KIA/WIA, vehicle losses, friendly fire, objectives, top fraggers); it was previously unmentioned in the wiki. Also corrected the Associated Files path.
- `_Sidebar` + `Feature-Tutorials` — navigation entries for all four.
- `Mission-Configuration-Reference` — Safestart, Diagnostics and AAR blocks added to the `initServer.sqf` section.
- `README.md` — Pack Features bullets for Tasks/Objectives, Diagnostics and the ENDEX AAR.

All terminology matches the in-file headers and `CLAUDE.md`, per the wiki Coding-Standards documentation standard.

## Validation

`sqf_validator.py` ✅ (551 files, 0 errors) · `config_style_checker.py` ✅ — no SQF/config files were changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRFbxA7CNCriF6XJrmyzbE)_