### PR TITLE
Economy: ZEN-module menu (replaces curator-tree injection) + dedicated-server authority fix; VVD deletion locality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,9 +311,12 @@ Registers "Waldos Mission Modules" in the Zeus module menu: Player Supply Crate,
 
 ### Waldos Economy Systems (Resource / Research / Build / Buy + Ground Command)
 
-A self-contained, **pub-Zeus** RTS-style economy suite. It injects its **own menu — "Waldos
-Economy Systems" — into the Zeus tree** (it does *not* use the ZEN module menu), so it works for
-any curator including player-controlled Zeus, with no editor work required. The four systems:
+A self-contained, **pub-Zeus** RTS-style economy suite. It exposes every action as a **Zeus
+Enhanced custom module** under the **"Waldos Economy Systems"** category (registered by
+`Waldo_fnc_EcoCore_registerZenModules`), so it works for any curator including player-controlled
+Zeus, with no editor work required. **Zeus Enhanced is required for the Zeus authoring menu** —
+without ZEN the suite still runs server-side (income, research, production, request handling) but
+exposes no in-Zeus menu. The four systems:
 
 - **Resource** — define arbitrary resources (name/colour/icon/storage cap), spawn collectable
   resource crates, and create capturable zones that passively generate resources (with deposit
@@ -384,10 +387,14 @@ construction vehicles.
 global world-object/marker creation are gated by `Waldo_fnc_EcoCore_canRunAuthority` /
 `canRunBackgroundAuthority`, which return **`isServer`** — so the server is the single authority and
 the background loops (income, production, research progress, request processing) run exactly once for
-the mission. Client-only work (Zeus menu injection, ACE action setup, dialogs, request *publishing*)
-is gated by `hasInterface`. This makes the suite correct on **dedicated** servers, not just
-SP/listen-host. When editing economy code: mutate shared state only under `canRunAuthority` and
-broadcast it (`setVariable [..., true]`); never gate client-local work on `canRunAuthority`.
+the mission. Client-only work (ZEN module registration, ACE action setup, dialogs, request
+*publishing*) is gated by `hasInterface`. Because ZEN custom-module code runs on the **curator's
+client**, the seven object-creation functions (research center, resource crate, resource zone,
+building, construction vehicle, purchase laptop, drop point) **forward themselves to the server via
+`remoteExec [..., 2]`** when called off the authority, so placement works on a **dedicated** server,
+not just SP/listen-host. When editing economy code: mutate shared state only under `canRunAuthority`
+and broadcast it (`setVariable [..., true]`); never gate client-local work on `canRunAuthority`; and
+route any new world-object creation through the authority the same way.
 
 **Operational notes for makers:**
 - `Waldo_fnc_EcoCore_isActive` returns whether the suite is running (gate dependent scripts on it).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,7 +299,7 @@ Params for `Waldo_fnc_CreateObjective`: `[taskId, owner, title, description, des
 // allowedSides: ["ALL"], ["BLUFOR"], ["OPFOR"], ["INDEP"], ["CIV"]
 ```
 
-This feature is explicitly marked **WIP and not recommended for live missions**. UAV removal is unreliable (~50%) due to an Arma engine limitation around UAV crew/connection lifecycle — it is not a simple scripting bug and has no robust fix. For a stable vehicle-spawning experience use **ACE Garage** instead. If you do use VVD, test thoroughly with your exact mod set first.
+This feature is explicitly marked **WIP and not recommended for live missions**. Vehicle removal routes deletion to the vehicle's owning machine via `Waldo_fnc_VVDPurgeVehicle` — depot vehicles and their (UAV) crew are created with `createVehicle`/`createVehicleCrew` on whichever client pressed spawn, so a client-side `deleteVehicle`/`deleteVehicleCrew` issued from another machine silently no-ops on the remote object; owner-routing fixes that dominant cause of orphaned UAV crew. A UAV with a player actively connected via a terminal remains an engine edge case with no guaranteed teardown. For a fully stable vehicle-spawning experience use **ACE Garage** instead. If you do use VVD, test thoroughly with your exact mod set first.
 
 ### Zeus Enhanced Modules
 

--- a/MissionScripts/EconomySystems/Build/spawnConfiguredBuilding.sqf
+++ b/MissionScripts/EconomySystems/Build/spawnConfiguredBuilding.sqf
@@ -19,7 +19,10 @@
 
         params ["_pos", "_buildName", ["_sideKey", "NONE"], ["_dir", 0]];
 
-        if !([] call Waldo_fnc_EcoCore_canRunAuthority) exitWith {};
+        // Authority-only creation; forward to the server when called on a client (dedicated-safe).
+        if !([] call Waldo_fnc_EcoCore_canRunAuthority) exitWith {
+            _this remoteExec ["Waldo_fnc_EcoBuild_spawnConfiguredBuilding", 2];
+        };
 
         private _catalog = call Waldo_fnc_EcoBuild_getBuildCatalog;
         private _index = _catalog findIf {

--- a/MissionScripts/EconomySystems/Build/spawnConstructionVehicle.sqf
+++ b/MissionScripts/EconomySystems/Build/spawnConstructionVehicle.sqf
@@ -17,7 +17,10 @@
 
         params ["_pos", ["_className", "B_Truck_01_box_F"]];
 
-        if !([] call Waldo_fnc_EcoCore_canRunAuthority) exitWith {};
+        // Authority-only creation; forward to the server when called on a client (dedicated-safe).
+        if !([] call Waldo_fnc_EcoCore_canRunAuthority) exitWith {
+            _this remoteExec ["Waldo_fnc_EcoBuild_spawnConstructionVehicle", 2];
+        };
 
         private _vehicle = createVehicle [_className, _pos, [], 0, "NONE"];
         _vehicle setVehiclePosition [_pos, [], 0, "NONE"];

--- a/MissionScripts/EconomySystems/Buy/createDropPoint.sqf
+++ b/MissionScripts/EconomySystems/Buy/createDropPoint.sqf
@@ -19,7 +19,10 @@
 
         params [["_pos", [0, 0, 0]], ["_typeName", "Ground"], ["_dir", 0], ["_sideKey", "ANY"]];
 
-        if !([] call Waldo_fnc_EcoCore_canRunAuthority) exitWith {};
+        // Authority-only creation; forward to the server when called on a client (dedicated-safe).
+        if !([] call Waldo_fnc_EcoCore_canRunAuthority) exitWith {
+            _this remoteExec ["Waldo_fnc_EcoBuy_createDropPoint", 2];
+        };
 
         private _dropPointId = format ["buy_drop_%1_%2", floor serverTime, floor (random 100000)];
         private _safeType = [_typeName] call Waldo_fnc_EcoBuy_normalizeDropPointType;

--- a/MissionScripts/EconomySystems/Buy/spawnPurchaseLaptop.sqf
+++ b/MissionScripts/EconomySystems/Buy/spawnPurchaseLaptop.sqf
@@ -20,7 +20,11 @@
             ["_dir", 0]
         ];
 
-        if !([] call Waldo_fnc_EcoCore_canRunAuthority) exitWith {objNull};
+        // Authority-only creation; forward to the server when called on a client (dedicated-safe).
+        if !([] call Waldo_fnc_EcoCore_canRunAuthority) exitWith {
+            _this remoteExec ["Waldo_fnc_EcoBuy_spawnPurchaseLaptop", 2];
+            objNull
+        };
 
         private _purchaseTerminal = createVehicle ["Land_Laptop_unfolded_F", _pos, [], 0, "CAN_COLLIDE"];
         _purchaseTerminal setPosATL _pos;

--- a/MissionScripts/EconomySystems/Core/registerZenModules.sqf
+++ b/MissionScripts/EconomySystems/Core/registerZenModules.sqf
@@ -12,8 +12,10 @@
  * exposes no Zeus authoring menu.
  *
  * ZEN passes each module's code [_modulePos (ASL), _attachedObject] on the curator's
- * client. Placement actions convert the drop position to AGL and hand it to the existing
- * spawn / prompt handlers; those spawn functions forward themselves to the server
+ * client. Every module first runs Waldo_fnc_EcoCore_zenModuleGuard so a purged / inactive
+ * economy no-ops instead of acting (ZEN cannot un-register modules mid-mission). Placement
+ * actions convert the drop position via Waldo_fnc_EcoCore_zenPlacementPos and hand it to the
+ * existing spawn / prompt handlers; those spawn functions forward themselves to the server
  * authority, so placement works on dedicated servers. Non-placement actions ignore the
  * position and open their existing dialog / toggle.
  *
@@ -37,103 +39,145 @@
 
     // ---- Resource ----
     [_cat, "Resource - Configure Resources",
-        { [] call Waldo_fnc_EcoResource_promptResourceConfig; },
+        {
+            if !(call Waldo_fnc_EcoCore_zenModuleGuard) exitWith {};
+            [] call Waldo_fnc_EcoResource_promptResourceConfig;
+        },
     _icon] call zen_custom_modules_fnc_register;
 
     [_cat, "Resource - Create Resource Crate",
         {
             params ["_modulePos"];
-            [ASLToAGL _modulePos] call Waldo_fnc_EcoResource_promptResourceCrateValue;
+            if !(call Waldo_fnc_EcoCore_zenModuleGuard) exitWith {};
+            [[_modulePos] call Waldo_fnc_EcoCore_zenPlacementPos] call Waldo_fnc_EcoResource_promptResourceCrateValue;
         },
     _icon] call zen_custom_modules_fnc_register;
 
     [_cat, "Resource - Create Resource Zone",
         {
             params ["_modulePos"];
-            [ASLToAGL _modulePos] call Waldo_fnc_EcoResource_promptResourceZone;
+            if !(call Waldo_fnc_EcoCore_zenModuleGuard) exitWith {};
+            [[_modulePos] call Waldo_fnc_EcoCore_zenPlacementPos] call Waldo_fnc_EcoResource_promptResourceZone;
         },
     _icon] call zen_custom_modules_fnc_register;
 
     [_cat, "Resource - Set Resources",
-        { [] call Waldo_fnc_EcoResource_promptResourceSettings; },
+        {
+            if !(call Waldo_fnc_EcoCore_zenModuleGuard) exitWith {};
+            [] call Waldo_fnc_EcoResource_promptResourceSettings;
+        },
     _icon] call zen_custom_modules_fnc_register;
 
     [_cat, "Resource - Toggle Resource Visibility",
-        { [name player] call Waldo_fnc_EcoResource_toggleResourceMarkerVisibility; },
+        {
+            if !(call Waldo_fnc_EcoCore_zenModuleGuard) exitWith {};
+            [name player] call Waldo_fnc_EcoResource_toggleResourceMarkerVisibility;
+        },
     _icon] call zen_custom_modules_fnc_register;
 
     // ---- Research ----
     [_cat, "Research - Configure Research",
-        { [] call Waldo_fnc_EcoResearch_promptResearchConfig; },
+        {
+            if !(call Waldo_fnc_EcoCore_zenModuleGuard) exitWith {};
+            [] call Waldo_fnc_EcoResearch_promptResearchConfig;
+        },
     _icon] call zen_custom_modules_fnc_register;
 
     [_cat, "Research - Create Research Center",
         {
             params ["_modulePos"];
-            [ASLToAGL _modulePos] call Waldo_fnc_EcoResearch_spawnResearchCenter;
+            if !(call Waldo_fnc_EcoCore_zenModuleGuard) exitWith {};
+            [[_modulePos] call Waldo_fnc_EcoCore_zenPlacementPos] call Waldo_fnc_EcoResearch_spawnResearchCenter;
         },
     _icon] call zen_custom_modules_fnc_register;
 
     // ---- Construction (Build) ----
     [_cat, "Construction - Configure Buildables",
-        { [] call Waldo_fnc_EcoBuild_promptBuildConfig; },
+        {
+            if !(call Waldo_fnc_EcoCore_zenModuleGuard) exitWith {};
+            [] call Waldo_fnc_EcoBuild_promptBuildConfig;
+        },
     _icon] call zen_custom_modules_fnc_register;
 
     [_cat, "Construction - Spawn Building",
         {
             params ["_modulePos"];
-            [ASLToAGL _modulePos] call Waldo_fnc_EcoBuild_promptSpawnBuilding;
+            if !(call Waldo_fnc_EcoCore_zenModuleGuard) exitWith {};
+            [[_modulePos] call Waldo_fnc_EcoCore_zenPlacementPos] call Waldo_fnc_EcoBuild_promptSpawnBuilding;
         },
     _icon] call zen_custom_modules_fnc_register;
 
     [_cat, "Construction - Spawn Construction Vehicle",
         {
             params ["_modulePos"];
-            [ASLToAGL _modulePos, "B_Truck_01_box_F"] call Waldo_fnc_EcoBuild_spawnConstructionVehicle;
+            if !(call Waldo_fnc_EcoCore_zenModuleGuard) exitWith {};
+            [[_modulePos] call Waldo_fnc_EcoCore_zenPlacementPos, "B_Truck_01_box_F"] call Waldo_fnc_EcoBuild_spawnConstructionVehicle;
         },
     _icon] call zen_custom_modules_fnc_register;
 
     // ---- Buy ----
     [_cat, "Buy - Configure Purchases",
-        { [] call Waldo_fnc_EcoBuy_promptPurchaseConfig; },
+        {
+            if !(call Waldo_fnc_EcoCore_zenModuleGuard) exitWith {};
+            [] call Waldo_fnc_EcoBuy_promptPurchaseConfig;
+        },
     _icon] call zen_custom_modules_fnc_register;
 
     [_cat, "Buy - Set Drop Point",
         {
             params ["_modulePos"];
-            [ASLToAGL _modulePos, getDir curatorCamera] call Waldo_fnc_EcoBuy_promptDropPoint;
+            if !(call Waldo_fnc_EcoCore_zenModuleGuard) exitWith {};
+            [[_modulePos] call Waldo_fnc_EcoCore_zenPlacementPos, getDir curatorCamera] call Waldo_fnc_EcoBuy_promptDropPoint;
         },
     _icon] call zen_custom_modules_fnc_register;
 
     [_cat, "Buy - Spawn Laptop",
         {
             params ["_modulePos"];
-            [ASLToAGL _modulePos, getDir curatorCamera] call Waldo_fnc_EcoBuy_spawnPurchaseLaptop;
+            if !(call Waldo_fnc_EcoCore_zenModuleGuard) exitWith {};
+            [[_modulePos] call Waldo_fnc_EcoCore_zenPlacementPos, getDir curatorCamera] call Waldo_fnc_EcoBuy_spawnPurchaseLaptop;
         },
     _icon] call zen_custom_modules_fnc_register;
 
     // ---- Ground Command ----
     [_cat, "Ground Command",
-        { [] call Waldo_fnc_EcoCommand_promptGroundCommand; },
+        {
+            if !(call Waldo_fnc_EcoCore_zenModuleGuard) exitWith {};
+            [] call Waldo_fnc_EcoCommand_promptGroundCommand;
+        },
     _icon] call zen_custom_modules_fnc_register;
 
     // ---- Core / Save ----
-    [_cat, "Commitment Mode",
-        { [] call Waldo_fnc_EcoCore_toggleCommitmentMode; },
+    [_cat, "Toggle Commitment Mode",
+        {
+            if !(call Waldo_fnc_EcoCore_zenModuleGuard) exitWith {};
+            [] call Waldo_fnc_EcoCore_toggleCommitmentMode;
+        },
     _icon] call zen_custom_modules_fnc_register;
 
-    [_cat, "Testing Notice",
-        { [] call Waldo_fnc_EcoCore_toggleTestingNotice; },
+    [_cat, "Toggle Testing Notice",
+        {
+            if !(call Waldo_fnc_EcoCore_zenModuleGuard) exitWith {};
+            [] call Waldo_fnc_EcoCore_toggleTestingNotice;
+        },
     _icon] call zen_custom_modules_fnc_register;
 
     [_cat, "Import / Export",
-        { [] call Waldo_fnc_EcoCore_promptUnifiedSaveSystem; },
+        {
+            if !(call Waldo_fnc_EcoCore_zenModuleGuard) exitWith {};
+            [] call Waldo_fnc_EcoCore_promptUnifiedSaveSystem;
+        },
     _icon] call zen_custom_modules_fnc_register;
 
     [_cat, "Preset Configurations",
-        { [] call Waldo_fnc_EcoCore_promptUnifiedPresetSystem; },
+        {
+            if !(call Waldo_fnc_EcoCore_zenModuleGuard) exitWith {};
+            [] call Waldo_fnc_EcoCore_promptUnifiedPresetSystem;
+        },
     _icon] call zen_custom_modules_fnc_register;
 
+    // Purge intentionally omits the active-guard: it must remain usable to confirm/clear a
+    // suite that is being torn down.
     [_cat, "Purge System",
         { [] call Waldo_fnc_EcoCore_promptUnifiedPurgeSystem; },
     _icon] call zen_custom_modules_fnc_register;

--- a/MissionScripts/EconomySystems/Core/registerZenModules.sqf
+++ b/MissionScripts/EconomySystems/Core/registerZenModules.sqf
@@ -36,18 +36,18 @@
     private _icon = "\a3\modules_f\data\portraitmodule_ca.paa";
 
     // ---- Resource ----
-    [_cat, "Resource - Configure",
+    [_cat, "Resource - Configure Resources",
         { [] call Waldo_fnc_EcoResource_promptResourceConfig; },
     _icon] call zen_custom_modules_fnc_register;
 
-    [_cat, "Resource - Create Crate",
+    [_cat, "Resource - Create Resource Crate",
         {
             params ["_modulePos"];
             [ASLToAGL _modulePos] call Waldo_fnc_EcoResource_promptResourceCrateValue;
         },
     _icon] call zen_custom_modules_fnc_register;
 
-    [_cat, "Resource - Create Zone",
+    [_cat, "Resource - Create Resource Zone",
         {
             params ["_modulePos"];
             [ASLToAGL _modulePos] call Waldo_fnc_EcoResource_promptResourceZone;
@@ -58,16 +58,16 @@
         { [] call Waldo_fnc_EcoResource_promptResourceSettings; },
     _icon] call zen_custom_modules_fnc_register;
 
-    [_cat, "Resource - Toggle Visibility",
+    [_cat, "Resource - Toggle Resource Visibility",
         { [name player] call Waldo_fnc_EcoResource_toggleResourceMarkerVisibility; },
     _icon] call zen_custom_modules_fnc_register;
 
     // ---- Research ----
-    [_cat, "Research - Configure",
+    [_cat, "Research - Configure Research",
         { [] call Waldo_fnc_EcoResearch_promptResearchConfig; },
     _icon] call zen_custom_modules_fnc_register;
 
-    [_cat, "Research - Create Center",
+    [_cat, "Research - Create Research Center",
         {
             params ["_modulePos"];
             [ASLToAGL _modulePos] call Waldo_fnc_EcoResearch_spawnResearchCenter;
@@ -86,7 +86,7 @@
         },
     _icon] call zen_custom_modules_fnc_register;
 
-    [_cat, "Construction - Spawn Vehicle",
+    [_cat, "Construction - Spawn Construction Vehicle",
         {
             params ["_modulePos"];
             [ASLToAGL _modulePos, "B_Truck_01_box_F"] call Waldo_fnc_EcoBuild_spawnConstructionVehicle;

--- a/MissionScripts/EconomySystems/Core/registerZenModules.sqf
+++ b/MissionScripts/EconomySystems/Core/registerZenModules.sqf
@@ -1,0 +1,139 @@
+/*
+ * Author: Waldo
+ * Register zen modules.
+ *
+ * Part of the Waldos Economy Systems suite (shared core system).
+ *
+ * Registers every Economy Systems action as a Zeus Enhanced custom module under the
+ * "Waldos Economy Systems" category. This is the supported replacement for the previous
+ * raw curator-tree injection: ZEN owns the module list, so there is no per-client polling
+ * loop and no dependency on undocumented curator display IDCs. Requires Zeus Enhanced -
+ * without it the suite still runs server-side (income, research, production, requests) but
+ * exposes no Zeus authoring menu.
+ *
+ * ZEN passes each module's code [_modulePos (ASL), _attachedObject] on the curator's
+ * client. Placement actions convert the drop position to AGL and hand it to the existing
+ * spawn / prompt handlers; those spawn functions forward themselves to the server
+ * authority, so placement works on dedicated servers. Non-placement actions ignore the
+ * position and open their existing dialog / toggle.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [] call Waldo_fnc_EcoCore_registerZenModules;
+ */
+
+    if (!hasInterface) exitWith {};
+    if !(isClass (configFile >> "CfgPatches" >> "zen_main")) exitWith {};
+    if (!isNil "WaldoEcoCore_ZenModulesRegistered") exitWith {};
+    WaldoEcoCore_ZenModulesRegistered = true;
+
+    private _cat = "Waldos Economy Systems";
+    private _icon = "\a3\modules_f\data\portraitmodule_ca.paa";
+
+    // ---- Resource ----
+    [_cat, "Resource - Configure",
+        { [] call Waldo_fnc_EcoResource_promptResourceConfig; },
+    _icon] call zen_custom_modules_fnc_register;
+
+    [_cat, "Resource - Create Crate",
+        {
+            params ["_modulePos"];
+            [ASLToAGL _modulePos] call Waldo_fnc_EcoResource_promptResourceCrateValue;
+        },
+    _icon] call zen_custom_modules_fnc_register;
+
+    [_cat, "Resource - Create Zone",
+        {
+            params ["_modulePos"];
+            [ASLToAGL _modulePos] call Waldo_fnc_EcoResource_promptResourceZone;
+        },
+    _icon] call zen_custom_modules_fnc_register;
+
+    [_cat, "Resource - Set Resources",
+        { [] call Waldo_fnc_EcoResource_promptResourceSettings; },
+    _icon] call zen_custom_modules_fnc_register;
+
+    [_cat, "Resource - Toggle Visibility",
+        { [name player] call Waldo_fnc_EcoResource_toggleResourceMarkerVisibility; },
+    _icon] call zen_custom_modules_fnc_register;
+
+    // ---- Research ----
+    [_cat, "Research - Configure",
+        { [] call Waldo_fnc_EcoResearch_promptResearchConfig; },
+    _icon] call zen_custom_modules_fnc_register;
+
+    [_cat, "Research - Create Center",
+        {
+            params ["_modulePos"];
+            [ASLToAGL _modulePos] call Waldo_fnc_EcoResearch_spawnResearchCenter;
+        },
+    _icon] call zen_custom_modules_fnc_register;
+
+    // ---- Construction (Build) ----
+    [_cat, "Construction - Configure Buildables",
+        { [] call Waldo_fnc_EcoBuild_promptBuildConfig; },
+    _icon] call zen_custom_modules_fnc_register;
+
+    [_cat, "Construction - Spawn Building",
+        {
+            params ["_modulePos"];
+            [ASLToAGL _modulePos] call Waldo_fnc_EcoBuild_promptSpawnBuilding;
+        },
+    _icon] call zen_custom_modules_fnc_register;
+
+    [_cat, "Construction - Spawn Vehicle",
+        {
+            params ["_modulePos"];
+            [ASLToAGL _modulePos, "B_Truck_01_box_F"] call Waldo_fnc_EcoBuild_spawnConstructionVehicle;
+        },
+    _icon] call zen_custom_modules_fnc_register;
+
+    // ---- Buy ----
+    [_cat, "Buy - Configure Purchases",
+        { [] call Waldo_fnc_EcoBuy_promptPurchaseConfig; },
+    _icon] call zen_custom_modules_fnc_register;
+
+    [_cat, "Buy - Set Drop Point",
+        {
+            params ["_modulePos"];
+            [ASLToAGL _modulePos, getDir curatorCamera] call Waldo_fnc_EcoBuy_promptDropPoint;
+        },
+    _icon] call zen_custom_modules_fnc_register;
+
+    [_cat, "Buy - Spawn Laptop",
+        {
+            params ["_modulePos"];
+            [ASLToAGL _modulePos, getDir curatorCamera] call Waldo_fnc_EcoBuy_spawnPurchaseLaptop;
+        },
+    _icon] call zen_custom_modules_fnc_register;
+
+    // ---- Ground Command ----
+    [_cat, "Ground Command",
+        { [] call Waldo_fnc_EcoCommand_promptGroundCommand; },
+    _icon] call zen_custom_modules_fnc_register;
+
+    // ---- Core / Save ----
+    [_cat, "Commitment Mode",
+        { [] call Waldo_fnc_EcoCore_toggleCommitmentMode; },
+    _icon] call zen_custom_modules_fnc_register;
+
+    [_cat, "Testing Notice",
+        { [] call Waldo_fnc_EcoCore_toggleTestingNotice; },
+    _icon] call zen_custom_modules_fnc_register;
+
+    [_cat, "Import / Export",
+        { [] call Waldo_fnc_EcoCore_promptUnifiedSaveSystem; },
+    _icon] call zen_custom_modules_fnc_register;
+
+    [_cat, "Preset Configurations",
+        { [] call Waldo_fnc_EcoCore_promptUnifiedPresetSystem; },
+    _icon] call zen_custom_modules_fnc_register;
+
+    [_cat, "Purge System",
+        { [] call Waldo_fnc_EcoCore_promptUnifiedPurgeSystem; },
+    _icon] call zen_custom_modules_fnc_register;

--- a/MissionScripts/EconomySystems/Core/registerZeusMenuInjector.sqf
+++ b/MissionScripts/EconomySystems/Core/registerZeusMenuInjector.sqf
@@ -1,0 +1,33 @@
+/*
+ * Author: Waldo
+ * Register zeus menu injector.
+ *
+ * Part of the Waldos Economy Systems suite (shared core system).
+ *
+ * Registers a per-client code block that injects one subsystem's menu into the Zeus
+ * curator tree. Every active subsystem registers its own injector here instead of
+ * spawning a private Zeus-open polling loop; a single shared detector loop
+ * (Waldo_fnc_EcoCore_startZeusMenuHook) then runs every registered injector whenever the
+ * curator display opens. Only subsystems that actually initialise register, so an
+ * inactive subsystem contributes neither an injector nor a loop.
+ *
+ * Arguments:
+ * 0: _injector <CODE> - injector run (spawned) on each Zeus-display open (optional, default: {})
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [{ ... inject my menu ... }] call Waldo_fnc_EcoCore_registerZeusMenuInjector;
+ */
+
+    params [["_injector", {}]];
+
+    if (!hasInterface) exitWith {};
+    if (!(_injector isEqualType {})) exitWith {};
+
+    private _list = missionNamespace getVariable ["WaldoEcoCore_ZeusMenuInjectors", []];
+    _list pushBack _injector;
+    missionNamespace setVariable ["WaldoEcoCore_ZeusMenuInjectors", _list];
+
+    [] call Waldo_fnc_EcoCore_startZeusMenuHook;

--- a/MissionScripts/EconomySystems/Core/startZeusMenuHook.sqf
+++ b/MissionScripts/EconomySystems/Core/startZeusMenuHook.sqf
@@ -1,0 +1,54 @@
+/*
+ * Author: Waldo
+ * Start zeus menu hook.
+ *
+ * Part of the Waldos Economy Systems suite (shared core system).
+ *
+ * Runs the single shared client-side loop that detects the Zeus curator display opening
+ * and, on each open transition, spawns every injector registered via
+ * Waldo_fnc_EcoCore_registerZeusMenuInjector. This replaces the previous design where
+ * each subsystem (Resource / Research / Build / Buy / Core-Save) ran its own identical
+ * Zeus-open polling loop - collapsing up to five per-client mission-long loops into one.
+ * Idempotent: the loop starts at most once per client.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [] call Waldo_fnc_EcoCore_startZeusMenuHook;
+ */
+
+    if (!hasInterface) exitWith {};
+    if (!isNil "WaldoEcoCore_ZeusMenuHookStarted") exitWith {};
+    WaldoEcoCore_ZeusMenuHookStarted = true;
+
+    [] spawn {
+        private _wasOpen = false;
+
+        while {[] call Waldo_fnc_EcoCore_isModuleActive} do {
+            private _disp = call Waldo_fnc_EcoCore_getZeusDisplay;
+            private _isOpen = !isNull _disp;
+
+            if (_isOpen && !_wasOpen) then {
+                _wasOpen = true;
+
+                // Each injector re-fetches the display, settles, and guards against
+                // double-injection via its own <system>_MenuInjected display variable,
+                // so spawning them per open transition mirrors the old per-loop behaviour.
+                {
+                    [] spawn _x;
+                } forEach (missionNamespace getVariable ["WaldoEcoCore_ZeusMenuInjectors", []]);
+            };
+
+            if (!_isOpen && _wasOpen) then {
+                _wasOpen = false;
+            };
+
+            uiSleep 0.5; // poll back-off (perf): detect Zeus open within 0.5s
+        };
+
+        WaldoEcoCore_ZeusMenuHookStarted = nil;
+    };

--- a/MissionScripts/EconomySystems/Core/startZeusMenuHook.sqf
+++ b/MissionScripts/EconomySystems/Core/startZeusMenuHook.sqf
@@ -4,12 +4,11 @@
  *
  * Part of the Waldos Economy Systems suite (shared core system).
  *
- * Runs the single shared client-side loop that detects the Zeus curator display opening
- * and, on each open transition, spawns every injector registered via
- * Waldo_fnc_EcoCore_registerZeusMenuInjector. This replaces the previous design where
- * each subsystem (Resource / Research / Build / Buy / Core-Save) ran its own identical
- * Zeus-open polling loop - collapsing up to five per-client mission-long loops into one.
- * Idempotent: the loop starts at most once per client.
+ * DEPRECATED / DISABLED. The Economy Systems Zeus menu is now provided by Zeus Enhanced
+ * custom modules (Waldo_fnc_EcoCore_registerZenModules), not by raw curator-tree injection.
+ * This function is retained only so any legacy injector registration is inert - it no longer
+ * starts the curator-display polling loop, so no tree menu is injected. Slated for removal
+ * along with the rest of the injection helpers.
  *
  * Arguments:
  * None
@@ -21,34 +20,4 @@
  * [] call Waldo_fnc_EcoCore_startZeusMenuHook;
  */
 
-    if (!hasInterface) exitWith {};
-    if (!isNil "WaldoEcoCore_ZeusMenuHookStarted") exitWith {};
-    WaldoEcoCore_ZeusMenuHookStarted = true;
-
-    [] spawn {
-        private _wasOpen = false;
-
-        while {[] call Waldo_fnc_EcoCore_isModuleActive} do {
-            private _disp = call Waldo_fnc_EcoCore_getZeusDisplay;
-            private _isOpen = !isNull _disp;
-
-            if (_isOpen && !_wasOpen) then {
-                _wasOpen = true;
-
-                // Each injector re-fetches the display, settles, and guards against
-                // double-injection via its own <system>_MenuInjected display variable,
-                // so spawning them per open transition mirrors the old per-loop behaviour.
-                {
-                    [] spawn _x;
-                } forEach (missionNamespace getVariable ["WaldoEcoCore_ZeusMenuInjectors", []]);
-            };
-
-            if (!_isOpen && _wasOpen) then {
-                _wasOpen = false;
-            };
-
-            uiSleep 0.5; // poll back-off (perf): detect Zeus open within 0.5s
-        };
-
-        WaldoEcoCore_ZeusMenuHookStarted = nil;
-    };
+    // Intentionally a no-op: menu injection has moved to ZEN custom modules.

--- a/MissionScripts/EconomySystems/Core/zenModuleGuard.sqf
+++ b/MissionScripts/EconomySystems/Core/zenModuleGuard.sqf
@@ -1,0 +1,25 @@
+/*
+ * Author: Waldo
+ * Zen module guard.
+ *
+ * Part of the Waldos Economy Systems suite (shared core system).
+ *
+ * Gate every "Waldos Economy Systems" ZEN custom module runs through. ZEN has no clean way
+ * to un-register custom modules mid-mission, so after a Purge the modules remain in the Zeus
+ * list; this guard makes them no-op (with a notice) instead of acting on a purged / not-yet-
+ * initialised economy. Returns true only when the suite is active.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Active <BOOL> - true if the economy is running and the module may proceed
+ *
+ * Example:
+ * if !(call Waldo_fnc_EcoCore_zenModuleGuard) exitWith {};
+ */
+
+    if ([] call Waldo_fnc_EcoCore_isActive) exitWith { true };
+
+    systemChat "Waldos Economy Systems is not active for this mission (purged or not initialised).";
+    false

--- a/MissionScripts/EconomySystems/Core/zenPlacementPos.sqf
+++ b/MissionScripts/EconomySystems/Core/zenPlacementPos.sqf
@@ -1,0 +1,25 @@
+/*
+ * Author: Waldo
+ * Zen placement pos.
+ *
+ * Part of the Waldos Economy Systems suite (shared core system).
+ *
+ * Converts a ZEN custom-module drop position (which ZEN provides in ASL) into the world
+ * position the Economy spawn / prompt handlers expect. Those handlers were originally fed
+ * screenToWorld coordinates (AGL), so ASL -> AGL keeps parity. This is the single tuning
+ * point for module placement height: if in-engine testing shows objects placed too high /
+ * low (e.g. over water), retune the conversion here rather than in every placement module.
+ *
+ * Arguments:
+ * 0: _moduleAslPos <ARRAY> - the ASL position handed to a ZEN module's code (optional, default: [0,0,0])
+ *
+ * Return Value:
+ * World position <ARRAY> - AGL position for the spawn / prompt handlers
+ *
+ * Example:
+ * private _worldPos = [_modulePos] call Waldo_fnc_EcoCore_zenPlacementPos;
+ */
+
+    params [["_moduleAslPos", [0, 0, 0]]];
+
+    ASLToAGL _moduleAslPos

--- a/MissionScripts/EconomySystems/Research/spawnResearchCenter.sqf
+++ b/MissionScripts/EconomySystems/Research/spawnResearchCenter.sqf
@@ -16,7 +16,12 @@
 
         params [["_pos", [0, 0, 0]]];
 
-        if !([] call Waldo_fnc_EcoCore_canRunAuthority) exitWith {objNull};
+        // Authority-only creation. Called from client-side ZEN module / dialog code too,
+        // so forward to the server when not the authority instead of no-opping (dedicated-safe).
+        if !([] call Waldo_fnc_EcoCore_canRunAuthority) exitWith {
+            _this remoteExec ["Waldo_fnc_EcoResearch_spawnResearchCenter", 2];
+            objNull
+        };
 
         private _researchCenter = createVehicle ["Land_Research_HQ_F", _pos, [], 0, "CAN_COLLIDE"];
         _researchCenter setVehiclePosition [_pos, [], 0, "CAN_COLLIDE"];

--- a/MissionScripts/EconomySystems/Resource/createResourceZone.sqf
+++ b/MissionScripts/EconomySystems/Resource/createResourceZone.sqf
@@ -21,7 +21,10 @@
 
     params ["_pos", "_name", "_radius", "_resourceRows", "_ownerSideKey", "_interval"];
 
-    if !([] call Waldo_fnc_EcoCore_canRunAuthority) exitWith {};
+    // Authority-only creation; forward to the server when called on a client (dedicated-safe).
+    if !([] call Waldo_fnc_EcoCore_canRunAuthority) exitWith {
+        _this remoteExec ["Waldo_fnc_EcoResource_createResourceZone", 2];
+    };
 
     private _zoneId = format ["zone_%1_%2", floor serverTime, floor (random 100000)];
     private _safeName = [_name] call Waldo_fnc_EcoResource_normalizeResourceName;

--- a/MissionScripts/EconomySystems/Resource/spawnResourceCrate.sqf
+++ b/MissionScripts/EconomySystems/Resource/spawnResourceCrate.sqf
@@ -18,7 +18,10 @@
 
     params ["_pos", ["_resourceRows", []], ["_legacyValue", 1]];
 
-    if !([] call Waldo_fnc_EcoCore_canRunAuthority) exitWith {};
+    // Authority-only creation; forward to the server when called on a client (dedicated-safe).
+    if !([] call Waldo_fnc_EcoCore_canRunAuthority) exitWith {
+        _this remoteExec ["Waldo_fnc_EcoResource_spawnResourceCrate", 2];
+    };
 
     private _safeRows = if (_resourceRows isEqualType []) then {
         [_resourceRows] call Waldo_fnc_EcoResource_normalizeResourceRows

--- a/MissionScripts/EconomySystems/Resource/startClientRuntime.sqf
+++ b/MissionScripts/EconomySystems/Resource/startClientRuntime.sqf
@@ -20,18 +20,9 @@
 
     WaldoEcoResource_ZeusHookStarted = true;
 
-    [] spawn {
-        private _wasOpen = false;
+    [{
+                    call Waldo_fnc_EcoResource_startAuthorityLoops;
 
-        while {[] call Waldo_fnc_EcoCore_isModuleActive} do {
-            private _disp = call Waldo_fnc_EcoCore_getZeusDisplay;
-            private _isOpen = !isNull _disp;
-
-            if (_isOpen && !_wasOpen) then {
-                _wasOpen = true;
-                call Waldo_fnc_EcoResource_startAuthorityLoops;
-
-                [] spawn {
                     uiSleep 0.5;
 
                     private _disp = call Waldo_fnc_EcoCore_getZeusDisplay;
@@ -133,16 +124,7 @@
 
                         _tree setVariable ["WaldoEcoResource_SelectEH", _eh];
                     };
-                };
-            };
-
-            if (!_isOpen && _wasOpen) then {
-                _wasOpen = false;
-            };
-
-            uiSleep 0.25;
-        };
-    };
+    }] call Waldo_fnc_EcoCore_registerZeusMenuInjector;
 
     [] spawn {
         private _lastVisible = missionNamespace getVariable ["WaldoEcoResource_ResourceMarkersVisible", true];

--- a/MissionScripts/EconomySystems/economyInit.sqf
+++ b/MissionScripts/EconomySystems/economyInit.sqf
@@ -412,6 +412,10 @@ missionNamespace setVariable ["WaldoEcoCore_PresetLibrary", [
 // Waldo_fnc_EcoCore_applyMakerConfig and the config block in initServer.sqf.
 [] call Waldo_fnc_EcoCore_applyMakerConfig;
 
+// Register the Economy Systems Zeus menu as ZEN custom modules (self-guarded: client +
+// Zeus Enhanced present + once). Replaces the legacy curator-tree injection.
+[] call Waldo_fnc_EcoCore_registerZenModules;
+
 if (hasInterface && {isNil "WaldoEcoCore_SaveZeusHookStarted"}) then {
     WaldoEcoCore_SaveZeusHookStarted = true;
 

--- a/MissionScripts/EconomySystems/economyInit.sqf
+++ b/MissionScripts/EconomySystems/economyInit.sqf
@@ -102,17 +102,7 @@ _fnc_installPromptInputGuard = Waldo_fnc_EcoCore_installPromptInputGuard;
     if (hasInterface && {isNil "WaldoEcoResearch_ZeusHookStarted"}) then {
         WaldoEcoResearch_ZeusHookStarted = true;
 
-        [] spawn {
-            private _wasOpen = false;
-
-            while {[] call Waldo_fnc_EcoCore_isModuleActive} do {
-                private _disp = call Waldo_fnc_EcoCore_getZeusDisplay;
-                private _isOpen = !isNull _disp;
-
-                if (_isOpen && !_wasOpen) then {
-                    _wasOpen = true;
-
-                    [] spawn {
+        [{
                         uiSleep 0.4;
 
                         private _disp = call Waldo_fnc_EcoCore_getZeusDisplay;
@@ -176,16 +166,7 @@ _fnc_installPromptInputGuard = Waldo_fnc_EcoCore_installPromptInputGuard;
 
                             _tree setVariable ["WaldoEcoResearch_SelectEH", _eh];
                         };
-                    };
-                };
-
-                if (!_isOpen && _wasOpen) then {
-                    _wasOpen = false;
-                };
-
-                uiSleep 0.5; // poll back-off (perf): detect Zeus open within 0.5s
-            };
-        };
+        }] call Waldo_fnc_EcoCore_registerZeusMenuInjector;
     };
 };
 
@@ -237,17 +218,7 @@ if (!(missionNamespace getVariable ["WaldoEcoBuild_SystemInitialized", false])) 
     if (hasInterface && {isNil "WaldoEcoBuild_ZeusHookStarted"}) then {
         WaldoEcoBuild_ZeusHookStarted = true;
 
-        [] spawn {
-            private _wasOpen = false;
-
-            while {[] call Waldo_fnc_EcoCore_isModuleActive} do {
-                private _disp = call Waldo_fnc_EcoCore_getZeusDisplay;
-                private _isOpen = !isNull _disp;
-
-                if (_isOpen && !_wasOpen) then {
-                    _wasOpen = true;
-
-                    [] spawn {
+        [{
                         uiSleep 0.3;
 
                         private _disp = call Waldo_fnc_EcoCore_getZeusDisplay;
@@ -319,16 +290,7 @@ if (!(missionNamespace getVariable ["WaldoEcoBuild_SystemInitialized", false])) 
 
                             _tree setVariable ["WaldoEcoBuild_SelectEH", _eh];
                         };
-                    };
-                };
-
-                if (!_isOpen && _wasOpen) then {
-                    _wasOpen = false;
-                };
-
-                uiSleep 0.5; // poll back-off (perf): detect Zeus open within 0.5s
-            };
-        };
+        }] call Waldo_fnc_EcoCore_registerZeusMenuInjector;
     };
 };
 
@@ -350,19 +312,10 @@ if (!(missionNamespace getVariable ["WaldoEcoBuy_SystemInitialized", false])) th
     if (hasInterface && {isNil "WaldoEcoBuy_ZeusHookStarted"}) then {
         WaldoEcoBuy_ZeusHookStarted = true;
 
-        [] spawn {
-            private _wasOpen = false;
+        [{
+                        call Waldo_fnc_EcoBuy_startAuthorityLoops;
+                        [] call Waldo_fnc_EcoBuy_startPurchaseRequestLoop;
 
-            while {[] call Waldo_fnc_EcoCore_isModuleActive} do {
-                private _disp = call Waldo_fnc_EcoCore_getZeusDisplay;
-                private _isOpen = !isNull _disp;
-
-                if (_isOpen && !_wasOpen) then {
-                    _wasOpen = true;
-                    call Waldo_fnc_EcoBuy_startAuthorityLoops;
-                    [] call Waldo_fnc_EcoBuy_startPurchaseRequestLoop;
-
-                    [] spawn {
                         uiSleep 0.2;
 
                         private _disp = call Waldo_fnc_EcoCore_getZeusDisplay;
@@ -432,16 +385,7 @@ if (!(missionNamespace getVariable ["WaldoEcoBuy_SystemInitialized", false])) th
 
                             _tree setVariable ["WaldoEcoBuy_SelectEH", _eh];
                         };
-                    };
-                };
-
-                if (!_isOpen && _wasOpen) then {
-                    _wasOpen = false;
-                };
-
-                uiSleep 0.5; // poll back-off (perf): detect Zeus open within 0.5s
-            };
-        };
+        }] call Waldo_fnc_EcoCore_registerZeusMenuInjector;
     };
 };
 
@@ -471,17 +415,7 @@ missionNamespace setVariable ["WaldoEcoCore_PresetLibrary", [
 if (hasInterface && {isNil "WaldoEcoCore_SaveZeusHookStarted"}) then {
     WaldoEcoCore_SaveZeusHookStarted = true;
 
-    [] spawn {
-        private _wasOpen = false;
-
-        while {[] call Waldo_fnc_EcoCore_isModuleActive} do {
-            private _disp = call Waldo_fnc_EcoCore_getZeusDisplay;
-            private _isOpen = !isNull _disp;
-
-            if (_isOpen && !_wasOpen) then {
-                _wasOpen = true;
-
-                [] spawn {
+    [{
                     uiSleep 0.6;
 
                     private _disp = call Waldo_fnc_EcoCore_getZeusDisplay;
@@ -571,16 +505,7 @@ if (hasInterface && {isNil "WaldoEcoCore_SaveZeusHookStarted"}) then {
 
                         _tree setVariable ["WaldoEcoCore_SaveSelectEH", _eh];
                     };
-                };
-            };
-
-            if (!_isOpen && _wasOpen) then {
-                _wasOpen = false;
-            };
-
-            uiSleep 0.5; // poll back-off (perf): detect Zeus open within 0.5s
-        };
-    };
+    }] call Waldo_fnc_EcoCore_registerZeusMenuInjector;
 };
 
 private _purchaseTerminal = objNull;

--- a/MissionScripts/Logistics/VirtualVehicleDepot/VVDInit.sqf
+++ b/MissionScripts/Logistics/VirtualVehicleDepot/VVDInit.sqf
@@ -3,10 +3,12 @@ Author: Waldo (Various Authors credited for the differing GUI and code snippets 
 
 This script initlises a virtual vehicle depot spawner. At present this script is incomplete and is WIP. It is released as is to allow for my co-operators to see how the script progresses.
 
-WARNING: Not recommended for live missions. UAV removal is unreliable (~50%) due to an Arma
-engine limitation around UAV crew/connection lifecycle, not a simple bug, and has no robust fix.
-For a stable vehicle-spawning experience, use ACE Garage instead. Test thoroughly with your
-exact mod set before relying on this in a real mission.
+WARNING: Not recommended for live missions. Vehicle removal now routes deletion to the
+owning machine (Waldo_fnc_VVDPurgeVehicle), which fixes the main cause of UAV crew being
+left behind - a client-side deleteVehicle/deleteVehicleCrew silently no-ops on a vehicle
+owned by another machine. A UAV with a player actively connected via a terminal remains an
+engine edge case with no guaranteed teardown. For a fully stable vehicle-spawning experience,
+use ACE Garage instead. Test thoroughly with your exact mod set before relying on this.
 
 Arguments:
 _depotSpawnerObject - The item to add the spawner addactions onto
@@ -120,8 +122,9 @@ _depotSpawnerObject addAction[format["<t color='#00ffff'>Delete Vehicles %1</t>"
       _defaultVeh = "DFV" in (_vehVarName splitString "_");
       if (!(_x isKindOf "Man") && !_defaultVeh) then
       {
-        {_nowvehicle deleteVehicleCrew _x} forEach crew _nowvehicle;
-        deleteVehicle _x;
+        // Route crew + hull deletion to the vehicle's owner so UAV AI created on a
+        // remote client is torn down where it is local (see Waldo_fnc_VVDPurgeVehicle).
+        [_nowvehicle] call Waldo_fnc_VVDPurgeVehicle;
       };
     } forEach _vehicles;
 

--- a/MissionScripts/Logistics/VirtualVehicleDepot/VVDPurgeVehicle.sqf
+++ b/MissionScripts/Logistics/VirtualVehicleDepot/VVDPurgeVehicle.sqf
@@ -1,0 +1,41 @@
+/*
+ * Author: Waldo
+ * Removes a depot-spawned vehicle together with its crew, executing the deletion on
+ * the machine that owns the vehicle. Virtual Vehicle Depot vehicles (and their crew,
+ * including engine-managed UAV AI) are created with createVehicle / createVehicleCrew
+ * on whichever client pressed spawn, so they are owned by that client. A deleteVehicle
+ * or deleteVehicleCrew issued from any other machine silently no-ops on the remote
+ * object, which is the dominant cause of UAV crew being left orphaned on removal. By
+ * routing the whole deletion to owner _veh, the crew and hull are torn down where they
+ * are local. (A UAV with a player currently connected via a terminal remains an engine
+ * edge case and is not guaranteed by this helper.)
+ *
+ * Arguments:
+ * 0: _veh <OBJECT> - the vehicle to remove (optional, default: objNull)
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [_vehicle] call Waldo_fnc_VVDPurgeVehicle;
+ */
+
+params [["_veh", objNull]];
+
+if (isNull _veh) exitWith {};
+
+// Hand off to the owning machine when the vehicle is not local here, so the crew and
+// hull deletions below run where the objects (and UAV AI agents) actually live.
+if (!local _veh) exitWith {
+    [_veh] remoteExec ["Waldo_fnc_VVDPurgeVehicle", owner _veh];
+};
+
+// deleteVehicleCrew is the sanctioned removal for AI/UAV crew; delete crew before the hull.
+{ _veh deleteVehicleCrew _x } forEach (crew _veh);
+
+// Strip attached decorations/objects, but never the depot's own game logic.
+{
+    if !("Logic" in (_x call BIS_fnc_objectType)) then { deleteVehicle _x };
+} forEach (attachedObjects _veh);
+
+deleteVehicle _veh;

--- a/MissionScripts/WaldosFunctions.sqf
+++ b/MissionScripts/WaldosFunctions.sqf
@@ -328,6 +328,9 @@ class CfgFunctions
             class EcoCore_applyMakerConfig {
                 file = "MissionScripts\EconomySystems\Core\applyMakerConfig.sqf";
             };
+            class EcoCore_registerZenModules {
+                file = "MissionScripts\EconomySystems\Core\registerZenModules.sqf";
+            };
             class EcoCore_registerZeusMenuInjector {
                 file = "MissionScripts\EconomySystems\Core\registerZeusMenuInjector.sqf";
             };

--- a/MissionScripts/WaldosFunctions.sqf
+++ b/MissionScripts/WaldosFunctions.sqf
@@ -331,6 +331,12 @@ class CfgFunctions
             class EcoCore_registerZenModules {
                 file = "MissionScripts\EconomySystems\Core\registerZenModules.sqf";
             };
+            class EcoCore_zenModuleGuard {
+                file = "MissionScripts\EconomySystems\Core\zenModuleGuard.sqf";
+            };
+            class EcoCore_zenPlacementPos {
+                file = "MissionScripts\EconomySystems\Core\zenPlacementPos.sqf";
+            };
             class EcoCore_registerZeusMenuInjector {
                 file = "MissionScripts\EconomySystems\Core\registerZeusMenuInjector.sqf";
             };

--- a/MissionScripts/WaldosFunctions.sqf
+++ b/MissionScripts/WaldosFunctions.sqf
@@ -316,6 +316,9 @@ class CfgFunctions
             class VVDVehicleDamage {
                 file = "MissionScripts\Logistics\VirtualVehicleDepot\VVDVehicleDamage.sqf";
             };
+            class VVDPurgeVehicle {
+                file = "MissionScripts\Logistics\VirtualVehicleDepot\VVDPurgeVehicle.sqf";
+            };
         };
         class EcoCore
         {
@@ -324,6 +327,12 @@ class CfgFunctions
             };
             class EcoCore_applyMakerConfig {
                 file = "MissionScripts\EconomySystems\Core\applyMakerConfig.sqf";
+            };
+            class EcoCore_registerZeusMenuInjector {
+                file = "MissionScripts\EconomySystems\Core\registerZeusMenuInjector.sqf";
+            };
+            class EcoCore_startZeusMenuHook {
+                file = "MissionScripts\EconomySystems\Core\startZeusMenuHook.sqf";
             };
             class EcoCore_isActive {
                 file = "MissionScripts\EconomySystems\Core\isActive.sqf";

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ to utilise critical systems of arma 3. Now, it is in continued use by at least f
 - Script-driven Tasks/Objectives helpers - JIP-safe BIS task wrappers with automatic map markers that also feed the After-Action Report.
 - Mission Diagnostics - a read-only server-side config sanity check that warns about the most common WMP misconfigurations at mission start.
 - Custom Zeus Enhanced modules for in-game access to the logistics system, ENDEX & Safestart scripts.
-- Waldos Economy Systems - a pub-Zeus Resource / Research / Build / Buy economy suite with Ground Command, run live from the Zeus menu.
+- Waldos Economy Systems - a pub-Zeus Resource / Research / Build / Buy economy suite with Ground Command, run live from the Zeus Enhanced module menu (ZEN required for the in-Zeus menu).
 - HALO & Static Line Jump Scripts with equipment & weapon loss simulation.
 - [WIP] Virtual Vehicle Deployment Garage
 - Bundled (optional, off by default) third-party scripts - Werthles' Headless Client kit and aeroson's dynamic player markers - wired through a single clean entry point.

--- a/wiki/Waldos-Economy-Systems-Setup-And-Configuration.md
+++ b/wiki/Waldos-Economy-Systems-Setup-And-Configuration.md
@@ -2,6 +2,8 @@ _Associated Files: `init.sqf`, `initServer.sqf`, `economyConfig.sqf`, `Waldo_fnc
 
 This page covers every way to enable and configure [Waldos Economy Systems](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Economy-Systems) — from a one-line toggle to a fully hand-authored economy baked into the mission file. Everything here is applied once on the server and broadcast, so **JIP and rejoining players inherit the configured economy automatically**.
 
+> **Zeus Enhanced is required for the in-Zeus menu.** Every operator action is a **ZEN custom module** in the Zeus module list under the single category **"Waldos Economy Systems"**. Modules are named `System - Action`, so the tutorial paths on the other pages map directly: e.g. "**Waldos Economy Systems → Resource → Configure Resources**" is the module **`Resource - Configure Resources`**, and "**Research → Create Research Center**" is **`Research - Create Research Center`**. Placement modules (create crate/zone/research center, spawn building/vehicle/laptop, set drop point) spawn at the point where you drop the module on the map. Without ZEN the economy still runs on the server, but there is no in-Zeus menu.
+
 ## 1. Enable the suite
 
 It is **off by default**, so missions that don't use it pay no performance cost. Turn it on whichever way is easiest for you:

--- a/wiki/Waldos-Economy-Systems.md
+++ b/wiki/Waldos-Economy-Systems.md
@@ -2,6 +2,8 @@ _Associated Files: MissionScripts\EconomySystems\ (the `Waldo_fnc_Eco*` function
 
 Waldos Economy Systems is a **pub-Zeus, RTS-style economy suite** built into the pack. It lets you run a resource economy, a tech tree, base construction, and a vehicle store entirely from inside Zeus — no scripting needed by the operator, and no Eden work needed beyond turning it on. It works for any curator, including a player-controlled Zeus.
 
+> **Requires Zeus Enhanced (ZEN).** Every action is a ZEN custom module under the **"Waldos Economy Systems"** category in the Zeus module list. Without ZEN loaded the economy still runs on the server (income, research, production, player requests), but there is no in-Zeus authoring menu. ZEN is already a common dependency for the pack's other Zeus modules.
+
 This is the hub page. Each system has its own tutorial:
 
 ## Feature pages


### PR DESCRIPTION
**When merged this pull request will:**

**VVD (Virtual Vehicle Depot) — vehicle/UAV removal locality**
- Add `Waldo_fnc_VVDPurgeVehicle`, routing crew + hull deletion to the vehicle's owning machine (`owner _veh`) so UAV AI created on the spawning client is torn down where it's local; wire it into the "Delete Vehicles" action. Reword the WIP warning (in-file + CLAUDE.md) to the locality-based description.

**Economy Systems — Zeus menu now via ZEN custom modules (ZEN required)**
- Add `Waldo_fnc_EcoCore_registerZenModules`: registers all 19 Economy actions as ZEN custom modules under the "Waldos Economy Systems" category (names match the old tree labels, e.g. `Resource - Configure Resources`, `Research - Create Research Center`), reusing the existing prompt/spawn handlers. Self-guarded: client + `zen_main` present + once.
- Placement modules convert ZEN's ASL drop position to AGL (via `Waldo_fnc_EcoCore_zenPlacementPos`, the single tuning point for placement height) and spawn at that point; non-placement modules open the existing dialog/toggle.
- Every module runs `Waldo_fnc_EcoCore_zenModuleGuard` first (except Purge), so after a Purge — which ZEN cannot un-register — the lingering modules no-op with a notice instead of acting on a torn-down economy.
- The two stateful toggles are named "Toggle Commitment Mode" / "Toggle Testing Notice" (ZEN module names are static; the toggles already `hintSilent` the resulting ON/OFF state).
- Disable the legacy curator-tree injection: `Waldo_fnc_EcoCore_startZeusMenuHook` is now a no-op, so the per-client polling loop never starts and no tree menu is injected.
- **Fix the dedicated-server authority gap:** the seven object-creation functions (research center, resource crate, resource zone, building, construction vehicle, purchase laptop, drop point) now `remoteExec [..., 2]` to the server when called on a client, instead of no-opping at the `isServer` guard. Required because ZEN module code runs on the curator's client.

**Docs**
- CLAUDE.md, README, and the Economy wiki hub + Setup pages updated: the Economy Zeus menu is now ZEN custom modules and ZEN is required for the in-Zeus menu (the suite still runs server-side without it); the MP/authority note documents the server-forwarding of object creation.

**Also included (earlier commit):** consolidation of the five per-client Economy Zeus-open polling loops into one shared detector. On this branch the ZEN-module work supersedes that mechanism (the hook is now a no-op); it remains as an independently-valid change and as the fallback path until the dead injection helpers are removed.

**Deferred / needed before this leaves draft:**
- **Stage 2 (not in this PR yet):** delete the now-dead curator-tree injection helpers (`injectZeusMenu`, `getZeusTreeControl`, `ensureZeusHeaderRoot`, tree-index helpers, `beginZeusPlacementSession`, the `begin*Placement` flows, `registerZeusMenuInjector`, `startZeusMenuHook`) — held back until the ZEN path is confirmed in-engine so the old path stays available for comparison/rollback. `getZeusDisplay` and the prompt dialogs are shared and stay.
- **In-engine smoke test on a dedicated server:** ZEN module placement for each action, ASL→AGL drop-height correctness (retune in `zenPlacementPos` if needed), authority routing of spawns, and post-Purge module no-op behaviour.

Both Python validators pass (`sqf_validator.py`, `config_style_checker.py`).

**Commits:** VVD locality + poller consolidation → ZEN modules (stage 1) → docs (stage 3) → ZEN hardening (purge guard, placement-pos knob, toggle rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1AifHuu1iWSM31Dyuecq2