### PR TITLE
Add Electronic Warfare suite: radio jamming (ACRE2/TFAR), UAV jamming, EMP, signal trackers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,39 @@ For custom aircraft that don't auto-detect, add in the object's init field in Ed
 [this] call Waldo_fnc_VehicleJumpSetup;
 ```
 
+### Radio Jamming — ACRE2 / TFAR (`init.sqf`)
+
+Localised, area-denial radio jamming for **both** ACRE2 and TFAR. A *jammer* is any world object with a radius; radios inside its field lose comms, with a linear falloff at the edge. Enabled by default (`Waldo_Jamming_Enable = true` in `init.sqf`) but has **zero effect until a jammer is placed** — the radio engines pass ACRE2/TFAR through unchanged when the registry is empty.
+
+**Server-authoritative registry, client-local engines.** The jammer registry (`Waldo_Jamming_Registry`) is owned and broadcast by the server via the create/toggle/remove functions (which forward to the server when called on a client, exactly like `Waldo_fnc_SafeStart`). Each client installs the radio engines from `init.sqf` (JIP-safe): the ACRE2 custom signal function and/or the TFAR throttle loop, plus an on-screen "radio jammed" watcher.
+
+Placing jammers (any of these):
+```sqf
+// From an object's init field in Eden:
+[this] call Waldo_fnc_Jammer;                         // 300 m, jams everyone, all bands
+[this, 500, "EAST"] call Waldo_fnc_Jammer;            // 500 m, jams OPFOR only
+// From a trigger / script (full params):
+[myTower, 800, "ALL", [[30, 88]], 50, 1, true, true] call Waldo_fnc_Jammer;
+// params: [object, radius, affectedSides, bands, falloff, strength, active, createMarker]
+```
+`affectedSides`: `"ALL"`, a side, or an array — accepts sides or strings (`"WEST"/"BLUFOR"`, `"EAST"/"OPFOR"`, `"IND"/"INDFOR"`, `"CIV"/"CIVILIAN"`). `bands`: `"ALL"` or an array of `[minMHz, maxMHz]` ranges (**ACRE2 only** — TFAR jamming is always broadband). `Waldo_fnc_Jammer` returns a numeric jammer id.
+
+Managing jammers later (server-authoritative; `ref` = the jammer object or its id):
+```sqf
+[myTower, false] call Waldo_fnc_JammerToggle;   // switch off (omit the bool to flip)
+[myTower, true]  call Waldo_fnc_JammerRemove;   // remove + delete the object
+```
+
+Global flags (`init.sqf`):
+```sqf
+Waldo_Jamming_Enable = true;                                          // false = feature off entirely
+missionNamespace setVariable ["Waldo_Jamming_Notify", true, true];    // on-screen "radio jammed" prompt
+```
+
+**ACRE2 requirement:** the ACRE2 signal model must be **LOS Multipath** (the default) or **Arcade** — ACRE2 does not call the custom signal hook under *LOS Simple*. The jamming model is receiver-oriented and symmetric: a link is degraded when **either** endpoint (the receiving or transmitting radio) sits inside an active field affecting the local player's side and matching the band. Implemented in `MissionScripts/MissionInit/Jamming/` (`Waldo_fnc_JammingInit`, `Waldo_fnc_Jammer`, `Waldo_fnc_JammerToggle`, `Waldo_fnc_JammerRemove`, `Waldo_fnc_JammingFactor`, `Waldo_fnc_JammingAcreSignal`, `Waldo_fnc_JammingTfarLoop`).
+
+Zeus ("Waldos Mission Modules"): **Radio Jammer - Place** (dialog: radius / falloff / strength / affected side / marker), **Radio Jammer - Toggle Nearest**, **Radio Jammer - Remove Nearest**.
+
 ### MHQ / Mobile Command Post (Eden Editor)
 
 1. Place a vehicle (or static object) with a variable name, e.g. `MHQ_1`
@@ -430,6 +463,7 @@ Replace `Pictures\loading.jpg` with a custom loading screen image.
 ## MissionScripts Directory Layout
 
 - `MissionInit/` — ACRE2 radio setup, vehicle action setup, team colour helpers, briefing document templates
+- `MissionInit/Jamming/` — Localised radio jamming for ACRE2 & TFAR (registry, create/toggle/remove, per-mod engines, shared factor helper)
 - `Logistics/` — The largest module: supply/medical crates, loadout saving, MHQ, teleport, fortification, vehicle camo, virtual vehicle depot, map location tools
 - `AiScripting/` — AI skill adjustment (`AITweak`) and convoy system (`SimpleAiConvoy`)
 - `MissionFlowAndUi/` — ENDEX, info text overlays, respawn messages, timed hints
@@ -567,6 +601,16 @@ if !(isClass(configFile >> "CfgPatches" >> "acre_main")) exitWith { systemChat "
 waitUntil { [] call acre_api_fnc_isInitialized };
 ```
 
+**Jamming (custom signal processing):** ACRE2 has no jammer API. The only hook is a single custom signal function — WMP's radio jamming (`Waldo_fnc_JammingAcreSignal`) owns it:
+```sqf
+// Override / reset ACRE2's signal calculation (only ONE custom func can exist at a time):
+[_myFunc] call acre_api_fnc_setCustomSignalFunc;     // _myFunc gets [freqMHz, powerMw, rxRadioId, txRadioId], returns [percent(0-1), dBm]
+[{}]      call acre_api_fnc_setCustomSignalFunc;     // reset to default
+_base = [_freq, _power, _rxId, _txId] call acre_sys_signal_fnc_getSignalCore;  // ACRE2's own baseline result
+_pos  = [_radioId] call acre_sys_radio_fnc_getRadioPos;                        // ASL position of a radio
+```
+The custom hook is called **only** under the *LOS Multipath* (default) or *Arcade* signal models.
+
 **Babel (multilingual) API** (`BabelActivation.sqf`):
 ```sqf
 [languageName]          call acre_api_fnc_babelAddLanguageType;
@@ -590,6 +634,16 @@ waitUntil { [] call acre_api_fnc_isInitialized };
 TFAR has **inherent Eden Editor support** — it assigns radios via the 3Den unit properties panel, not through scripts. WMP has zero TFAR function calls.
 
 The one point of integration: `missionFileLookup.sqf` reads the `radio` inventory slot from `mission.sqm` when scraping unit loadouts. This slot captures TFAR radio classnames placed via Eden, so they flow into supply crates automatically alongside all other items — no extra scripting needed.
+
+**Jamming:** TFAR has no signal hook, but it exposes client-side unit variables that WMP's jamming loop (`Waldo_fnc_JammingTfarLoop`) drives while a player is inside a jammer field (detected via `task_force_radio` or `tfar_core` in `CfgPatches`):
+
+| Variable | Type | Effect |
+|---|---|---|
+| `tf_receivingDistanceMultiplicator` | unit var (client) | Scales receive range; WMP sets it toward `0` to kill reception. |
+| `tf_sendingDistanceMultiplicator` | unit var (client) | Scales transmit range; WMP sets it toward `0` to kill outbound comms. |
+| `tf_unable_to_use_radio` | unit var (client) | `true` fully disables the radio (set at near-total jamming). |
+
+The loop only restores these to their defaults (`1.0` / `false`) when the player leaves the field, so it never clobbers other scripts while un-jammed. TFAR jamming is broadband (no per-band filter).
 
 ---
 
@@ -620,6 +674,9 @@ if !(isClass(configFile >> "CfgPatches" >> "zen_main")) exitWith {};
 - Safestart - Activate → `[true] remoteExec ["Waldo_fnc_SafeStart", 2]`
 - Safestart - Go Live (Lift) → `[false] remoteExec ["Waldo_fnc_SafeStart", 2]`
 - Safestart - Start Go-Live Countdown → calls `Waldo_fnc_ZenSafeStartTimer` (prompts for minutes, then `Waldo_fnc_SafeStartTimer`)
+- Radio Jammer - Place → calls `Waldo_fnc_ZenJammerPlace` (dialog: radius / falloff / strength / affected side / marker; spawns an emitter and registers it via `Waldo_fnc_Jammer`)
+- Radio Jammer - Toggle Nearest → calls `Waldo_fnc_ZenJammerToggle` (flips the nearest jammer on/off)
+- Radio Jammer - Remove Nearest → calls `Waldo_fnc_ZenJammerRemove` (removes + deletes the nearest jammer)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,10 +204,12 @@ Placing jammers (any of these):
 [this] call Waldo_fnc_Jammer;                         // 300 m, jams everyone, all bands
 [this, 500, "EAST"] call Waldo_fnc_Jammer;            // 500 m, jams OPFOR only
 // From a trigger / script (full params):
-[myTower, 800, "ALL", [[30, 88]], 50, 1, true, true, [90, 60], [4, 2]] call Waldo_fnc_Jammer;
-// params: [object, radius, affectedSides, bands, falloff, strength, active, createMarker, sector, duty]
+[myTower, 800, "ALL", [[30, 88]], 50, 1, true, true, [90, 60], [4, 2], true] call Waldo_fnc_Jammer;
+// params: [object, radius, affectedSides, bands, falloff, strength, active, createMarker, sector, duty, jamUAV]
 ```
-`affectedSides`: `"ALL"`, a side, or an array — accepts sides or strings (`"WEST"/"BLUFOR"`, `"EAST"/"OPFOR"`, `"IND"/"INDFOR"`, `"CIV"/"CIVILIAN"`). `bands`: `"ALL"` or an array of `[minMHz, maxMHz]` ranges (**ACRE2 only** — TFAR jamming is always broadband). `sector`: `[]` for omni or `[bearing, arc]` for a directional cone. `duty`: `[]` for constant or `[onSec, offSec]` to pulse. `Waldo_fnc_Jammer` returns a numeric jammer id.
+`affectedSides`: `"ALL"`, a side, or an array — accepts sides or strings (`"WEST"/"BLUFOR"`, `"EAST"/"OPFOR"`, `"IND"/"INDFOR"`, `"CIV"/"CIVILIAN"`). `bands`: `"ALL"` or an array of `[minMHz, maxMHz]` ranges (**ACRE2 only** — TFAR jamming is always broadband). `sector`: `[]` for omni or `[bearing, arc]` for a directional cone. `duty`: `[]` for constant or `[onSec, offSec]` to pulse. `jamUAV`: also jam drones in the field. `Waldo_fnc_Jammer` returns a numeric jammer id.
+
+**UAV / UGV jamming** (`jamUAV = true`): drones inside the field are jammed too — the server freezes autonomous drones' AI (`Waldo_fnc_JammingUavServer`), and a controlling player's client (`Waldo_fnc_JammingUavClient`) degrades the video feed as the link weakens and severs the terminal link at near-total jamming. It carries the **same loud feedback** as radio jamming: a persistent "UAV LINK JAMMED — not a game bug" HUD banner (IDC 5311) and a clear "datalink lost" message, so a jammed drone is never mistaken for an Arma UAV bug.
 
 **Jamming model** (global toggles in `init.sqf`, read by `Waldo_fnc_JammingFactor`):
 
@@ -237,9 +239,30 @@ Waldo_Jamming_Enable = true;                                          // false =
 missionNamespace setVariable ["Waldo_Jamming_Notify", true, true];    // on-screen "radio jammed" prompt
 ```
 
-**ACRE2 requirement:** the ACRE2 signal model must be **LOS Multipath** (the default) or **Arcade** — ACRE2 does not call the custom signal hook under *LOS Simple*. The jamming model is receiver-oriented and symmetric: a link is degraded when **either** endpoint (the receiving or transmitting radio) sits inside an active field affecting the local player's side and matching the band. Implemented in `MissionScripts/MissionInit/Jamming/` (`Waldo_fnc_JammingInit`, `Waldo_fnc_Jammer`, `Waldo_fnc_JammerToggle`, `Waldo_fnc_JammerRemove`, `Waldo_fnc_JammingFactor`, `Waldo_fnc_JammingAcreSignal`, `Waldo_fnc_JammingTfarLoop`, `Waldo_fnc_JammerInteraction`, `Waldo_fnc_JammerScan`, `Waldo_fnc_JammerMapDraw`, `Waldo_fnc_JammingHud`).
+**ACRE2 requirement:** the ACRE2 signal model must be **LOS Multipath** (the default) or **Arcade** — ACRE2 does not call the custom signal hook under *LOS Simple*. The jamming model is receiver-oriented and symmetric: a link is degraded when **either** endpoint (the receiving or transmitting radio) sits inside an active field affecting the local player's side and matching the band. Implemented in `MissionScripts/MissionInit/Jamming/` (`Waldo_fnc_JammingInit`, `Waldo_fnc_Jammer`, `Waldo_fnc_JammerToggle`, `Waldo_fnc_JammerRemove`, `Waldo_fnc_JammingFactor`, `Waldo_fnc_JammingAcreSignal`, `Waldo_fnc_JammingTfarLoop`, `Waldo_fnc_JammingUavServer`, `Waldo_fnc_JammingUavClient`, `Waldo_fnc_JammerInteraction`, `Waldo_fnc_JammerScan`, `Waldo_fnc_JammerMapDraw`, `Waldo_fnc_JammingHud`).
 
-Zeus ("Waldos Mission Modules"): **Radio Jammer - Place** (dialog: radius / falloff / strength / affected side / cone arc + bearing / pulsing / marker), **Radio Jammer - Toggle Nearest**, **Radio Jammer - Remove Nearest**.
+Zeus ("Waldos Mission Modules"): **Radio Jammer - Place** (dialog: radius / falloff / strength / affected side / cone arc + bearing / pulsing / jam UAVs / marker), **Radio Jammer - Toggle Nearest**, **Radio Jammer - Remove Nearest**.
+
+### EMP Burst (`Waldo_fnc_EMP`)
+
+A one-shot electromagnetic pulse — an area electronics kill, the offensive counterpart to the (persistent) jammer. Server-authoritative; because it fires once and reverts on a timer it runs **no polling loops**, so it is free to leave available.
+
+```sqf
+[getPosATL myObject, 200, 30] call Waldo_fnc_EMP;   // [position, radius(m), duration(s)]
+[commandVehicle] call Waldo_fnc_EMPImmune;          // exempt a unit/vehicle (occupants inherit)
+```
+Effects in radius (non-immune): infantry lose NVGs and (TFAR) radio use for the duration; vehicles have their engine cut (fuel drained, restored after); every affected **player** gets a white-out flash and an explicit "EMP DETONATION — electronics down" message. Applied per-entity on its owning machine via `Waldo_fnc_EMPApply`. Zeus: **EMP Detonation** (dialog: radius / duration). Implemented in `MissionScripts/MissionInit/ElectronicWarfare/`.
+
+### Signal Trackers — C-Track (`Waldo_fnc_Tracker`)
+
+Plant a tracker on a unit or vehicle and a chosen side follows it live on the map — electronic recon. Server-authoritative registry (`Waldo_Tracker_Registry`, JIP-safe) with a light server prune loop that drops trackers whose target dies; markers are drawn **locally** on each tracking client (`Waldo_fnc_TrackerRender`) so they stay hidden from the tracked side.
+
+```sqf
+[enemyTruck, west, "Convoy Lead"] call Waldo_fnc_Tracker;   // [target, trackingSide, label]
+[cursorTarget] call Waldo_fnc_TrackerAttach;                // plant on what you're looking at (your side)
+[enemyTruck] call Waldo_fnc_TrackerRemove;                  // remove
+```
+Players get an ACE **Plant Signal Tracker** action on units and vehicles; Zeus gets a **Plant Signal Tracker** module (attaches to the nearest unit, tracked by a chosen side). Implemented in `MissionScripts/MissionInit/ElectronicWarfare/`.
 
 ### MHQ / Mobile Command Post (Eden Editor)
 
@@ -479,7 +502,8 @@ Replace `Pictures\loading.jpg` with a custom loading screen image.
 ## MissionScripts Directory Layout
 
 - `MissionInit/` — ACRE2 radio setup, vehicle action setup, team colour helpers, briefing document templates
-- `MissionInit/Jamming/` — Localised radio jamming for ACRE2 & TFAR (registry, create/toggle/remove, per-mod engines, shared factor helper)
+- `MissionInit/Jamming/` — Localised radio jamming for ACRE2 & TFAR (registry, create/toggle/remove, per-mod engines, UAV jamming, shared factor helper, EW toolkit + feedback HUD)
+- `MissionInit/ElectronicWarfare/` — EMP burst (`Waldo_fnc_EMP`) and signal trackers / C-Track (`Waldo_fnc_Tracker`)
 - `Logistics/` — The largest module: supply/medical crates, loadout saving, MHQ, teleport, fortification, vehicle camo, virtual vehicle depot, map location tools
 - `AiScripting/` — AI skill adjustment (`AITweak`) and convoy system (`SimpleAiConvoy`)
 - `MissionFlowAndUi/` — ENDEX, info text overlays, respawn messages, timed hints
@@ -690,9 +714,11 @@ if !(isClass(configFile >> "CfgPatches" >> "zen_main")) exitWith {};
 - Safestart - Activate → `[true] remoteExec ["Waldo_fnc_SafeStart", 2]`
 - Safestart - Go Live (Lift) → `[false] remoteExec ["Waldo_fnc_SafeStart", 2]`
 - Safestart - Start Go-Live Countdown → calls `Waldo_fnc_ZenSafeStartTimer` (prompts for minutes, then `Waldo_fnc_SafeStartTimer`)
-- Radio Jammer - Place → calls `Waldo_fnc_ZenJammerPlace` (dialog: radius / falloff / strength / affected side / marker; spawns an emitter and registers it via `Waldo_fnc_Jammer`)
+- Radio Jammer - Place → calls `Waldo_fnc_ZenJammerPlace` (dialog: radius / falloff / strength / affected side / cone / pulsing / jam UAVs / marker; spawns an emitter and registers it via `Waldo_fnc_Jammer`)
 - Radio Jammer - Toggle Nearest → calls `Waldo_fnc_ZenJammerToggle` (flips the nearest jammer on/off)
 - Radio Jammer - Remove Nearest → calls `Waldo_fnc_ZenJammerRemove` (removes + deletes the nearest jammer)
+- EMP Detonation → calls `Waldo_fnc_ZenEMP` (dialog: radius / duration; detonates an EMP via `Waldo_fnc_EMP`)
+- Plant Signal Tracker → calls `Waldo_fnc_ZenTracker` (tags the nearest unit/vehicle, tracked by a chosen side, via `Waldo_fnc_Tracker`)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,10 +204,26 @@ Placing jammers (any of these):
 [this] call Waldo_fnc_Jammer;                         // 300 m, jams everyone, all bands
 [this, 500, "EAST"] call Waldo_fnc_Jammer;            // 500 m, jams OPFOR only
 // From a trigger / script (full params):
-[myTower, 800, "ALL", [[30, 88]], 50, 1, true, true] call Waldo_fnc_Jammer;
-// params: [object, radius, affectedSides, bands, falloff, strength, active, createMarker]
+[myTower, 800, "ALL", [[30, 88]], 50, 1, true, true, [90, 60], [4, 2]] call Waldo_fnc_Jammer;
+// params: [object, radius, affectedSides, bands, falloff, strength, active, createMarker, sector, duty]
 ```
-`affectedSides`: `"ALL"`, a side, or an array — accepts sides or strings (`"WEST"/"BLUFOR"`, `"EAST"/"OPFOR"`, `"IND"/"INDFOR"`, `"CIV"/"CIVILIAN"`). `bands`: `"ALL"` or an array of `[minMHz, maxMHz]` ranges (**ACRE2 only** — TFAR jamming is always broadband). `Waldo_fnc_Jammer` returns a numeric jammer id.
+`affectedSides`: `"ALL"`, a side, or an array — accepts sides or strings (`"WEST"/"BLUFOR"`, `"EAST"/"OPFOR"`, `"IND"/"INDFOR"`, `"CIV"/"CIVILIAN"`). `bands`: `"ALL"` or an array of `[minMHz, maxMHz]` ranges (**ACRE2 only** — TFAR jamming is always broadband). `sector`: `[]` for omni or `[bearing, arc]` for a directional cone. `duty`: `[]` for constant or `[onSec, offSec]` to pulse. `Waldo_fnc_Jammer` returns a numeric jammer id.
+
+**Jamming model** (global toggles in `init.sqf`, read by `Waldo_fnc_JammingFactor`):
+
+| Flag | Default | Effect |
+|---|---|---|
+| `Waldo_Jamming_LOS` | `true` | Terrain/hills between jammer and radio block the field (`terrainIntersectASL`). |
+| `Waldo_Jamming_BurnThrough` | `true` | Higher-power radios resist jamming — the effective radius shrinks by `(power/ref)^0.35`. |
+| `Waldo_Jamming_BurnThroughRef` | `500` | Reference radio power (mW); a radio at this power is fully affected. |
+| `Waldo_Jamming_Curve` | `"LINEAR"` | Edge falloff shape: `"LINEAR"` or `"INVSQ"`. |
+| `Waldo_Jamming_Destructible` | `true` | Destroying a jammer's object auto-deregisters it (EW objectives for free). |
+| `Waldo_Jamming_GmOverlay` | `true` | Curators see a Draw3D marker/facing-line over each jammer. |
+| `Waldo_Jamming_ScanRange` | `3000` | Detection range (m) of the handheld RDF ACE self-action. |
+
+**EW toolkit (players):** every jammer object gets ACE actions **Toggle Radio Jammer** (anyone) and **Disable Radio Jammer** (engineers — destroys it); every player gets an ACE self-action **Scan for Radio Jammers** (`Waldo_fnc_JammerScan`) that reports bearing / coarse range / strength to the nearest active emitter for RDF hunting.
+
+**Feedback:** while jammed the player sees a persistent, blinking HUD banner on the main display (IDC 5310, `Waldo_fnc_JammingHud`) that other hints can't overwrite, a strength %, and an explicit "not a game bug" line, backed by an entry banner and a periodic chat reminder — deliberately unmistakable, because Arma radio bugs otherwise look identical to jamming.
 
 Managing jammers later (server-authoritative; `ref` = the jammer object or its id):
 ```sqf
@@ -221,9 +237,9 @@ Waldo_Jamming_Enable = true;                                          // false =
 missionNamespace setVariable ["Waldo_Jamming_Notify", true, true];    // on-screen "radio jammed" prompt
 ```
 
-**ACRE2 requirement:** the ACRE2 signal model must be **LOS Multipath** (the default) or **Arcade** — ACRE2 does not call the custom signal hook under *LOS Simple*. The jamming model is receiver-oriented and symmetric: a link is degraded when **either** endpoint (the receiving or transmitting radio) sits inside an active field affecting the local player's side and matching the band. Implemented in `MissionScripts/MissionInit/Jamming/` (`Waldo_fnc_JammingInit`, `Waldo_fnc_Jammer`, `Waldo_fnc_JammerToggle`, `Waldo_fnc_JammerRemove`, `Waldo_fnc_JammingFactor`, `Waldo_fnc_JammingAcreSignal`, `Waldo_fnc_JammingTfarLoop`).
+**ACRE2 requirement:** the ACRE2 signal model must be **LOS Multipath** (the default) or **Arcade** — ACRE2 does not call the custom signal hook under *LOS Simple*. The jamming model is receiver-oriented and symmetric: a link is degraded when **either** endpoint (the receiving or transmitting radio) sits inside an active field affecting the local player's side and matching the band. Implemented in `MissionScripts/MissionInit/Jamming/` (`Waldo_fnc_JammingInit`, `Waldo_fnc_Jammer`, `Waldo_fnc_JammerToggle`, `Waldo_fnc_JammerRemove`, `Waldo_fnc_JammingFactor`, `Waldo_fnc_JammingAcreSignal`, `Waldo_fnc_JammingTfarLoop`, `Waldo_fnc_JammerInteraction`, `Waldo_fnc_JammerScan`, `Waldo_fnc_JammerMapDraw`, `Waldo_fnc_JammingHud`).
 
-Zeus ("Waldos Mission Modules"): **Radio Jammer - Place** (dialog: radius / falloff / strength / affected side / marker), **Radio Jammer - Toggle Nearest**, **Radio Jammer - Remove Nearest**.
+Zeus ("Waldos Mission Modules"): **Radio Jammer - Place** (dialog: radius / falloff / strength / affected side / cone arc + bearing / pulsing / marker), **Radio Jammer - Toggle Nearest**, **Radio Jammer - Remove Nearest**.
 
 ### MHQ / Mobile Command Post (Eden Editor)
 

--- a/MissionScripts/MissionFlowAndUi/runDiagnostics.sqf
+++ b/MissionScripts/MissionFlowAndUi/runDiagnostics.sqf
@@ -130,6 +130,20 @@ if (isClass (configFile >> "CfgPatches" >> "acre_main")) then {
     ];
 };
 
+// 6. Radio jamming --------------------------------------------------------
+// Only meaningful when the jamming feature is enabled (init.sqf sets the flag).
+if (missionNamespace getVariable ["Waldo_Jamming_Enable", false]) then {
+    private _acre = isClass (configFile >> "CfgPatches" >> "acre_main");
+    private _tfar = isClass (configFile >> "CfgPatches" >> "task_force_radio")
+        || isClass (configFile >> "CfgPatches" >> "tfar_core");
+    if (!_acre && {!_tfar}) then {
+        ["WARN", "Radio jamming is enabled but neither ACRE2 nor TFAR is loaded - jamming will do nothing."] call _log;
+        _warnings = _warnings + 1;
+    } else {
+        ["INFO", format ["Radio jamming enabled (ACRE2: %1, TFAR: %2). ACRE2 needs the LOS Multipath or Arcade signal model.", _acre, _tfar]] call _log;
+    };
+};
+
 // Summary -----------------------------------------------------------------
 if (_warnings == 0) then {
     ["INFO", "Diagnostics complete - no configuration issues detected."] call _log;

--- a/MissionScripts/MissionInit/ElectronicWarfare/emp.sqf
+++ b/MissionScripts/MissionInit/ElectronicWarfare/emp.sqf
@@ -1,0 +1,43 @@
+/*
+ * Author: Waldo
+ * Detonates an electromagnetic pulse at a position: a one-shot area effect that fries electronics
+ * for a while. Infantry in range lose their night-vision goggles and (TFAR) radio use; vehicles
+ * have their engines killed; every affected player gets a white-out flash and a clear on-screen
+ * message so it reads as an EW event, not a bug. Units and vehicles tagged with Waldo_fnc_EMPImmune
+ * are spared, and occupants of an immune vehicle are spared too. Server-authoritative - calling on
+ * a client forwards to the server. Because it fires once and reverts on a timer, it costs nothing
+ * to leave available (no polling loops).
+ *
+ * Arguments:
+ * 0: Position <ARRAY> - centre of the pulse (ASL/AGL world position)
+ * 1: Radius <NUMBER> - effect radius in metres (optional, default: 150)
+ * 2: Duration <NUMBER> - seconds the electronics stay down (optional, default: 30)
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [getPosATL myObject, 200, 30] call Waldo_fnc_EMP;
+ */
+
+params [["_pos", [0, 0, 0]], ["_radius", 150], ["_duration", 30]];
+
+if (!isServer) exitWith {
+    _this remoteExec ["Waldo_fnc_EMP", 2];
+};
+
+private _ents = _pos nearEntities [["Man", "Car", "Tank", "Air", "Ship", "Motorcycle", "StaticWeapon"], _radius];
+
+{
+    private _e = _x;
+    private _immune = _e getVariable ["Waldo_EMP_Immune", false];
+    // Infantry inside an immune vehicle are protected as well.
+    if (!_immune && {_e isKindOf "Man"} && {!isNull objectParent _e}) then {
+        if ((objectParent _e) getVariable ["Waldo_EMP_Immune", false]) then { _immune = true; };
+    };
+    if (!_immune) then {
+        [_e, _duration] remoteExec ["Waldo_fnc_EMPApply", _e];
+    };
+} forEach _ents;
+
+diag_log format ["[WMP EMP] EMP detonated at %1 (radius %2 m, %3 s) - %4 entities in range.", _pos, _radius, _duration, count _ents];

--- a/MissionScripts/MissionInit/ElectronicWarfare/empApply.sqf
+++ b/MissionScripts/MissionInit/ElectronicWarfare/empApply.sqf
@@ -1,0 +1,67 @@
+/*
+ * Author: Waldo
+ * Applies the EMP effect to one entity on the machine that owns it (so the changes replicate
+ * correctly). Infantry lose their night-vision goggles and have their TFAR radio disabled for the
+ * duration; if the infantryman is the local player they also get a white-out flash and a clear
+ * "EMP - electronics down" message. Vehicles have their engine cut (fuel drained) for the duration
+ * and restored afterwards. Driven by Waldo_fnc_EMP; not usually called directly.
+ *
+ * Arguments:
+ * 0: Entity <OBJECT> - the unit or vehicle to disable
+ * 1: Duration <NUMBER> - seconds the electronics stay down (optional, default: 30)
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [_unit, 30] call Waldo_fnc_EMPApply;
+ */
+
+params [["_entity", objNull], ["_duration", 30]];
+
+if (isNull _entity) exitWith {};
+
+if (_entity isKindOf "Man") then {
+    // Fry night-vision.
+    private _nvg = hmd _entity;
+    if (_nvg != "") then {
+        _entity unassignItem _nvg;
+        _entity removeItem _nvg;
+    };
+
+    // Cut TFAR radio use for the duration (no-op if TFAR is absent - it is just a unit variable).
+    _entity setVariable ["tf_unable_to_use_radio", true];
+    [_entity, _duration] spawn {
+        params ["_u", "_d"];
+        sleep _d;
+        if (!isNull _u) then { _u setVariable ["tf_unable_to_use_radio", false]; };
+    };
+
+    // Local player feedback: white-out flash + explicit message.
+    if (_entity == player && {hasInterface}) then {
+        [] spawn {
+            cutText ["", "WHITE OUT", 0.15];
+            sleep 0.2;
+            cutText ["", "WHITE IN", 1.2];
+        };
+        systemChat "*** EMP DETONATION - electronics down (intentional EW effect, not a bug). ***";
+        private _msg = parseText "<t color='#7ab8ff' size='2' shadow='1' align='center'>EMP</t><br /><t size='1' align='center'>Electronics disrupted in this area</t><br />";
+        [_msg, 4] spawn Waldo_fnc_TimedHint;
+    };
+} else {
+    // Vehicle: kill the engine by draining fuel, restore it afterwards.
+    if !(_entity getVariable ["Waldo_EMP_VehDown", false]) then {
+        private _fuel = fuel _entity;
+        _entity setVariable ["Waldo_EMP_VehDown", true, true];
+        _entity engineOn false;
+        _entity setFuel 0;
+        [_entity, _fuel, _duration] spawn {
+            params ["_v", "_f", "_d"];
+            sleep _d;
+            if (!isNull _v) then {
+                _v setFuel (_f max 0.05);
+                _v setVariable ["Waldo_EMP_VehDown", false, true];
+            };
+        };
+    };
+};

--- a/MissionScripts/MissionInit/ElectronicWarfare/empImmune.sqf
+++ b/MissionScripts/MissionInit/ElectronicWarfare/empImmune.sqf
@@ -1,0 +1,27 @@
+/*
+ * Author: Waldo
+ * Marks a unit or vehicle as immune to EMP (Waldo_fnc_EMP). Occupants of an immune vehicle inherit
+ * the immunity automatically. Server-authoritative and broadcast, so the flag holds for JIP players.
+ * Set it from an object's init field or a script for command vehicles, mission-critical assets, etc.
+ *
+ * Arguments:
+ * 0: Object <OBJECT> - the unit or vehicle to make EMP-immune
+ * 1: Immune <BOOL> - true to grant immunity, false to revoke it (optional, default: true)
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [this] call Waldo_fnc_EMPImmune;          // in a vehicle's init field
+ * [commandVehicle, true] call Waldo_fnc_EMPImmune;
+ */
+
+params [["_object", objNull], ["_immune", true]];
+
+if (isNull _object) exitWith {};
+
+if (!isServer) exitWith {
+    _this remoteExec ["Waldo_fnc_EMPImmune", 2];
+};
+
+_object setVariable ["Waldo_EMP_Immune", _immune, true];

--- a/MissionScripts/MissionInit/ElectronicWarfare/tracker.sqf
+++ b/MissionScripts/MissionInit/ElectronicWarfare/tracker.sqf
@@ -1,0 +1,72 @@
+/*
+ * Author: Waldo
+ * Plants a signal tracker on a unit or vehicle so a chosen side can follow it on the map - the
+ * C-Track style of electronic reconnaissance. Server-authoritative: it registers the target in the
+ * broadcast tracker registry (so JIP players inherit it) and starts a light server prune loop that
+ * drops trackers whose target has died or been deleted. The actual map markers are drawn locally on
+ * each tracking client (Waldo_fnc_TrackerRender) so they stay hidden from the tracked side.
+ *
+ * Arguments:
+ * 0: Target <OBJECT> - the unit or vehicle to track
+ * 1: Tracking side <SIDE or STRING> - who sees the marker: a side, or "ALL" (optional, default: the
+ *      caller's side; on the server, "ALL")
+ * 2: Label <STRING> - marker label (optional, default: "TRK-<id>")
+ * 3: Active <BOOL> - start active (optional, default: true)
+ *
+ * Return Value:
+ * Number <NUMBER> - the tracker id (server side); -1 when forwarded from a client
+ *
+ * Example:
+ * [enemyTruck, west, "Convoy Lead"] call Waldo_fnc_Tracker;
+ */
+
+params [["_target", objNull], ["_side", sideUnknown], ["_label", ""], ["_active", true]];
+
+if (isNull _target) exitWith { -1 };
+
+if (!isServer) exitWith {
+    _this remoteExec ["Waldo_fnc_Tracker", 2];
+    -1
+};
+
+// Normalise the tracking side.
+private _sideN = _side;
+if (_side isEqualType "") then {
+    switch (toUpper _side) do {
+        case "ALL": { _sideN = "ALL"; };
+        case "WEST"; case "BLUFOR": { _sideN = west; };
+        case "EAST"; case "OPFOR": { _sideN = east; };
+        case "IND"; case "INDEP"; case "INDFOR"; case "GUER": { _sideN = independent; };
+        case "CIV"; case "CIVILIAN": { _sideN = civilian; };
+        default { _sideN = "ALL"; };
+    };
+};
+if (_sideN isEqualType sideUnknown && {_sideN == sideUnknown}) then { _sideN = "ALL"; };
+
+private _id = missionNamespace getVariable ["Waldo_Tracker_NextId", 0];
+missionNamespace setVariable ["Waldo_Tracker_NextId", _id + 1, true];
+
+if (_label == "") then { _label = format ["TRK-%1", _id]; };
+
+private _registry = missionNamespace getVariable ["Waldo_Tracker_Registry", []];
+_registry pushBack [_id, _target, _sideN, _label, _active];
+missionNamespace setVariable ["Waldo_Tracker_Registry", _registry, true];
+
+// Lazy server prune loop: removes trackers whose target is gone.
+if !(missionNamespace getVariable ["Waldo_Tracker_PruneRunning", false]) then {
+    missionNamespace setVariable ["Waldo_Tracker_PruneRunning", true];
+    [] spawn {
+        while {true} do {
+            private _reg = missionNamespace getVariable ["Waldo_Tracker_Registry", []];
+            private _kept = _reg select { !isNull (_x select 1) && {alive (_x select 1)} };
+            if (count _kept != count _reg) then {
+                missionNamespace setVariable ["Waldo_Tracker_Registry", _kept, true];
+            };
+            sleep 5;
+        };
+    };
+};
+
+diag_log format ["[WMP TRK] Tracker %1 (%2) planted on %3 for %4.", _id, _label, _target, _sideN];
+
+_id

--- a/MissionScripts/MissionInit/ElectronicWarfare/trackerAttach.sqf
+++ b/MissionScripts/MissionInit/ElectronicWarfare/trackerAttach.sqf
@@ -1,0 +1,33 @@
+/*
+ * Author: Waldo
+ * Convenience "plant a tracker" helper for players and scripts. Tags a target (defaulting to the
+ * object under the player's cursor) so the caller's side can follow it on the map. Wired to the ACE
+ * "Plant Signal Tracker" interaction on units and vehicles by Waldo_fnc_JammingInit, and also usable
+ * from a trigger or script. Forwards to the server via Waldo_fnc_Tracker.
+ *
+ * Arguments:
+ * 0: Target <OBJECT> - the unit/vehicle to tag (optional, default: cursorTarget)
+ * 1: Tracking side <SIDE or STRING> - who sees it (optional, default: the caller's side)
+ * 2: Label <STRING> - marker label (optional, default: auto "TRK-<id>")
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [cursorTarget] call Waldo_fnc_TrackerAttach;
+ * [enemyTruck, west, "Convoy Lead"] call Waldo_fnc_TrackerAttach;
+ */
+
+params [["_target", cursorTarget], ["_side", side player], ["_label", ""]];
+
+if (isNull _target) exitWith {
+    if (hasInterface) then { systemChat "No valid target to tag."; };
+};
+
+[_target, _side, _label] call Waldo_fnc_Tracker;
+
+if (hasInterface) then {
+    systemChat "Signal tracker planted - target now tracked on your map.";
+    private _msg = parseText "<t color='#c8102e' size='1.3' align='center'>TRACKER PLANTED</t><br /><t size='0.9' align='center'>Target tracked on your map</t><br />";
+    [_msg, 3] spawn Waldo_fnc_TimedHint;
+};

--- a/MissionScripts/MissionInit/ElectronicWarfare/trackerRemove.sqf
+++ b/MissionScripts/MissionInit/ElectronicWarfare/trackerRemove.sqf
@@ -1,0 +1,35 @@
+/*
+ * Author: Waldo
+ * Removes a planted signal tracker from the registry. Server-authoritative - calling on a client
+ * forwards to the server, which re-broadcasts so the marker disappears on every tracking client.
+ *
+ * Arguments:
+ * 0: Reference <OBJECT or NUMBER> - the tracked object, or the tracker id from Waldo_fnc_Tracker
+ *
+ * Return Value:
+ * Bool <BOOL> - true if a matching tracker was found and removed (server side)
+ *
+ * Example:
+ * [enemyTruck] call Waldo_fnc_TrackerRemove;
+ * [2] call Waldo_fnc_TrackerRemove;
+ */
+
+params [["_ref", objNull]];
+
+if (!isServer) exitWith {
+    _this remoteExec ["Waldo_fnc_TrackerRemove", 2];
+    false
+};
+
+private _registry = missionNamespace getVariable ["Waldo_Tracker_Registry", []];
+private _idx = -1;
+if (_ref isEqualType objNull) then {
+    _idx = _registry findIf { (_x select 1) == _ref };
+} else {
+    if (_ref isEqualType 0) then { _idx = _registry findIf { (_x select 0) == _ref }; };
+};
+if (_idx < 0) exitWith { false };
+
+_registry deleteAt _idx;
+missionNamespace setVariable ["Waldo_Tracker_Registry", _registry, true];
+true

--- a/MissionScripts/MissionInit/ElectronicWarfare/trackerRender.sqf
+++ b/MissionScripts/MissionInit/ElectronicWarfare/trackerRender.sqf
@@ -1,0 +1,58 @@
+/*
+ * Author: Waldo
+ * Client render loop for signal trackers. Keeps a set of local map markers in sync with the
+ * broadcast tracker registry, showing only the trackers whose tracking side is "ALL" or the local
+ * player's side - so a tracker is visible to the side that planted it and stays hidden from the
+ * target's side. Markers are local (createMarkerLocal), so nothing leaks over the network. Creates,
+ * moves and deletes markers as trackers are planted, move and are removed. One instance per client.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [] call Waldo_fnc_TrackerRender;   // started from Waldo_fnc_JammingInit
+ */
+
+if !(hasInterface) exitWith {};
+if (missionNamespace getVariable ["Waldo_Tracker_RenderRunning", false]) exitWith {};
+missionNamespace setVariable ["Waldo_Tracker_RenderRunning", true];
+
+[] spawn {
+    private _live = [];   // ids currently drawn locally
+
+    while {true} do {
+        private _registry = missionNamespace getVariable ["Waldo_Tracker_Registry", []];
+        private _wanted = [];
+
+        {
+            _x params ["_id", "_tgt", "_side", "_label", "_active"];
+            private _see = (_side isEqualType "") || {_side == side player};
+            if (_active && _see && {!isNull _tgt} && {alive _tgt}) then {
+                _wanted pushBack _id;
+                private _mk = format ["Waldo_TrkL_%1", _id];
+                if !(_id in _live) then {
+                    createMarkerLocal [_mk, getPosATL _tgt];
+                    _mk setMarkerTypeLocal "mil_triangle";
+                    _mk setMarkerColorLocal "ColorRed";
+                    _mk setMarkerTextLocal _label;
+                    _mk setMarkerSizeLocal [0.8, 0.8];
+                };
+                _mk setMarkerPosLocal (getPosATL _tgt);
+                _mk setMarkerDirLocal (getDir _tgt);
+            };
+        } forEach _registry;
+
+        // Drop markers whose tracker is gone or no longer visible.
+        {
+            if !(_x in _wanted) then {
+                deleteMarkerLocal (format ["Waldo_TrkL_%1", _x]);
+            };
+        } forEach _live;
+
+        _live = _wanted;
+        sleep 2;
+    };
+};

--- a/MissionScripts/MissionInit/Jamming/jammerCreate.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammerCreate.sqf
@@ -24,6 +24,8 @@
  *      "bearing" degrees with a total width of "arc" degrees (optional, default: [])
  * 9: Duty <ARRAY> - [] for a constant jammer, or [onSeconds, offSeconds] to pulse it on and off
  *      (optional, default: [])
+ * 10: Jam UAVs <BOOL> - also jam drones/UGVs in the field (freeze autonomous ones, cut controlling
+ *      players' datalinks) as well as radios (optional, default: false)
  *
  * Return Value:
  * Number <NUMBER> - the jammer id (server side); -1 when forwarded from a client
@@ -47,7 +49,8 @@ params [
     ["_active", true, [false]],
     ["_marker", false, [false]],
     ["_sector", [], [[]]],
-    ["_duty", [], [[]]]
+    ["_duty", [], [[]]],
+    ["_jamUAV", false, [false]]
 ];
 
 if (isNull _object) exitWith {
@@ -130,7 +133,7 @@ if (_marker) then {
     };
 };
 
-private _entry = [_id, _object, _radius, _falloff, _sidesN, _bandsN, _strength, _active, _markerName, _sectorN, _dutyN];
+private _entry = [_id, _object, _radius, _falloff, _sidesN, _bandsN, _strength, _active, _markerName, _sectorN, _dutyN, _jamUAV];
 
 // Replace an existing entry for this id, else append.
 private _registry = missionNamespace getVariable ["Waldo_Jamming_Registry", []];

--- a/MissionScripts/MissionInit/Jamming/jammerCreate.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammerCreate.sqf
@@ -1,0 +1,125 @@
+/*
+ * Author: Waldo
+ * Creates (or updates) a localised radio jammer anchored to a world object. This is the main
+ * ease-of-use entry point for the jamming system: give it an object and a radius and you have
+ * a working jammer that denies ACRE2 and/or TFAR radio comms in that area. Server-authoritative
+ * - calling it from a client (or an object init field on a client) forwards to the server, which
+ * owns the broadcast jammer registry so JIP / rejoining players inherit every jammer. Idempotent
+ * per object: calling again on the same object updates that jammer in place instead of stacking.
+ *
+ * Arguments:
+ * 0: Object <OBJECT> - the emitter the jammer is anchored to (its position is the jam centre)
+ * 1: Radius <NUMBER> - full-strength jamming radius in metres (optional, default: 300)
+ * 2: Affected sides <STRING or ARRAY> - "ALL", a single side/side-string, or an array of them.
+ *      Accepts sides (west/east/...) or strings ("WEST"/"BLUFOR","EAST"/"OPFOR",
+ *      "IND"/"INDFOR","CIV"/"CIVILIAN"). Only listed sides are jammed (optional, default: "ALL")
+ * 3: Bands <STRING or ARRAY> - "ALL" for every frequency, or an array of [minMHz, maxMHz] ranges
+ *      to jam only those bands. Band filtering is ACRE2 only; TFAR is always broadband
+ *      (optional, default: "ALL")
+ * 4: Falloff <NUMBER> - extra metres of linear falloff beyond the radius (optional, default: 50)
+ * 5: Strength <NUMBER> - jamming strength at full effect, 0..1 (optional, default: 1)
+ * 6: Active <BOOL> - start switched on (optional, default: true)
+ * 7: Create marker <BOOL> - place a map marker on the jammer (optional, default: false)
+ *
+ * Return Value:
+ * Number <NUMBER> - the jammer id (server side); -1 when forwarded from a client
+ *
+ * Example:
+ * // Simplest - a 300 m jammer that jams everyone, from an object's init field:
+ * [this] call Waldo_fnc_Jammer;
+ * // A 500 m jammer that only jams OPFOR, on the 30-88 MHz band, with a map marker:
+ * [this, 500, "EAST", [[30, 88]], 50, 1, true, true] call Waldo_fnc_Jammer;
+ */
+
+params [
+    ["_object", objNull, [objNull]],
+    ["_radius", 300, [0]],
+    ["_sides", "ALL", ["", [], sideUnknown]],
+    ["_bands", "ALL", ["", []]],
+    ["_falloff", 50, [0]],
+    ["_strength", 1, [0]],
+    ["_active", true, [false]],
+    ["_marker", false, [false]]
+];
+
+if (isNull _object) exitWith {
+    diag_log "[WMP JAM] Waldo_fnc_Jammer called with a null object - ignored.";
+    -1
+};
+
+// Keep all registry writes on the server so JIP behaviour stays correct.
+if (!isServer) exitWith {
+    _this remoteExec ["Waldo_fnc_Jammer", 2];
+    -1
+};
+
+// Normalise the affected-sides argument to "ALL" or an array of side values.
+private _sidesN = "ALL";
+if !(_sides isEqualType "" && {toUpper _sides == "ALL"}) then {
+    private _raw = _sides;
+    if !(_raw isEqualType []) then { _raw = [_raw]; };
+    private _out = [];
+    {
+        private _s = _x;
+        if (_s isEqualType "") then {
+            switch (toUpper _s) do {
+                case "WEST"; case "BLUFOR": { _s = west; };
+                case "EAST"; case "OPFOR": { _s = east; };
+                case "IND"; case "INDEP"; case "INDFOR"; case "GUER"; case "GUERRILA": { _s = independent; };
+                case "CIV"; case "CIVILIAN": { _s = civilian; };
+                default { _s = sideUnknown; };
+            };
+        };
+        if (_s isEqualType sideUnknown && {!(_s in _out)}) then { _out pushBack _s; };
+    } forEach _raw;
+    if (_out isEqualTo []) then { _sidesN = "ALL"; } else { _sidesN = _out; };
+};
+
+// Normalise the bands argument to "ALL" or an array of [min, max] ranges.
+private _bandsN = "ALL";
+if !(_bands isEqualType "" && {toUpper _bands == "ALL"}) then {
+    private _raw = _bands;
+    // Allow a single [min, max] range without the outer array.
+    if (_raw isEqualType [] && {count _raw == 2} && {(_raw select 0) isEqualType 0}) then { _raw = [_raw]; };
+    if (_raw isEqualType [] && {count _raw > 0}) then { _bandsN = _raw; } else { _bandsN = "ALL"; };
+};
+
+// Clamp strength into a sane range.
+_strength = (_strength max 0) min 1;
+
+// Re-use an existing id for this object so repeat calls update rather than duplicate.
+private _id = _object getVariable ["Waldo_Jamming_Id", -1];
+if (_id < 0) then {
+    _id = missionNamespace getVariable ["Waldo_Jamming_NextId", 0];
+    missionNamespace setVariable ["Waldo_Jamming_NextId", _id + 1, true];
+    _object setVariable ["Waldo_Jamming_Id", _id, true];
+};
+
+private _markerName = "";
+if (_marker) then {
+    _markerName = format ["Waldo_Jammer_%1", _id];
+    if (getMarkerType _markerName == "") then {
+        createMarker [_markerName, getPosATL _object];
+        _markerName setMarkerType "mil_warning";
+        _markerName setMarkerColor "ColorRed";
+        _markerName setMarkerText "Radio Jammer";
+    };
+};
+
+private _entry = [_id, _object, _radius, _falloff, _sidesN, _bandsN, _strength, _active, _markerName];
+
+// Replace an existing entry for this id, else append.
+private _registry = missionNamespace getVariable ["Waldo_Jamming_Registry", []];
+private _idx = _registry findIf { (_x select 0) == _id };
+if (_idx >= 0) then {
+    // Preserve any marker created previously if this call did not make one.
+    if (_markerName == "") then { _entry set [8, (_registry select _idx) select 8]; };
+    _registry set [_idx, _entry];
+} else {
+    _registry pushBack _entry;
+};
+missionNamespace setVariable ["Waldo_Jamming_Registry", _registry, true];
+
+diag_log format ["[WMP JAM] Jammer %1 registered: radius=%2 falloff=%3 sides=%4 active=%5", _id, _radius, _falloff, _sidesN, _active];
+
+_id

--- a/MissionScripts/MissionInit/Jamming/jammerCreate.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammerCreate.sqf
@@ -20,6 +20,10 @@
  * 5: Strength <NUMBER> - jamming strength at full effect, 0..1 (optional, default: 1)
  * 6: Active <BOOL> - start switched on (optional, default: true)
  * 7: Create marker <BOOL> - place a map marker on the jammer (optional, default: false)
+ * 8: Sector <ARRAY> - [] for omnidirectional, or [bearing, arc] for a directional cone facing
+ *      "bearing" degrees with a total width of "arc" degrees (optional, default: [])
+ * 9: Duty <ARRAY> - [] for a constant jammer, or [onSeconds, offSeconds] to pulse it on and off
+ *      (optional, default: [])
  *
  * Return Value:
  * Number <NUMBER> - the jammer id (server side); -1 when forwarded from a client
@@ -29,6 +33,8 @@
  * [this] call Waldo_fnc_Jammer;
  * // A 500 m jammer that only jams OPFOR, on the 30-88 MHz band, with a map marker:
  * [this, 500, "EAST", [[30, 88]], 50, 1, true, true] call Waldo_fnc_Jammer;
+ * // An 800 m cone facing 090 deg, 60 deg wide, pulsing 4s on / 2s off:
+ * [this, 800, "ALL", "ALL", 50, 1, true, true, [90, 60], [4, 2]] call Waldo_fnc_Jammer;
  */
 
 params [
@@ -39,7 +45,9 @@ params [
     ["_falloff", 50, [0]],
     ["_strength", 1, [0]],
     ["_active", true, [false]],
-    ["_marker", false, [false]]
+    ["_marker", false, [false]],
+    ["_sector", [], [[]]],
+    ["_duty", [], [[]]]
 ];
 
 if (isNull _object) exitWith {
@@ -84,6 +92,22 @@ if !(_bands isEqualType "" && {toUpper _bands == "ALL"}) then {
     if (_raw isEqualType [] && {count _raw > 0}) then { _bandsN = _raw; } else { _bandsN = "ALL"; };
 };
 
+// Normalise the directional sector: [] omni, or a valid [bearing, arc].
+private _sectorN = [];
+if (_sector isEqualType [] && {count _sector == 2}) then {
+    private _b = (_sector select 0) % 360;
+    private _a = (_sector select 1) max 0;
+    if (_a > 0 && {_a < 360}) then { _sectorN = [_b, _a]; };
+};
+
+// Normalise the duty cycle: [] constant, or a valid [on, off] with a positive period.
+private _dutyN = [];
+if (_duty isEqualType [] && {count _duty == 2}) then {
+    private _onT = (_duty select 0) max 0;
+    private _offT = (_duty select 1) max 0;
+    if ((_onT + _offT) > 0 && {_offT > 0}) then { _dutyN = [_onT, _offT]; };
+};
+
 // Clamp strength into a sane range.
 _strength = (_strength max 0) min 1;
 
@@ -106,11 +130,12 @@ if (_marker) then {
     };
 };
 
-private _entry = [_id, _object, _radius, _falloff, _sidesN, _bandsN, _strength, _active, _markerName];
+private _entry = [_id, _object, _radius, _falloff, _sidesN, _bandsN, _strength, _active, _markerName, _sectorN, _dutyN];
 
 // Replace an existing entry for this id, else append.
 private _registry = missionNamespace getVariable ["Waldo_Jamming_Registry", []];
 private _idx = _registry findIf { (_x select 0) == _id };
+private _isNew = _idx < 0;
 if (_idx >= 0) then {
     // Preserve any marker created previously if this call did not make one.
     if (_markerName == "") then { _entry set [8, (_registry select _idx) select 8]; };
@@ -120,6 +145,19 @@ if (_idx >= 0) then {
 };
 missionNamespace setVariable ["Waldo_Jamming_Registry", _registry, true];
 
-diag_log format ["[WMP JAM] Jammer %1 registered: radius=%2 falloff=%3 sides=%4 active=%5", _id, _radius, _falloff, _sidesN, _active];
+// Destructible jammers: auto-deregister when the emitter is destroyed (EW objectives for free).
+if (_isNew && {missionNamespace getVariable ["Waldo_Jamming_Destructible", true]}) then {
+    _object addEventHandler ["Killed", {
+        params ["_deadObj"];
+        [_deadObj] call Waldo_fnc_JammerRemove;
+    }];
+};
+
+// Install the player ACE interaction (toggle / detonate) on every machine for this emitter.
+if (_isNew) then {
+    [_object] remoteExec ["Waldo_fnc_JammerInteraction", 0, true];
+};
+
+diag_log format ["[WMP JAM] Jammer %1 registered: radius=%2 falloff=%3 sides=%4 sector=%5 duty=%6 active=%7", _id, _radius, _falloff, _sidesN, _sectorN, _dutyN, _active];
 
 _id

--- a/MissionScripts/MissionInit/Jamming/jammerInteraction.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammerInteraction.sqf
@@ -1,0 +1,63 @@
+/*
+ * Author: Waldo
+ * Adds the player-facing ACE interaction on a jammer emitter so an EW team can deal with a jammer
+ * in the field without Zeus: a "Toggle Radio Jammer" action (anyone) that switches it on/off, and
+ * a "Disable Radio Jammer" action (engineers, if ACE) that destroys the emitter - which, with
+ * destructible jammers on, auto-deregisters it. Broadcast to every client from Waldo_fnc_Jammer
+ * when a jammer is created, and re-run for JIP. Silently does nothing without ACE interaction.
+ *
+ * Arguments:
+ * 0: Object <OBJECT> - the jammer emitter to add the actions to
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [myJammer] call Waldo_fnc_JammerInteraction;
+ */
+
+params [["_object", objNull]];
+
+if !(hasInterface) exitWith {};
+if (isNull _object) exitWith {};
+if !(isClass (configFile >> "CfgPatches" >> "ace_interact_menu")) exitWith {};
+if (_object getVariable ["Waldo_Jamming_AceAdded", false]) exitWith {};
+_object setVariable ["Waldo_Jamming_AceAdded", true];
+
+// Toggle on/off - available to anyone who can reach the emitter.
+private _toggle = [
+    "Waldo_Jammer_Toggle",
+    "Toggle Radio Jammer",
+    "\a3\ui_f\data\igui\cfg\simpletasks\types\interact_ca.paa",
+    {
+        params ["_target", "_player"];
+        [_target] call Waldo_fnc_JammerToggle;
+    },
+    {
+        params ["_target"];
+        (_target getVariable ["Waldo_Jamming_Id", -1]) >= 0
+    }
+] call ace_interact_menu_fnc_createAction;
+[_object, 0, ["ACE_MainActions"], _toggle] call ace_interact_menu_fnc_addActionToObject;
+
+// Disable/destroy - engineers only (if ACE common is present to test for it).
+private _disable = [
+    "Waldo_Jammer_Disable",
+    "Disable Radio Jammer",
+    "\a3\ui_f\data\igui\cfg\simpletasks\types\danger_ca.paa",
+    {
+        params ["_target", "_player"];
+        // Destroying the emitter triggers its Killed handler, which deregisters the jammer.
+        [_target, 1] remoteExec ["setDamage", _target];
+        [_target] call Waldo_fnc_JammerRemove;
+    },
+    {
+        params ["_target", "_player"];
+        private _isEng = true;
+        if (isClass (configFile >> "CfgPatches" >> "ace_common")) then {
+            _isEng = [_player] call ace_common_fnc_isEngineer;
+        };
+        _isEng && {(_target getVariable ["Waldo_Jamming_Id", -1]) >= 0}
+    }
+] call ace_interact_menu_fnc_createAction;
+[_object, 0, ["ACE_MainActions"], _disable] call ace_interact_menu_fnc_addActionToObject;

--- a/MissionScripts/MissionInit/Jamming/jammerMapDraw.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammerMapDraw.sqf
@@ -1,0 +1,53 @@
+/*
+ * Author: Waldo
+ * Game-master overlay for the jamming system. Draws a floating icon and label above every active
+ * jammer, plus its facing line for directional jammers, so a curator can see the electronic order
+ * of battle in the world. Visible only to local curators (Zeus) - ordinary players never see it,
+ * so it never leaks jammer positions. Registers a single Draw3D mission event handler that reads
+ * the live registry each frame. Controlled by Waldo_Jamming_GmOverlay. Client-only, single instance.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [] call Waldo_fnc_JammerMapDraw;
+ */
+
+if !(hasInterface) exitWith {};
+if (missionNamespace getVariable ["Waldo_Jamming_OverlayRunning", false]) exitWith {};
+missionNamespace setVariable ["Waldo_Jamming_OverlayRunning", true];
+
+addMissionEventHandler ["Draw3D", {
+    if !(missionNamespace getVariable ["Waldo_Jamming_GmOverlay", true]) exitWith {};
+    // Curators only.
+    if (isNull (getAssignedCuratorLogic player)) exitWith {};
+
+    private _registry = missionNamespace getVariable ["Waldo_Jamming_Registry", []];
+    {
+        _x params ["_id", "_obj", "_radius", "_falloff", "_sides", "_bands", "_strength", "_active", "_mk", ["_sector", []], ["_duty", []]];
+        if (!isNull _obj) then {
+            private _col = if (_active) then { [0.85, 0.1, 0.15, 1] } else { [0.5, 0.5, 0.5, 0.8] };
+            private _pos = getPosATL _obj;
+            private _label = format ["JAMMER #%1  %2m  %3", _id, round _radius, (["OFF", "ON"] select (_active))];
+            drawIcon3D [
+                "\a3\ui_f\data\map\markers\military\dot_ca.paa",
+                _col,
+                [_pos select 0, _pos select 1, (_pos select 2) + 3],
+                0.8, 0.8, 0,
+                _label, 1, 0.03, "PuristaMedium"
+            ];
+
+            // Directional facing line.
+            if (_sector isEqualType [] && {count _sector == 2} && {(_sector select 1) < 360}) then {
+                private _bearing = _sector select 0;
+                private _tip = _obj getPos [_radius, _bearing];
+                drawLine3D [ASLToAGL (getPosASL _obj), [_tip select 0, _tip select 1, (getPosATL _obj) select 2], _col];
+            };
+        };
+    } forEach _registry;
+}];
+
+diag_log "[WMP JAM] GM jammer overlay (Draw3D) installed.";

--- a/MissionScripts/MissionInit/Jamming/jammerRemove.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammerRemove.sqf
@@ -1,0 +1,58 @@
+/*
+ * Author: Waldo
+ * Permanently removes a jammer from the registry (and its map marker), optionally deleting the
+ * emitter object too. Server-authoritative - calling on a client forwards to the server, which
+ * re-broadcasts the updated registry so the jammer stops affecting every machine.
+ *
+ * Arguments:
+ * 0: Reference <OBJECT or NUMBER> - the jammer object, or its jammer id (from Waldo_fnc_Jammer)
+ * 1: Delete object <BOOL> - also deleteVehicle the emitter object (optional, default: false)
+ *
+ * Return Value:
+ * Bool <BOOL> - true if a matching jammer was found and removed (server side)
+ *
+ * Example:
+ * [myJammer, true] call Waldo_fnc_JammerRemove;   // remove jammer and delete its object
+ * [3] call Waldo_fnc_JammerRemove;                // remove jammer id 3, keep the object
+ */
+
+params [["_ref", objNull], ["_deleteObject", false]];
+
+if (!isServer) exitWith {
+    _this remoteExec ["Waldo_fnc_JammerRemove", 2];
+    false
+};
+
+// Resolve the target id from either an object or a raw id.
+private _id = -1;
+if (_ref isEqualType objNull) then {
+    _id = _ref getVariable ["Waldo_Jamming_Id", -1];
+} else {
+    if (_ref isEqualType 0) then { _id = _ref; };
+};
+if (_id < 0) exitWith { false };
+
+private _registry = missionNamespace getVariable ["Waldo_Jamming_Registry", []];
+private _idx = _registry findIf { (_x select 0) == _id };
+if (_idx < 0) exitWith { false };
+
+private _entry = _registry select _idx;
+private _obj = _entry select 1;
+private _markerName = _entry select 8;
+
+// Tidy up the marker.
+if (_markerName != "" && {getMarkerType _markerName != ""}) then { deleteMarker _markerName; };
+
+// Drop the entry and re-broadcast.
+_registry deleteAt _idx;
+missionNamespace setVariable ["Waldo_Jamming_Registry", _registry, true];
+
+// Optionally remove the emitter object.
+if (_deleteObject && {!isNull _obj}) then {
+    _obj setVariable ["Waldo_Jamming_Id", nil, true];
+    deleteVehicle _obj;
+};
+
+diag_log format ["[WMP JAM] Jammer %1 removed.", _id];
+
+true

--- a/MissionScripts/MissionInit/Jamming/jammerScan.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammerScan.sqf
@@ -1,0 +1,69 @@
+/*
+ * Author: Waldo
+ * Handheld radio direction finding (RDF). Sweeps the jammer registry for active emitters within
+ * detection range and reports the nearest one to the operator: a compass bearing to the signal
+ * source, a coarse range estimate and a signal-strength read. Lets an EW team triangulate and
+ * hunt a jammer by taking bearings from different spots. Purely a read-out - it changes nothing.
+ * Exposed as an ACE self-interaction ("Scan for Radio Jammers") wired up in Waldo_fnc_JammingInit.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [] call Waldo_fnc_JammerScan;
+ */
+
+if !(hasInterface) exitWith {};
+
+private _registry = missionNamespace getVariable ["Waldo_Jamming_Registry", []];
+private _range = missionNamespace getVariable ["Waldo_Jamming_ScanRange", 3000];
+
+private _bestObj = objNull;
+private _bestDist = 1e11;
+{
+    _x params ["_id", "_obj", "_radius", "_falloff", "_sides", "_bands", "_strength", "_active"];
+    if (_active && {!isNull _obj}) then {
+        private _d = player distance _obj;
+        if (_d <= _range && {_d < _bestDist}) then {
+            _bestDist = _d;
+            _bestObj = _obj;
+        };
+    };
+} forEach _registry;
+
+if (isNull _bestObj) exitWith {
+    systemChat "RDF: no radio jamming sources detected in range.";
+    private _none = parseText "<t color='#3a9c3a' size='1.2' align='center'>RDF SCAN</t><br /><t size='0.9' align='center'>No jamming sources in range</t><br />";
+    [_none, 3] spawn Waldo_fnc_TimedHint;
+};
+
+private _bearing = round (player getDir _bestObj);
+private _dist = _bestDist;
+
+// Coarse range bucket so the read-out is a direction-finder, not a GPS fix.
+private _rangeTxt = "far (>2 km)";
+if (_dist <= 250) then { _rangeTxt = "very close (<250 m)"; }
+else {
+    if (_dist <= 750) then { _rangeTxt = "close (<750 m)"; }
+    else {
+        if (_dist <= 2000) then { _rangeTxt = "medium (<2 km)"; };
+    };
+};
+
+// Strength: how hard it is hitting the operator right now.
+private _factor = [getPosASL player, side player, -1] call Waldo_fnc_JammingFactor;
+private _strTxt = "weak";
+if (_factor >= 0.66) then { _strTxt = "STRONG"; }
+else {
+    if (_factor >= 0.2) then { _strTxt = "moderate"; };
+};
+
+systemChat format ["RDF: jamming source bearing %1 deg, %2, signal %3.", _bearing, _rangeTxt, _strTxt];
+private _hint = parseText format [
+    "<t color='#c8102e' size='1.2' align='center'>RDF SCAN</t><br /><t size='1.0' align='center'>Bearing %1 deg</t><br /><t size='0.9' align='center'>Range: %2</t><br /><t size='0.9' align='center'>Signal: %3</t><br />",
+    _bearing, _rangeTxt, _strTxt
+];
+[_hint, 4] spawn Waldo_fnc_TimedHint;

--- a/MissionScripts/MissionInit/Jamming/jammerToggle.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammerToggle.sqf
@@ -1,0 +1,48 @@
+/*
+ * Author: Waldo
+ * Switches a registered jammer on or off without removing it, so a mission maker or curator can
+ * flip a jammer's state from a trigger, script or Zeus module. Server-authoritative - calling on
+ * a client forwards to the server, which updates and re-broadcasts the jammer registry.
+ *
+ * Arguments:
+ * 0: Reference <OBJECT or NUMBER> - the jammer object, or its jammer id (from Waldo_fnc_Jammer)
+ * 1: Active <BOOL> - true = switch on, false = switch off (optional, default: toggles current)
+ *
+ * Return Value:
+ * Bool <BOOL> - true if a matching jammer was found and updated (server side)
+ *
+ * Example:
+ * [myJammer, false] call Waldo_fnc_JammerToggle;   // switch a jammer object off
+ * [3] call Waldo_fnc_JammerToggle;                 // flip jammer id 3 to its opposite state
+ */
+
+params [["_ref", objNull], ["_active", "TOGGLE"]];
+
+if (!isServer) exitWith {
+    _this remoteExec ["Waldo_fnc_JammerToggle", 2];
+    false
+};
+
+// Resolve the target id from either an object or a raw id.
+private _id = -1;
+if (_ref isEqualType objNull) then {
+    _id = _ref getVariable ["Waldo_Jamming_Id", -1];
+} else {
+    if (_ref isEqualType 0) then { _id = _ref; };
+};
+if (_id < 0) exitWith { false };
+
+private _registry = missionNamespace getVariable ["Waldo_Jamming_Registry", []];
+private _idx = _registry findIf { (_x select 0) == _id };
+if (_idx < 0) exitWith { false };
+
+private _entry = _registry select _idx;
+private _new = _active;
+if (_active isEqualType "") then { _new = !(_entry select 7); };
+_entry set [7, _new];
+_registry set [_idx, _entry];
+missionNamespace setVariable ["Waldo_Jamming_Registry", _registry, true];
+
+diag_log format ["[WMP JAM] Jammer %1 set active=%2", _id, _new];
+
+true

--- a/MissionScripts/MissionInit/Jamming/jammingAcreSignal.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammingAcreSignal.sqf
@@ -1,0 +1,82 @@
+/*
+ * Author: Waldo
+ * Installs the ACRE2 side of the jamming system. ACRE2 has no built-in jammer API - the only
+ * hook is a single custom signal function (acre_api_fnc_setCustomSignalFunc) which ACRE2 calls
+ * whenever it works out how well one radio hears another. This installs a function that first
+ * asks ACRE2 for the normal signal (acre_sys_signal_fnc_getSignalCore) and then attenuates it by
+ * the jammer registry: if either the receiving or the transmitting radio sits inside an active
+ * jammer field that affects the local player's side (and matches the band), the received signal
+ * strength and audio power are pushed down toward the noise floor. With no active jammers it
+ * returns ACRE2's own result unchanged, so it has zero gameplay effect until a jammer exists.
+ *
+ * Client-local (audio is calculated per client). Only one custom signal function can exist at a
+ * time in ACRE2, so this owns that hook while the jamming feature is enabled. Requires ACRE2's
+ * signal model to be "LOS Multipath" (the default) or "Arcade" - the custom hook is not called
+ * under "LOS Simple".
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [] call Waldo_fnc_JammingAcreSignal;
+ */
+
+if !(hasInterface) exitWith {};
+if !(isClass (configFile >> "CfgPatches" >> "acre_main")) exitWith {};
+if (missionNamespace getVariable ["Waldo_Jamming_AcreInstalled", false]) exitWith {};
+missionNamespace setVariable ["Waldo_Jamming_AcreInstalled", true];
+
+// Wait until ACRE2 is initialised before touching its signal hook.
+[] spawn {
+    waitUntil { sleep 1; [] call acre_api_fnc_isInitialized };
+
+    private _jamFunc = {
+        // ACRE2 passes [frequencyMHz, powerMilliwatts, receiverRadioId, transmitterRadioId].
+        params ["_freq", "_power", "_rxId", "_txId"];
+
+        // Baseline: ask ACRE2 for its normal calculation so we only ever attenuate from it.
+        private _base = [1, -60];
+        if !(isNil "acre_sys_signal_fnc_getSignalCore") then {
+            _base = _this call acre_sys_signal_fnc_getSignalCore;
+        };
+
+        private _registry = missionNamespace getVariable ["Waldo_Jamming_Registry", []];
+        if (_registry isEqualTo []) exitWith { _base };
+
+        // Jam if either endpoint is inside a field affecting our side on this band.
+        private _sidePlayer = side player;
+        private _rxPos = [];
+        private _txPos = [];
+        if !(isNil "acre_sys_radio_fnc_getRadioPos") then {
+            _rxPos = [_rxId] call acre_sys_radio_fnc_getRadioPos;
+            _txPos = [_txId] call acre_sys_radio_fnc_getRadioPos;
+        } else {
+            // Fallback if the helper is unavailable: the receiver is the local player.
+            _rxPos = getPosASL player;
+        };
+
+        private _f1 = 0;
+        if (_rxPos isEqualType [] && {count _rxPos >= 3}) then {
+            _f1 = [_rxPos, _sidePlayer, _freq] call Waldo_fnc_JammingFactor;
+        };
+        private _f2 = 0;
+        if (_txPos isEqualType [] && {count _txPos >= 3}) then {
+            _f2 = [_txPos, _sidePlayer, _freq] call Waldo_fnc_JammingFactor;
+        };
+
+        private _jam = _f1 max _f2;
+        if (_jam <= 0) exitWith { _base };
+
+        _base params ["_pct", "_dbm"];
+        _pct = (_pct * (1 - _jam)) max 0;
+        // Push received strength down toward / below the noise floor so ACRE2 garbles then drops it.
+        _dbm = _dbm - (_jam * 130);
+        [_pct, _dbm]
+    };
+
+    [_jamFunc] call acre_api_fnc_setCustomSignalFunc;
+    diag_log "[WMP JAM] ACRE2 custom signal function installed for localised jamming.";
+};

--- a/MissionScripts/MissionInit/Jamming/jammingAcreSignal.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammingAcreSignal.sqf
@@ -60,11 +60,11 @@ missionNamespace setVariable ["Waldo_Jamming_AcreInstalled", true];
 
         private _f1 = 0;
         if (_rxPos isEqualType [] && {count _rxPos >= 3}) then {
-            _f1 = [_rxPos, _sidePlayer, _freq] call Waldo_fnc_JammingFactor;
+            _f1 = [_rxPos, _sidePlayer, _freq, _power] call Waldo_fnc_JammingFactor;
         };
         private _f2 = 0;
         if (_txPos isEqualType [] && {count _txPos >= 3}) then {
-            _f2 = [_txPos, _sidePlayer, _freq] call Waldo_fnc_JammingFactor;
+            _f2 = [_txPos, _sidePlayer, _freq, _power] call Waldo_fnc_JammingFactor;
         };
 
         private _jam = _f1 max _f2;

--- a/MissionScripts/MissionInit/Jamming/jammingFactor.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammingFactor.sqf
@@ -1,62 +1,126 @@
 /*
  * Author: Waldo
- * Shared jamming-strength calculator. Given a world position, a side and (optionally) a
- * radio frequency, returns how strongly the active jammer registry jams that point, from
- * 0 (no jamming) to 1 (total blackout). Used by both radio engines (ACRE2 signal function
- * and the TFAR loop) and by the on-screen "jamming detected" watcher, so every part of the
- * system agrees on where a jammer reaches. Runs anywhere - it only reads the broadcast
- * registry; it never changes state. Kept lean because the ACRE2 signal path calls it often.
+ * Shared jamming-strength calculator - the heart of the jamming model. Given a world position, a
+ * side and (optionally) a radio frequency and radio power, it returns how strongly the active
+ * jammer registry jams that point, from 0 (clear) to 1 (total blackout). Every part of the system
+ * (the ACRE2 signal function, the TFAR loop, the on-screen meter, the RDF detector and the GM
+ * overlay) routes through this so they all agree on where each jammer reaches.
+ *
+ * It applies the full model per jammer: active + duty-cycle window, affected-sides filter,
+ * frequency-band filter (ACRE2), a directional cone (bearing + arc), terrain line-of-sight
+ * occlusion, radio-power burn-through (stronger radios shrink the effective field) and a
+ * linear or inverse-square falloff. Reads only broadcast state; never changes anything. Kept as
+ * lean as the feature set allows because the ACRE2 path calls it often.
+ *
+ * Model toggles (missionNamespace, set in init.sqf):
+ *   Waldo_Jamming_LOS            - true = terrain blocks jamming (default true)
+ *   Waldo_Jamming_BurnThrough    - true = radio power resists jamming (default true)
+ *   Waldo_Jamming_BurnThroughRef - reference radio power in mW (default 500)
+ *   Waldo_Jamming_Curve          - "LINEAR" or "INVSQ" falloff (default "LINEAR")
  *
  * Arguments:
- * 0: Position <ARRAY> - ASL position to test (e.g. a radio position or getPosASL player)
+ * 0: Position <ARRAY> - ASL position to test (a radio position or getPosASL player)
  * 1: Side <SIDE> - the side of the receiver being tested (for the affected-sides filter)
- * 2: Frequency <NUMBER> - frequency in MHz to test against jammer bands, or -1 to ignore
- *                         band filtering (broadband, used by TFAR) (optional, default: -1)
+ * 2: Frequency <NUMBER> - MHz to test against jammer bands, or -1 to ignore bands (optional, default: -1)
+ * 3: Radio power <NUMBER> - transmit power in mW for burn-through, or -1 to skip it (optional, default: -1)
  *
  * Return Value:
  * Number <NUMBER> - strongest jamming factor at this point, 0..1
  *
  * Example:
- * private _jam = [getPosASL player, side player, -1] call Waldo_fnc_JammingFactor;
+ * private _jam = [getPosASL player, side player, 45, 5000] call Waldo_fnc_JammingFactor;
  */
 
-params ["_pos", "_side", ["_freq", -1]];
+params ["_pos", "_side", ["_freq", -1], ["_power", -1]];
 
 private _registry = missionNamespace getVariable ["Waldo_Jamming_Registry", []];
 if (_registry isEqualTo []) exitWith { 0 };
 if !(_pos isEqualType []) exitWith { 0 };
 if (count _pos < 3) exitWith { 0 };
 
+private _useLos = missionNamespace getVariable ["Waldo_Jamming_LOS", true];
+private _useBurn = missionNamespace getVariable ["Waldo_Jamming_BurnThrough", true];
+private _burnRef = missionNamespace getVariable ["Waldo_Jamming_BurnThroughRef", 500];
+private _curve = missionNamespace getVariable ["Waldo_Jamming_Curve", "LINEAR"];
+private _now = serverTime;
+
 private _max = 0;
 
 {
-    _x params ["_id", "_obj", "_radius", "_falloff", "_sides", "_bands", "_strength", "_active"];
+    _x params ["_id", "_obj", "_radius", "_falloff", "_sides", "_bands", "_strength", "_active", "_mk", ["_sector", []], ["_duty", []]];
 
-    if (_active && {!isNull _obj}) then {
-        // Affected-sides filter: "ALL" (string) hits everyone, else the receiver's side must be listed.
-        private _sideOk = (_sides isEqualType "") || {_side in _sides};
+    private _skip = !(_active) || {isNull _obj};
 
-        // Frequency-band filter (ACRE2 only): a frequency of -1 means broadband (ignore bands).
-        private _bandOk = true;
-        if (_sideOk && {_freq >= 0} && {!(_bands isEqualType "")}) then {
-            _bandOk = false;
-            {
-                if (_freq >= (_x select 0) && {_freq <= (_x select 1)}) exitWith { _bandOk = true; };
-            } forEach _bands;
+    // Duty cycle: only jam during the "on" slice of the on/off period.
+    if (!_skip && {_duty isEqualType []} && {count _duty == 2}) then {
+        private _onT = _duty select 0;
+        private _offT = _duty select 1;
+        private _period = _onT + _offT;
+        if (_period > 0) then {
+            if ((_now % _period) >= _onT) then { _skip = true; };
+        };
+    };
+
+    // Affected-sides filter: "ALL" (string) hits everyone, else the receiver's side must be listed.
+    if (!_skip) then {
+        if !((_sides isEqualType "") || {_side in _sides}) then { _skip = true; };
+    };
+
+    // Frequency-band filter (ACRE2 only): -1 frequency means broadband (ignore bands).
+    if (!_skip && {_freq >= 0} && {!(_bands isEqualType "")}) then {
+        private _bandOk = false;
+        {
+            if (_freq >= (_x select 0) && {_freq <= (_x select 1)}) exitWith { _bandOk = true; };
+        } forEach _bands;
+        if (!_bandOk) then { _skip = true; };
+    };
+
+    if (!_skip) then {
+        private _jPos = getPosASL _obj;
+
+        // Directional cone: skip if the target lies outside the jammer's arc.
+        if (_sector isEqualType [] && {count _sector == 2} && {(_sector select 1) < 360}) then {
+            private _bearing = _sector select 0;
+            private _arc = _sector select 1;
+            private _to = _obj getDir _pos;
+            private _diff = abs (((_to - _bearing) + 540) % 360 - 180);
+            if (_diff > (_arc / 2)) then { _skip = true; };
         };
 
-        if (_sideOk && _bandOk) then {
-            private _d = _pos distance (getPosASL _obj);
-            private _f = 0;
-            if (_d <= _radius) then {
-                _f = 1;
-            } else {
-                if (_falloff > 0 && {_d <= (_radius + _falloff)}) then {
-                    _f = (_radius + _falloff - _d) / _falloff;
-                };
+        if (!_skip) then {
+            // Terrain line-of-sight: a hill or ridge between jammer and radio blocks the field.
+            private _blocked = false;
+            if (_useLos) then {
+                _blocked = terrainIntersectASL [[_jPos select 0, _jPos select 1, (_jPos select 2) + 2], _pos];
             };
-            _f = _f * _strength;
-            if (_f > _max) then { _max = _f; };
+
+            if (!_blocked) then {
+                // Burn-through: a higher-power link shrinks the jammer's effective reach.
+                private _effR = _radius;
+                private _effF = _falloff;
+                if (_useBurn && {_power > 0} && {_burnRef > 0}) then {
+                    private _ratio = _power / _burnRef;
+                    if (_ratio > 1) then {
+                        private _scale = 1 / (_ratio ^ 0.35);
+                        _effR = _radius * _scale;
+                        _effF = _falloff * _scale;
+                    };
+                };
+
+                private _d = _pos distance _jPos;
+                private _f = 0;
+                if (_d <= _effR) then {
+                    _f = 1;
+                } else {
+                    if (_effF > 0 && {_d <= (_effR + _effF)}) then {
+                        private _t = (_effR + _effF - _d) / _effF;
+                        if (_curve == "INVSQ") then { _f = _t * _t; } else { _f = _t; };
+                    };
+                };
+
+                _f = _f * _strength;
+                if (_f > _max) then { _max = _f; };
+            };
         };
     };
 } forEach _registry;

--- a/MissionScripts/MissionInit/Jamming/jammingFactor.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammingFactor.sqf
@@ -1,0 +1,64 @@
+/*
+ * Author: Waldo
+ * Shared jamming-strength calculator. Given a world position, a side and (optionally) a
+ * radio frequency, returns how strongly the active jammer registry jams that point, from
+ * 0 (no jamming) to 1 (total blackout). Used by both radio engines (ACRE2 signal function
+ * and the TFAR loop) and by the on-screen "jamming detected" watcher, so every part of the
+ * system agrees on where a jammer reaches. Runs anywhere - it only reads the broadcast
+ * registry; it never changes state. Kept lean because the ACRE2 signal path calls it often.
+ *
+ * Arguments:
+ * 0: Position <ARRAY> - ASL position to test (e.g. a radio position or getPosASL player)
+ * 1: Side <SIDE> - the side of the receiver being tested (for the affected-sides filter)
+ * 2: Frequency <NUMBER> - frequency in MHz to test against jammer bands, or -1 to ignore
+ *                         band filtering (broadband, used by TFAR) (optional, default: -1)
+ *
+ * Return Value:
+ * Number <NUMBER> - strongest jamming factor at this point, 0..1
+ *
+ * Example:
+ * private _jam = [getPosASL player, side player, -1] call Waldo_fnc_JammingFactor;
+ */
+
+params ["_pos", "_side", ["_freq", -1]];
+
+private _registry = missionNamespace getVariable ["Waldo_Jamming_Registry", []];
+if (_registry isEqualTo []) exitWith { 0 };
+if !(_pos isEqualType []) exitWith { 0 };
+if (count _pos < 3) exitWith { 0 };
+
+private _max = 0;
+
+{
+    _x params ["_id", "_obj", "_radius", "_falloff", "_sides", "_bands", "_strength", "_active"];
+
+    if (_active && {!isNull _obj}) then {
+        // Affected-sides filter: "ALL" (string) hits everyone, else the receiver's side must be listed.
+        private _sideOk = (_sides isEqualType "") || {_side in _sides};
+
+        // Frequency-band filter (ACRE2 only): a frequency of -1 means broadband (ignore bands).
+        private _bandOk = true;
+        if (_sideOk && {_freq >= 0} && {!(_bands isEqualType "")}) then {
+            _bandOk = false;
+            {
+                if (_freq >= (_x select 0) && {_freq <= (_x select 1)}) exitWith { _bandOk = true; };
+            } forEach _bands;
+        };
+
+        if (_sideOk && _bandOk) then {
+            private _d = _pos distance (getPosASL _obj);
+            private _f = 0;
+            if (_d <= _radius) then {
+                _f = 1;
+            } else {
+                if (_falloff > 0 && {_d <= (_radius + _falloff)}) then {
+                    _f = (_radius + _falloff - _d) / _falloff;
+                };
+            };
+            _f = _f * _strength;
+            if (_f > _max) then { _max = _f; };
+        };
+    };
+} forEach _registry;
+
+_max min 1

--- a/MissionScripts/MissionInit/Jamming/jammingFactor.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammingFactor.sqf
@@ -23,15 +23,18 @@
  * 1: Side <SIDE> - the side of the receiver being tested (for the affected-sides filter)
  * 2: Frequency <NUMBER> - MHz to test against jammer bands, or -1 to ignore bands (optional, default: -1)
  * 3: Radio power <NUMBER> - transmit power in mW for burn-through, or -1 to skip it (optional, default: -1)
+ * 4: UAV mode <BOOL> - true = only count jammers flagged to jam UAVs, and ignore band/burn-through
+ *                      (drones are not radios) (optional, default: false)
  *
  * Return Value:
  * Number <NUMBER> - strongest jamming factor at this point, 0..1
  *
  * Example:
  * private _jam = [getPosASL player, side player, 45, 5000] call Waldo_fnc_JammingFactor;
+ * private _uavJam = [getPosASL _drone, side _drone, -1, -1, true] call Waldo_fnc_JammingFactor;
  */
 
-params ["_pos", "_side", ["_freq", -1], ["_power", -1]];
+params ["_pos", "_side", ["_freq", -1], ["_power", -1], ["_uavMode", false]];
 
 private _registry = missionNamespace getVariable ["Waldo_Jamming_Registry", []];
 if (_registry isEqualTo []) exitWith { 0 };
@@ -47,9 +50,12 @@ private _now = serverTime;
 private _max = 0;
 
 {
-    _x params ["_id", "_obj", "_radius", "_falloff", "_sides", "_bands", "_strength", "_active", "_mk", ["_sector", []], ["_duty", []]];
+    _x params ["_id", "_obj", "_radius", "_falloff", "_sides", "_bands", "_strength", "_active", "_mk", ["_sector", []], ["_duty", []], ["_jamUAV", false]];
 
     private _skip = !(_active) || {isNull _obj};
+
+    // UAV mode only counts jammers explicitly set to jam drones; radio mode counts all jammers.
+    if (!_skip && {_uavMode} && {!_jamUAV}) then { _skip = true; };
 
     // Duty cycle: only jam during the "on" slice of the on/off period.
     if (!_skip && {_duty isEqualType []} && {count _duty == 2}) then {

--- a/MissionScripts/MissionInit/Jamming/jammingHud.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammingHud.sqf
@@ -1,35 +1,41 @@
 /*
  * Author: Waldo
- * Draws the persistent "RADIO JAMMED" HUD element. Arma's radio mods drop comms for all sorts of
- * buggy reasons, so this makes jamming unmistakable: a dedicated control on the main mission
- * display (IDC 5310) that other scripts' hints cannot overwrite, showing a blinking banner, a
- * strength bar and an explicit "this is intentional, not a bug" line while the player is jammed.
- * Passing a factor of 0 hides it. Called every tick by the watcher in Waldo_fnc_JammingInit.
+ * Draws a persistent electronic-warfare HUD element. Arma's radio and UAV systems drop out for all
+ * sorts of buggy reasons, so this makes jamming unmistakable: a dedicated control on the main
+ * mission display that other scripts' hints cannot overwrite, showing a blinking banner, a strength
+ * bar and an explicit "this is intentional, not a bug" line while active. Passing a factor of 0
+ * hides it. Reused for both radio jamming and UAV-link jamming by passing a different label and IDC.
+ * Called every tick by the watchers in Waldo_fnc_JammingInit.
  *
  * Arguments:
- * 0: Factor <NUMBER> - current jamming strength on the player, 0..1 (0 hides the HUD)
+ * 0: Factor <NUMBER> - current effect strength, 0..1 (0 hides the HUD)
+ * 1: Label <STRING> - the banner title (optional, default: "RADIO JAMMED")
+ * 2: IDC <NUMBER> - unique control id so multiple banners can coexist (optional, default: 5310)
+ * 3: Sub <STRING> - the small explanatory line (optional, default: the radio wording)
  *
  * Return Value:
  * Nothing
  *
  * Example:
- * [0.8] call Waldo_fnc_JammingHud;
+ * [0.8] call Waldo_fnc_JammingHud;                                   // radio banner
+ * [0.5, "UAV LINK JAMMED", 5311, "Drone datalink is jammed - not a game bug"] call Waldo_fnc_JammingHud;
  */
 
 if !(hasInterface) exitWith {};
 
-params [["_factor", 0]];
+params [["_factor", 0], ["_label", "RADIO JAMMED"], ["_idc", 5310], ["_sub", "Comms loss here is intentional - not a game bug"]];
 
 private _display = findDisplay 46;
 if (isNull _display) exitWith {};
 
-private _idc = 5310;
 private _ctrl = _display displayCtrl _idc;
 if (isNull _ctrl) then {
     _ctrl = _display ctrlCreate ["RscStructuredText", _idc];
+    // Stack a second banner (UAV) just below the first (radio) using the IDC offset.
+    private _row = 0.09 + (0.10 * (_idc - 5310));
     _ctrl ctrlSetPosition [
         safezoneX + safezoneW * 0.31,
-        safezoneY + safezoneH * 0.09,
+        safezoneY + safezoneH * _row,
         safezoneW * 0.38,
         safezoneH * 0.085
     ];
@@ -53,6 +59,6 @@ private _blink = (floor (diag_tickTime * 2)) % 2 == 0;
 private _col = ["#c8102e", "#ff6161"] select _blink;
 
 _ctrl ctrlSetStructuredText parseText format [
-    "<t align='center' color='%1' size='1.7' shadow='1'>RADIO JAMMED  %2%3</t><br/><t align='center' color='%1' size='1.3'>[%4]</t><br/><t align='center' color='#ffffff' size='0.85'>Comms loss here is intentional - not a game bug</t>",
-    _col, _pct, "%", _bar
+    "<t align='center' color='%1' size='1.7' shadow='1'>%2  %3%4</t><br/><t align='center' color='%1' size='1.3'>[%5]</t><br/><t align='center' color='#ffffff' size='0.85'>%6</t>",
+    _col, _label, _pct, "%", _bar, _sub
 ];

--- a/MissionScripts/MissionInit/Jamming/jammingHud.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammingHud.sqf
@@ -1,0 +1,58 @@
+/*
+ * Author: Waldo
+ * Draws the persistent "RADIO JAMMED" HUD element. Arma's radio mods drop comms for all sorts of
+ * buggy reasons, so this makes jamming unmistakable: a dedicated control on the main mission
+ * display (IDC 5310) that other scripts' hints cannot overwrite, showing a blinking banner, a
+ * strength bar and an explicit "this is intentional, not a bug" line while the player is jammed.
+ * Passing a factor of 0 hides it. Called every tick by the watcher in Waldo_fnc_JammingInit.
+ *
+ * Arguments:
+ * 0: Factor <NUMBER> - current jamming strength on the player, 0..1 (0 hides the HUD)
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [0.8] call Waldo_fnc_JammingHud;
+ */
+
+if !(hasInterface) exitWith {};
+
+params [["_factor", 0]];
+
+private _display = findDisplay 46;
+if (isNull _display) exitWith {};
+
+private _idc = 5310;
+private _ctrl = _display displayCtrl _idc;
+if (isNull _ctrl) then {
+    _ctrl = _display ctrlCreate ["RscStructuredText", _idc];
+    _ctrl ctrlSetPosition [
+        safezoneX + safezoneW * 0.31,
+        safezoneY + safezoneH * 0.09,
+        safezoneW * 0.38,
+        safezoneH * 0.085
+    ];
+    _ctrl ctrlSetBackgroundColor [0, 0, 0, 0.65];
+    _ctrl ctrlCommit 0;
+};
+
+if (_factor <= 0) exitWith { _ctrl ctrlShow false; };
+
+_ctrl ctrlShow true;
+
+private _pct = round (_factor * 100);
+private _filled = round (_factor * 10);
+private _bar = "";
+for "_i" from 1 to 10 do {
+    _bar = _bar + (["_", "#"] select (_i <= _filled));
+};
+
+// Blink between two reds so it visibly pulses and cannot be mistaken for a static UI leftover.
+private _blink = (floor (diag_tickTime * 2)) % 2 == 0;
+private _col = ["#c8102e", "#ff6161"] select _blink;
+
+_ctrl ctrlSetStructuredText parseText format [
+    "<t align='center' color='%1' size='1.7' shadow='1'>RADIO JAMMED  %2%3</t><br/><t align='center' color='%1' size='1.3'>[%4]</t><br/><t align='center' color='#ffffff' size='0.85'>Comms loss here is intentional - not a game bug</t>",
+    _col, _pct, "%", _bar
+];

--- a/MissionScripts/MissionInit/Jamming/jammingInit.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammingInit.sqf
@@ -1,0 +1,55 @@
+/*
+ * Author: Waldo
+ * Client bootstrap for the localised radio jamming system. Installs whichever radio engine is
+ * present (the ACRE2 custom signal function and/or the TFAR throttle loop) and starts a small
+ * on-screen watcher that tells the player when they enter or leave a jamming field. Runs on every
+ * client including JIP (it is called from init.sqf), and does nothing on a dedicated server since
+ * both engines are client-local and the jammer registry itself is owned/broadcast by the server
+ * through the create/toggle/remove functions. Idempotent - safe to call more than once.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [] call Waldo_fnc_JammingInit;   // called from init.sqf when Waldo_Jamming_Enable is true
+ */
+
+if !(hasInterface) exitWith {};
+
+// Install the radio engines (each self-guards on its mod being present).
+[] call Waldo_fnc_JammingAcreSignal;
+[] call Waldo_fnc_JammingTfarLoop;
+
+// Player feedback watcher - one instance per client.
+if (missionNamespace getVariable ["Waldo_Jamming_UiRunning", false]) exitWith {};
+missionNamespace setVariable ["Waldo_Jamming_UiRunning", true];
+
+[] spawn {
+    private _prev = false;
+    while {true} do {
+        private _registry = missionNamespace getVariable ["Waldo_Jamming_Registry", []];
+        private _jammed = false;
+        if !(_registry isEqualTo []) then {
+            if (alive player) then {
+                _jammed = ([getPosASL player, side player, -1] call Waldo_fnc_JammingFactor) > 0;
+            };
+        };
+
+        if (missionNamespace getVariable ["Waldo_Jamming_Notify", true]) then {
+            if (_jammed && {!_prev}) then {
+                systemChat "RADIO JAMMING DETECTED - communications degraded in this area.";
+                private _msg = parseText "<t color='#c8102e' size='1.4' shadow='1' align='center'>RADIO JAMMED</t><br /><t size='0.9' align='center'>Comms degraded in this area</t><br />";
+                [_msg, 3] spawn Waldo_fnc_TimedHint;
+            };
+            if (!_jammed && {_prev}) then {
+                systemChat "Radio jamming cleared - communications restored.";
+            };
+        };
+
+        _prev = _jammed;
+        sleep 2;
+    };
+};

--- a/MissionScripts/MissionInit/Jamming/jammingInit.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammingInit.sqf
@@ -1,11 +1,11 @@
 /*
  * Author: Waldo
  * Client bootstrap for the localised radio jamming system. Installs whichever radio engine is
- * present (the ACRE2 custom signal function and/or the TFAR throttle loop) and starts a small
- * on-screen watcher that tells the player when they enter or leave a jamming field. Runs on every
- * client including JIP (it is called from init.sqf), and does nothing on a dedicated server since
- * both engines are client-local and the jammer registry itself is owned/broadcast by the server
- * through the create/toggle/remove functions. Idempotent - safe to call more than once.
+ * present (the ACRE2 custom signal function and/or the TFAR throttle loop), starts a graduated
+ * on-screen jamming meter, registers the handheld RDF "Scan for Radio Jammers" ACE self-action,
+ * and starts the game-master Draw3D overlay. Runs on every client including JIP (called from
+ * init.sqf) and does nothing on a dedicated server, since the engines are client-local and the
+ * jammer registry is owned/broadcast by the server. Idempotent - safe to call more than once.
  *
  * Arguments:
  * None
@@ -23,33 +23,74 @@ if !(hasInterface) exitWith {};
 [] call Waldo_fnc_JammingAcreSignal;
 [] call Waldo_fnc_JammingTfarLoop;
 
-// Player feedback watcher - one instance per client.
+// Game-master 3D overlay (curators only).
+[] call Waldo_fnc_JammerMapDraw;
+
+// Handheld RDF detector as an ACE self-interaction.
+if (isClass (configFile >> "CfgPatches" >> "ace_interact_menu")) then {
+    if !(missionNamespace getVariable ["Waldo_Jamming_ScanActionAdded", false]) then {
+        missionNamespace setVariable ["Waldo_Jamming_ScanActionAdded", true];
+        private _scan = [
+            "Waldo_Jammer_Scan",
+            "Scan for Radio Jammers",
+            "\a3\ui_f\data\igui\cfg\simpletasks\types\radio_ca.paa",
+            { [] call Waldo_fnc_JammerScan; },
+            { (count (missionNamespace getVariable ["Waldo_Jamming_Registry", []])) > 0 }
+        ] call ace_interact_menu_fnc_createAction;
+        [player, 1, ["ACE_SelfActions"], _scan] call ace_interact_menu_fnc_addActionToObject;
+    };
+};
+
+// Player feedback watcher - one instance per client. Uses the persistent HUD (Waldo_fnc_JammingHud)
+// plus enter/leave banners and a periodic chat reminder, so a jam is never confused with a game bug.
 if (missionNamespace getVariable ["Waldo_Jamming_UiRunning", false]) exitWith {};
 missionNamespace setVariable ["Waldo_Jamming_UiRunning", true];
 
 [] spawn {
     private _prev = false;
+    private _lastChat = -999;
     while {true} do {
         private _registry = missionNamespace getVariable ["Waldo_Jamming_Registry", []];
-        private _jammed = false;
+        private _factor = 0;
         if !(_registry isEqualTo []) then {
             if (alive player) then {
-                _jammed = ([getPosASL player, side player, -1] call Waldo_fnc_JammingFactor) > 0;
+                _factor = [getPosASL player, side player, -1] call Waldo_fnc_JammingFactor;
             };
         };
+        private _jammed = _factor > 0;
+        private _notify = missionNamespace getVariable ["Waldo_Jamming_Notify", true];
 
-        if (missionNamespace getVariable ["Waldo_Jamming_Notify", true]) then {
-            if (_jammed && {!_prev}) then {
-                systemChat "RADIO JAMMING DETECTED - communications degraded in this area.";
-                private _msg = parseText "<t color='#c8102e' size='1.4' shadow='1' align='center'>RADIO JAMMED</t><br /><t size='0.9' align='center'>Comms degraded in this area</t><br />";
-                [_msg, 3] spawn Waldo_fnc_TimedHint;
+        if (_notify) then {
+            // Persistent, un-clobberable HUD banner (hidden when _factor is 0).
+            [_factor] call Waldo_fnc_JammingHud;
+
+            if (_jammed) then {
+                // Loud, explicit entry banner the first time.
+                if (!_prev) then {
+                    systemChat "*** RADIO JAMMING ACTIVE - your comms are being jammed (this is intentional, not a bug). ***";
+                    private _in = parseText "<t color='#c8102e' size='2' shadow='1' align='center'>RADIO JAMMED</t><br /><t size='1' align='center'>Comms in this area are being jammed - not a game bug</t><br />";
+                    [_in, 4] spawn Waldo_fnc_TimedHint;
+                    _lastChat = time;
+                };
+                // Periodic reminder so a long jam keeps signalling in the chat log too.
+                if (time - _lastChat >= 8) then {
+                    systemChat format ["~~ RADIO JAMMED (%1%2 strength) - transmissions unreliable here. ~~", round (_factor * 100), "%"];
+                    _lastChat = time;
+                };
+            } else {
+                if (_prev) then {
+                    systemChat "RADIO JAMMING CLEARED - communications restored.";
+                    private _out = parseText "<t color='#3a9c3a' size='1.8' shadow='1' align='center'>COMMS RESTORED</t><br />";
+                    [_out, 3] spawn Waldo_fnc_TimedHint;
+                };
             };
-            if (!_jammed && {_prev}) then {
-                systemChat "Radio jamming cleared - communications restored.";
-            };
+        } else {
+            // Notifications off: still make sure the HUD is not left showing.
+            [0] call Waldo_fnc_JammingHud;
         };
 
         _prev = _jammed;
-        sleep 2;
+        // Tighter tick while jammed so the meter blinks and tracks movement smoothly.
+        sleep ([2, 0.5] select _jammed);
     };
 };

--- a/MissionScripts/MissionInit/Jamming/jammingInit.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammingInit.sqf
@@ -17,19 +17,32 @@
  * [] call Waldo_fnc_JammingInit;   // called from init.sqf when Waldo_Jamming_Enable is true
  */
 
+// Server authority for UAV/UGV jamming (freezes autonomous drones in a UAV-jamming field).
+if (isServer) then {
+    [] call Waldo_fnc_JammingUavServer;
+};
+
 if !(hasInterface) exitWith {};
 
 // Install the radio engines (each self-guards on its mod being present).
 [] call Waldo_fnc_JammingAcreSignal;
 [] call Waldo_fnc_JammingTfarLoop;
 
+// Local UAV datalink jamming (disconnects a controlled drone + feed degrade + HUD).
+[] call Waldo_fnc_JammingUavClient;
+
 // Game-master 3D overlay (curators only).
 [] call Waldo_fnc_JammerMapDraw;
 
-// Handheld RDF detector as an ACE self-interaction.
+// Signal tracker map rendering (side-restricted local markers).
+[] call Waldo_fnc_TrackerRender;
+
+// ACE interactions: handheld RDF detector + "plant tracker" on units and vehicles.
 if (isClass (configFile >> "CfgPatches" >> "ace_interact_menu")) then {
     if !(missionNamespace getVariable ["Waldo_Jamming_ScanActionAdded", false]) then {
         missionNamespace setVariable ["Waldo_Jamming_ScanActionAdded", true];
+
+        // Handheld RDF detector as an ACE self-interaction.
         private _scan = [
             "Waldo_Jammer_Scan",
             "Scan for Radio Jammers",
@@ -38,6 +51,23 @@ if (isClass (configFile >> "CfgPatches" >> "ace_interact_menu")) then {
             { (count (missionNamespace getVariable ["Waldo_Jamming_Registry", []])) > 0 }
         ] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions"], _scan] call ace_interact_menu_fnc_addActionToObject;
+
+        // "Plant Signal Tracker" on any unit or vehicle you can reach.
+        private _plant = [
+            "Waldo_Tracker_Plant",
+            "Plant Signal Tracker",
+            "\a3\ui_f\data\igui\cfg\simpletasks\types\track_ca.paa",
+            {
+                params ["_target", "_player"];
+                [_target] call Waldo_fnc_TrackerAttach;
+            },
+            {
+                params ["_target", "_player"];
+                !isNull _target && {_target != _player} && {alive _target}
+            }
+        ] call ace_interact_menu_fnc_createAction;
+        ["CAManBase", 0, ["ACE_MainActions"], _plant] call ace_interact_menu_fnc_addActionToClass;
+        ["AllVehicles", 0, ["ACE_MainActions"], _plant] call ace_interact_menu_fnc_addActionToClass;
     };
 };
 

--- a/MissionScripts/MissionInit/Jamming/jammingTfarLoop.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammingTfarLoop.sqf
@@ -1,0 +1,65 @@
+/*
+ * Author: Waldo
+ * Installs the TFAR side of the jamming system. TFAR has no signal hook like ACRE2, but it does
+ * expose client-side unit variables that scale how far a player can receive/transmit and whether
+ * they can use a radio at all. This runs a lightweight per-client loop that checks the local
+ * player against the jammer registry and, when they are inside an active field affecting their
+ * side, throttles their TFAR reception and transmission (and fully cuts the radio at near-total
+ * jamming). It restores the variables to normal when the player leaves the field. TFAR jamming is
+ * always broadband - the per-band filter is an ACRE2-only feature.
+ *
+ * Client-local. Works for Task Force Radio (legacy) and TFAR (task_force_radio / tfar_core).
+ * The loop uses the current player each tick, so it survives respawns automatically.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [] call Waldo_fnc_JammingTfarLoop;
+ */
+
+if !(hasInterface) exitWith {};
+
+private _tfar = isClass (configFile >> "CfgPatches" >> "task_force_radio")
+    || {isClass (configFile >> "CfgPatches" >> "tfar_core")};
+if !(_tfar) exitWith {};
+
+if (missionNamespace getVariable ["Waldo_Jamming_TfarRunning", false]) exitWith {};
+missionNamespace setVariable ["Waldo_Jamming_TfarRunning", true];
+
+[] spawn {
+    private _wasJammed = false;
+    while {true} do {
+        private _registry = missionNamespace getVariable ["Waldo_Jamming_Registry", []];
+        private _jam = 0;
+        if !(_registry isEqualTo []) then {
+            if (alive player) then {
+                // Broadband (frequency -1): TFAR does not expose per-link frequency here.
+                _jam = [getPosASL player, side player, -1] call Waldo_fnc_JammingFactor;
+            };
+        };
+
+        if (_jam > 0) then {
+            private _mult = (1 - _jam) max 0;
+            player setVariable ["tf_receivingDistanceMultiplicator", _mult];
+            player setVariable ["tf_sendingDistanceMultiplicator", _mult];
+            player setVariable ["tf_unable_to_use_radio", (_jam >= 0.99)];
+            _wasJammed = true;
+        } else {
+            // Only restore what we changed, and only once on leaving the field.
+            if (_wasJammed) then {
+                player setVariable ["tf_receivingDistanceMultiplicator", 1];
+                player setVariable ["tf_sendingDistanceMultiplicator", 1];
+                player setVariable ["tf_unable_to_use_radio", false];
+                _wasJammed = false;
+            };
+        };
+
+        sleep 1.5;
+    };
+};
+
+diag_log "[WMP JAM] TFAR jamming loop started.";

--- a/MissionScripts/MissionInit/Jamming/jammingUavClient.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammingUavClient.sqf
@@ -1,0 +1,75 @@
+/*
+ * Author: Waldo
+ * Client side of UAV/UGV jamming - and, like the radio HUD, it is deliberately loud so a jammed
+ * drone is never mistaken for one of Arma's UAV bugs. While the local player is controlling a drone
+ * whose datalink runs into a UAV-jamming field it: degrades the video feed with a rising screen
+ * distortion as the link weakens, shows the persistent "UAV LINK JAMMED - not a game bug" HUD
+ * banner, and at near-total jamming cuts the terminal link outright with a clear message. Everything
+ * restores when the drone leaves the field or the player disconnects the terminal.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [] call Waldo_fnc_JammingUavClient;
+ */
+
+if !(hasInterface) exitWith {};
+if (missionNamespace getVariable ["Waldo_Jamming_UavClientRunning", false]) exitWith {};
+missionNamespace setVariable ["Waldo_Jamming_UavClientRunning", true];
+
+[] spawn {
+    private _pp = -1;
+    private _lastUav = objNull;
+    private _cutThisLink = false;
+
+    while {true} do {
+        private _uav = getConnectedUAV player;
+        private _factor = 0;
+        if (!isNull _uav && {alive _uav}) then {
+            _factor = [getPosASL _uav, side _uav, -1, -1, true] call Waldo_fnc_JammingFactor;
+        };
+
+        // A freshly connected drone clears the one-shot "cut" latch.
+        if (_uav != _lastUav) then {
+            _cutThisLink = false;
+            _lastUav = _uav;
+        };
+
+        private _notify = missionNamespace getVariable ["Waldo_Jamming_Notify", true];
+
+        if (_factor > 0 && {!isNull _uav}) then {
+            // Video feed degradation - chromatic tearing that gets worse as the link weakens.
+            if (_pp < 0) then { _pp = ppEffectCreate ["ChromAberration", 2200]; };
+            _pp ppEffectEnable true;
+            _pp ppEffectAdjust [0.02 * _factor, 0.02 * _factor, true];
+            _pp ppEffectCommit 0;
+
+            if (_notify) then { [_factor, "UAV LINK JAMMED", 5311, "Drone datalink is jammed - not a game bug"] call Waldo_fnc_JammingHud; };
+
+            // Hard jam: sever the terminal link once for this connection.
+            if (_factor >= 0.95 && {!_cutThisLink}) then {
+                _cutThisLink = true;
+                player connectTerminalToUAV objNull;
+                if (_notify) then {
+                    systemChat "*** UAV DATALINK LOST - your drone is being jammed (intentional, not a bug). ***";
+                    private _msg = parseText "<t color='#c8102e' size='2' shadow='1' align='center'>UAV LINK LOST</t><br /><t size='1' align='center'>Datalink jammed in this area - not a game bug</t><br />";
+                    [_msg, 4] spawn Waldo_fnc_TimedHint;
+                };
+            };
+        } else {
+            // Clear effects when not connected / not jammed.
+            if (_pp >= 0) then {
+                _pp ppEffectEnable false;
+                ppEffectDestroy _pp;
+                _pp = -1;
+            };
+            [0, "UAV LINK JAMMED", 5311] call Waldo_fnc_JammingHud;
+        };
+
+        sleep ([1.5, 0.5] select (_factor > 0));
+    };
+};

--- a/MissionScripts/MissionInit/Jamming/jammingUavServer.sqf
+++ b/MissionScripts/MissionInit/Jamming/jammingUavServer.sqf
@@ -1,0 +1,65 @@
+/*
+ * Author: Waldo
+ * Server authority for UAV/UGV jamming. While any jammer flagged to jam UAVs exists, this checks
+ * every drone against the jammer fields and, for drones inside one, freezes their autonomous AI
+ * (they stop flying/driving and hunting) and broadcasts a "jammed" flag on the drone so the
+ * controlling player's client can react. Restores the AI when the drone leaves the field. Only the
+ * server runs this so a drone is judged once, and it only does work when a UAV-jamming jammer is
+ * actually placed. Player-controlled drones are handled client-side (Waldo_fnc_JammingUavClient).
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [] call Waldo_fnc_JammingUavServer;
+ */
+
+if !(isServer) exitWith {};
+if (missionNamespace getVariable ["Waldo_Jamming_UavServerRunning", false]) exitWith {};
+missionNamespace setVariable ["Waldo_Jamming_UavServerRunning", true];
+
+[] spawn {
+    while {true} do {
+        private _registry = missionNamespace getVariable ["Waldo_Jamming_Registry", []];
+        // Only do the drone sweep if at least one active jammer is set to jam UAVs.
+        private _hasUavJammer = (_registry findIf {
+            (_x select 7) && {(count _x > 11) && {_x select 11}}
+        }) >= 0;
+
+        if (_hasUavJammer) then {
+            private _drones = vehicles select { alive _x && {unitIsUAV _x} };
+            {
+                private _drone = _x;
+                private _f = [getPosASL _drone, side _drone, -1, -1, true] call Waldo_fnc_JammingFactor;
+                private _jammed = _f > 0;
+                private _was = _drone getVariable ["Waldo_Jamming_UAVJammed", false];
+
+                if (_jammed && {!_was}) then {
+                    _drone setVariable ["Waldo_Jamming_UAVJammed", true, true];
+                    {
+                        _x disableAI "MOVE";
+                        _x disableAI "TARGET";
+                        _x disableAI "AUTOTARGET";
+                        _x disableAI "FSM";
+                    } forEach (crew _drone);
+                };
+                if (!_jammed && {_was}) then {
+                    _drone setVariable ["Waldo_Jamming_UAVJammed", false, true];
+                    {
+                        _x enableAI "MOVE";
+                        _x enableAI "TARGET";
+                        _x enableAI "AUTOTARGET";
+                        _x enableAI "FSM";
+                    } forEach (crew _drone);
+                };
+            } forEach _drones;
+        };
+
+        sleep 2;
+    };
+};
+
+diag_log "[WMP JAM] UAV jamming server authority started.";

--- a/MissionScripts/WaldosFunctions.sqf
+++ b/MissionScripts/WaldosFunctions.sqf
@@ -141,6 +141,30 @@ class CfgFunctions
                 file = "MissionScripts\MissionFlowAndUi\runDiagnostics.sqf";
             };
         };
+        class Jamming
+        {
+            class JammingInit {
+                file = "MissionScripts\MissionInit\Jamming\jammingInit.sqf";
+            };
+            class Jammer {
+                file = "MissionScripts\MissionInit\Jamming\jammerCreate.sqf";
+            };
+            class JammerToggle {
+                file = "MissionScripts\MissionInit\Jamming\jammerToggle.sqf";
+            };
+            class JammerRemove {
+                file = "MissionScripts\MissionInit\Jamming\jammerRemove.sqf";
+            };
+            class JammingFactor {
+                file = "MissionScripts\MissionInit\Jamming\jammingFactor.sqf";
+            };
+            class JammingAcreSignal {
+                file = "MissionScripts\MissionInit\Jamming\jammingAcreSignal.sqf";
+            };
+            class JammingTfarLoop {
+                file = "MissionScripts\MissionInit\Jamming\jammingTfarLoop.sqf";
+            };
+        };
         class Tasks
         {
             class CreateObjective {
@@ -258,6 +282,15 @@ class CfgFunctions
             };
             class ZenSafeStartTimer {
                 file = "MissionScripts\ZenModules\Zen_safeStartTimer.sqf";
+            };
+            class ZenJammerPlace {
+                file = "MissionScripts\ZenModules\Zen_jammerPlaceModule.sqf";
+            };
+            class ZenJammerToggle {
+                file = "MissionScripts\ZenModules\Zen_jammerToggleModule.sqf";
+            };
+            class ZenJammerRemove {
+                file = "MissionScripts\ZenModules\Zen_jammerRemoveModule.sqf";
             };
         };
         class Paradrop {

--- a/MissionScripts/WaldosFunctions.sqf
+++ b/MissionScripts/WaldosFunctions.sqf
@@ -176,6 +176,36 @@ class CfgFunctions
             class JammingHud {
                 file = "MissionScripts\MissionInit\Jamming\jammingHud.sqf";
             };
+            class JammingUavServer {
+                file = "MissionScripts\MissionInit\Jamming\jammingUavServer.sqf";
+            };
+            class JammingUavClient {
+                file = "MissionScripts\MissionInit\Jamming\jammingUavClient.sqf";
+            };
+        };
+        class ElectronicWarfare
+        {
+            class EMP {
+                file = "MissionScripts\MissionInit\ElectronicWarfare\emp.sqf";
+            };
+            class EMPApply {
+                file = "MissionScripts\MissionInit\ElectronicWarfare\empApply.sqf";
+            };
+            class EMPImmune {
+                file = "MissionScripts\MissionInit\ElectronicWarfare\empImmune.sqf";
+            };
+            class Tracker {
+                file = "MissionScripts\MissionInit\ElectronicWarfare\tracker.sqf";
+            };
+            class TrackerRemove {
+                file = "MissionScripts\MissionInit\ElectronicWarfare\trackerRemove.sqf";
+            };
+            class TrackerRender {
+                file = "MissionScripts\MissionInit\ElectronicWarfare\trackerRender.sqf";
+            };
+            class TrackerAttach {
+                file = "MissionScripts\MissionInit\ElectronicWarfare\trackerAttach.sqf";
+            };
         };
         class Tasks
         {
@@ -303,6 +333,12 @@ class CfgFunctions
             };
             class ZenJammerRemove {
                 file = "MissionScripts\ZenModules\Zen_jammerRemoveModule.sqf";
+            };
+            class ZenEMP {
+                file = "MissionScripts\ZenModules\Zen_empModule.sqf";
+            };
+            class ZenTracker {
+                file = "MissionScripts\ZenModules\Zen_trackerModule.sqf";
             };
         };
         class Paradrop {

--- a/MissionScripts/WaldosFunctions.sqf
+++ b/MissionScripts/WaldosFunctions.sqf
@@ -164,6 +164,18 @@ class CfgFunctions
             class JammingTfarLoop {
                 file = "MissionScripts\MissionInit\Jamming\jammingTfarLoop.sqf";
             };
+            class JammerInteraction {
+                file = "MissionScripts\MissionInit\Jamming\jammerInteraction.sqf";
+            };
+            class JammerScan {
+                file = "MissionScripts\MissionInit\Jamming\jammerScan.sqf";
+            };
+            class JammerMapDraw {
+                file = "MissionScripts\MissionInit\Jamming\jammerMapDraw.sqf";
+            };
+            class JammingHud {
+                file = "MissionScripts\MissionInit\Jamming\jammingHud.sqf";
+            };
         };
         class Tasks
         {

--- a/MissionScripts/ZenModules/Zen_empModule.sqf
+++ b/MissionScripts/ZenModules/Zen_empModule.sqf
@@ -1,0 +1,36 @@
+/*
+ * Author: Waldo
+ * Zeus module handler: prompts the curator for an EMP radius and duration, then detonates an
+ * electromagnetic pulse at the module position (Waldo_fnc_EMP). The pulse is server-authoritative;
+ * this just gathers the parameters and forwards them.
+ *
+ * Arguments:
+ * 0: modulePos <ARRAY> - position the curator placed the module
+ * 1: objectPos <OBJECT> - object the module was dropped on (unused)
+ *
+ * Example:
+ * [_modulePos, _objectPos] call Waldo_fnc_ZenEMP;
+ *
+ * Public: No
+ */
+
+if !(isClass (configFile >> "CfgPatches" >> "zen_main")) exitWith {};
+
+params ["_modulePos", "_objectPos"];
+
+[
+    "EMP Detonation",
+    [
+        ["SLIDER", ["Radius (m)", "Effect radius of the pulse."], [25, 1000, 150, 0], false],
+        ["SLIDER", ["Duration (s)", "How long electronics stay down."], [5, 300, 30, 0], false]
+    ],
+    {
+        params ["_args", "_pos"];
+        _args params ["_radius", "_duration"];
+        _pos params ["_modulePos"];
+        [_modulePos, _radius, _duration] call Waldo_fnc_EMP;
+        systemChat format ["EMP detonated: %1 m radius, %2 s.", _radius, _duration];
+    },
+    {},
+    [_modulePos]
+] call zen_dialog_fnc_create;

--- a/MissionScripts/ZenModules/Zen_initModules.sqf
+++ b/MissionScripts/ZenModules/Zen_initModules.sqf
@@ -114,3 +114,19 @@ if !(isClass(configFile >> "CfgPatches" >> "zen_main")) exitWith {};
     },
     "\a3\ui_f\data\map\markers\military\destroy_ca.paa"
 ] call zen_custom_modules_fnc_register;
+
+["Waldos Mission Modules", "EMP Detonation",
+    {
+        params ["_modulePos", "_objectPos"];
+        [_modulePos, _objectPos] call Waldo_fnc_ZenEMP;
+    },
+    "\a3\ui_f\data\igui\cfg\simpletasks\types\backpack_ca.paa"
+] call zen_custom_modules_fnc_register;
+
+["Waldos Mission Modules", "Plant Signal Tracker",
+    {
+        params ["_modulePos", "_objectPos"];
+        [_modulePos, _objectPos] call Waldo_fnc_ZenTracker;
+    },
+    "\a3\ui_f\data\igui\cfg\simpletasks\types\track_ca.paa"
+] call zen_custom_modules_fnc_register;

--- a/MissionScripts/ZenModules/Zen_initModules.sqf
+++ b/MissionScripts/ZenModules/Zen_initModules.sqf
@@ -90,3 +90,27 @@ if !(isClass(configFile >> "CfgPatches" >> "zen_main")) exitWith {};
     },
     "\a3\ui_f\data\igui\cfg\simpletasks\types\download_ca.paa"
 ] call zen_custom_modules_fnc_register;
+
+["Waldos Mission Modules", "Radio Jammer - Place",
+    {
+        params ["_modulePos", "_objectPos"];
+        [_modulePos, _objectPos] call Waldo_fnc_ZenJammerPlace;
+    },
+    "\a3\ui_f\data\map\markers\nato\b_naval_ca.paa"
+] call zen_custom_modules_fnc_register;
+
+["Waldos Mission Modules", "Radio Jammer - Toggle Nearest",
+    {
+        params ["_modulePos", "_objectPos"];
+        [_modulePos, _objectPos] call Waldo_fnc_ZenJammerToggle;
+    },
+    "\a3\ui_f\data\igui\cfg\simpletasks\types\interact_ca.paa"
+] call zen_custom_modules_fnc_register;
+
+["Waldos Mission Modules", "Radio Jammer - Remove Nearest",
+    {
+        params ["_modulePos", "_objectPos"];
+        [_modulePos, _objectPos] call Waldo_fnc_ZenJammerRemove;
+    },
+    "\a3\ui_f\data\map\markers\military\destroy_ca.paa"
+] call zen_custom_modules_fnc_register;

--- a/MissionScripts/ZenModules/Zen_jammerPlaceModule.sqf
+++ b/MissionScripts/ZenModules/Zen_jammerPlaceModule.sqf
@@ -33,15 +33,23 @@ params ["_modulePos", "_objectPos"];
                 0
             ],
         false],
+        ["SLIDER", ["Cone Arc (deg)", "360 = omnidirectional; less = a directional cone facing the bearing below."], [10, 360, 360, 0], false],
+        ["SLIDER", ["Cone Bearing (deg)", "Compass bearing the cone faces (ignored when arc is 360)."], [0, 359, 0, 0], false],
+        ["CHECKBOX", ["Pulsing (4s on / 2s off)", "Jam intermittently instead of constantly."], false, false],
         ["CHECKBOX", ["Show Map Marker", "Place a map marker on the jammer (visible to curators)."], false, false]
     ],
     {
         params ["_args", "_pos"];
-        _args params ["_radius", "_falloff", "_strengthPct", "_sideStr", "_marker"];
+        _args params ["_radius", "_falloff", "_strengthPct", "_sideStr", "_arc", "_bearing", "_pulse", "_marker"];
         _pos params ["_modulePos"];
 
+        private _sector = [];
+        if (_arc < 360) then { _sector = [_bearing, _arc]; };
+        private _duty = [];
+        if (_pulse) then { _duty = [4, 2]; };
+
         private _obj = "Land_PowerGenerator_F" createVehicle _modulePos;
-        [_obj, _radius, _sideStr, "ALL", _falloff, (_strengthPct / 100), true, _marker] call Waldo_fnc_Jammer;
+        [_obj, _radius, _sideStr, "ALL", _falloff, (_strengthPct / 100), true, _marker, _sector, _duty] call Waldo_fnc_Jammer;
 
         // Add the emitter to the curator so it can be managed in Zeus.
         [{

--- a/MissionScripts/ZenModules/Zen_jammerPlaceModule.sqf
+++ b/MissionScripts/ZenModules/Zen_jammerPlaceModule.sqf
@@ -1,0 +1,55 @@
+/*
+ * Author: Waldo
+ * Zeus module handler: prompts the curator for a jammer's radius, falloff, strength, the side it
+ * jams and whether to mark it, then spawns an emitter object at the module position and registers
+ * it as a localised radio jammer (Waldo_fnc_Jammer). Works for ACRE2 and TFAR. The object is
+ * created on the curator's machine and added to the curator so it can be moved or deleted in Zeus;
+ * the jammer registry write is forwarded to the server by Waldo_fnc_Jammer.
+ *
+ * Arguments:
+ * 0: modulePos <ARRAY> - position the curator placed the module
+ * 1: objectPos <OBJECT> - object the module was dropped on (unused)
+ *
+ * Example:
+ * [_modulePos, _objectPos] call Waldo_fnc_ZenJammerPlace;
+ *
+ * Public: No
+ */
+
+if !(isClass (configFile >> "CfgPatches" >> "zen_main")) exitWith {};
+
+params ["_modulePos", "_objectPos"];
+
+[
+    "Waldos Radio Jammer",
+    [
+        ["SLIDER", ["Radius (m)", "Full-strength jamming radius in metres."], [50, 2000, 300, 0], false],
+        ["SLIDER", ["Falloff (m)", "Extra metres of linear falloff beyond the radius."], [0, 1000, 50, 0], false],
+        ["SLIDER", ["Strength (%)", "Jamming strength at full effect (100% = total blackout)."], [0, 100, 100, 0], false],
+        ["COMBO", ["Affected Side", "Which side's radios are jammed."],
+            [
+                ["ALL", "WEST", "EAST", "IND", "CIV"],
+                ["All Sides", "BLUFOR", "OPFOR", "INDFOR", "CIVILIAN"],
+                0
+            ],
+        false],
+        ["CHECKBOX", ["Show Map Marker", "Place a map marker on the jammer (visible to curators)."], false, false]
+    ],
+    {
+        params ["_args", "_pos"];
+        _args params ["_radius", "_falloff", "_strengthPct", "_sideStr", "_marker"];
+        _pos params ["_modulePos"];
+
+        private _obj = "Land_PowerGenerator_F" createVehicle _modulePos;
+        [_obj, _radius, _sideStr, "ALL", _falloff, (_strengthPct / 100), true, _marker] call Waldo_fnc_Jammer;
+
+        // Add the emitter to the curator so it can be managed in Zeus.
+        [{
+            _this call ace_zeus_fnc_addObjectToCurator;
+        }, _obj] call CBA_fnc_execNextFrame;
+
+        systemChat format ["Radio jammer placed: %1 m radius, jams %2.", _radius, _sideStr];
+    },
+    {},
+    [_modulePos]
+] call zen_dialog_fnc_create;

--- a/MissionScripts/ZenModules/Zen_jammerPlaceModule.sqf
+++ b/MissionScripts/ZenModules/Zen_jammerPlaceModule.sqf
@@ -36,11 +36,12 @@ params ["_modulePos", "_objectPos"];
         ["SLIDER", ["Cone Arc (deg)", "360 = omnidirectional; less = a directional cone facing the bearing below."], [10, 360, 360, 0], false],
         ["SLIDER", ["Cone Bearing (deg)", "Compass bearing the cone faces (ignored when arc is 360)."], [0, 359, 0, 0], false],
         ["CHECKBOX", ["Pulsing (4s on / 2s off)", "Jam intermittently instead of constantly."], false, false],
+        ["CHECKBOX", ["Also Jam UAVs / Drones", "Freeze autonomous drones and cut controlling players' datalinks in the field."], false, false],
         ["CHECKBOX", ["Show Map Marker", "Place a map marker on the jammer (visible to curators)."], false, false]
     ],
     {
         params ["_args", "_pos"];
-        _args params ["_radius", "_falloff", "_strengthPct", "_sideStr", "_arc", "_bearing", "_pulse", "_marker"];
+        _args params ["_radius", "_falloff", "_strengthPct", "_sideStr", "_arc", "_bearing", "_pulse", "_jamUAV", "_marker"];
         _pos params ["_modulePos"];
 
         private _sector = [];
@@ -49,7 +50,7 @@ params ["_modulePos", "_objectPos"];
         if (_pulse) then { _duty = [4, 2]; };
 
         private _obj = "Land_PowerGenerator_F" createVehicle _modulePos;
-        [_obj, _radius, _sideStr, "ALL", _falloff, (_strengthPct / 100), true, _marker, _sector, _duty] call Waldo_fnc_Jammer;
+        [_obj, _radius, _sideStr, "ALL", _falloff, (_strengthPct / 100), true, _marker, _sector, _duty, _jamUAV] call Waldo_fnc_Jammer;
 
         // Add the emitter to the curator so it can be managed in Zeus.
         [{

--- a/MissionScripts/ZenModules/Zen_jammerRemoveModule.sqf
+++ b/MissionScripts/ZenModules/Zen_jammerRemoveModule.sqf
@@ -1,0 +1,41 @@
+/*
+ * Author: Waldo
+ * Zeus module handler: finds the nearest registered radio jammer to where the curator dropped the
+ * module and removes it, deleting its emitter object and map marker (Waldo_fnc_JammerRemove). No
+ * dialog - it acts immediately and reports to the curator. The registry write is server-authoritative.
+ *
+ * Arguments:
+ * 0: modulePos <ARRAY> - position the curator placed the module
+ * 1: objectPos <OBJECT> - object the module was dropped on (unused)
+ *
+ * Example:
+ * [_modulePos, _objectPos] call Waldo_fnc_ZenJammerRemove;
+ *
+ * Public: No
+ */
+
+if !(isClass (configFile >> "CfgPatches" >> "zen_main")) exitWith {};
+
+params ["_modulePos", "_objectPos"];
+
+private _registry = missionNamespace getVariable ["Waldo_Jamming_Registry", []];
+if (_registry isEqualTo []) exitWith { systemChat "No radio jammers exist in this mission."; };
+
+// Pick the nearest jammer with a valid object.
+private _bestId = -1;
+private _bestDist = 1e11;
+{
+    private _obj = _x select 1;
+    if (!isNull _obj) then {
+        private _d = _obj distance _modulePos;
+        if (_d < _bestDist) then {
+            _bestDist = _d;
+            _bestId = _x select 0;
+        };
+    };
+} forEach _registry;
+
+if (_bestId < 0) exitWith { systemChat "No radio jammer found nearby."; };
+
+[_bestId, true] call Waldo_fnc_JammerRemove;
+systemChat "Nearest radio jammer removed.";

--- a/MissionScripts/ZenModules/Zen_jammerToggleModule.sqf
+++ b/MissionScripts/ZenModules/Zen_jammerToggleModule.sqf
@@ -1,0 +1,44 @@
+/*
+ * Author: Waldo
+ * Zeus module handler: finds the nearest registered radio jammer to where the curator dropped the
+ * module and flips it on/off (Waldo_fnc_JammerToggle). No dialog - it acts immediately and reports
+ * the new state to the curator via systemChat. The registry write is server-authoritative.
+ *
+ * Arguments:
+ * 0: modulePos <ARRAY> - position the curator placed the module
+ * 1: objectPos <OBJECT> - object the module was dropped on (unused)
+ *
+ * Example:
+ * [_modulePos, _objectPos] call Waldo_fnc_ZenJammerToggle;
+ *
+ * Public: No
+ */
+
+if !(isClass (configFile >> "CfgPatches" >> "zen_main")) exitWith {};
+
+params ["_modulePos", "_objectPos"];
+
+private _registry = missionNamespace getVariable ["Waldo_Jamming_Registry", []];
+if (_registry isEqualTo []) exitWith { systemChat "No radio jammers exist in this mission."; };
+
+// Pick the nearest jammer with a valid object.
+private _bestId = -1;
+private _bestState = false;
+private _bestDist = 1e11;
+{
+    private _obj = _x select 1;
+    if (!isNull _obj) then {
+        private _d = _obj distance _modulePos;
+        if (_d < _bestDist) then {
+            _bestDist = _d;
+            _bestId = _x select 0;
+            _bestState = _x select 7;
+        };
+    };
+} forEach _registry;
+
+if (_bestId < 0) exitWith { systemChat "No radio jammer found nearby."; };
+
+private _new = !_bestState;
+[_bestId, _new] call Waldo_fnc_JammerToggle;
+systemChat format ["Nearest radio jammer switched %1.", (["OFF", "ON"] select _new)];

--- a/MissionScripts/ZenModules/Zen_trackerModule.sqf
+++ b/MissionScripts/ZenModules/Zen_trackerModule.sqf
@@ -1,0 +1,50 @@
+/*
+ * Author: Waldo
+ * Zeus module handler: plants a signal tracker on the nearest unit/vehicle to the module position,
+ * visible to a chosen side (Waldo_fnc_Tracker). Lets a curator mark a target for a side to follow
+ * on the map without touching the target.
+ *
+ * Arguments:
+ * 0: modulePos <ARRAY> - position the curator placed the module
+ * 1: objectPos <OBJECT> - object the module was dropped on (unused)
+ *
+ * Example:
+ * [_modulePos, _objectPos] call Waldo_fnc_ZenTracker;
+ *
+ * Public: No
+ */
+
+if !(isClass (configFile >> "CfgPatches" >> "zen_main")) exitWith {};
+
+params ["_modulePos", "_objectPos"];
+
+[
+    "Plant Signal Tracker",
+    [
+        ["COMBO", ["Tracked By", "Which side can see the tracker on their map."],
+            [
+                ["ALL", "WEST", "EAST", "IND", "CIV"],
+                ["All Sides", "BLUFOR", "OPFOR", "INDFOR", "CIVILIAN"],
+                0
+            ],
+        false]
+    ],
+    {
+        params ["_args", "_pos"];
+        _args params ["_sideStr"];
+        _pos params ["_modulePos"];
+
+        private _near = nearestObjects [_modulePos, ["Man", "Car", "Tank", "Air", "Ship", "Motorcycle"], 60];
+        private _tgt = objNull;
+        {
+            if (alive _x) exitWith { _tgt = _x; };
+        } forEach _near;
+
+        if (isNull _tgt) exitWith { systemChat "No unit or vehicle nearby to tag."; };
+
+        [_tgt, _sideStr] call Waldo_fnc_Tracker;
+        systemChat format ["Signal tracker planted (%1).", _sideStr];
+    },
+    {},
+    [_modulePos]
+] call zen_dialog_fnc_create;

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ to utilise critical systems of arma 3. Now, it is in continued use by at least f
 # Pack Features
 - Loadout saving and respawn system
 - Automatic ACRE2 Radio setup and respawn handling - based on mission makers specification in init.sqf
-- Localised Radio Jamming for ACRE2 & TFAR - drop a jammer object (or place one live from Zeus) to deny comms in an area, with per-side and (ACRE2) per-band control, falloff and an on-screen "radio jammed" prompt.
+- Localised Radio Jamming for ACRE2 & TFAR - drop a jammer object (or place one live from Zeus) to deny comms in an area. Terrain line-of-sight, radio-power burn-through, directional cones, pulsing, per-side and (ACRE2) per-band control; destructible jammers for "blow the tower" objectives, ACE toggle/disable actions and a handheld RDF scanner for EW teams, plus a deliberately loud on-screen jamming HUD so it's never mistaken for a game bug.
 - Custom loadout & logistics system which scrapes the kits of all playable characters to fulfil base logistical needs - such as starter crates and supply crates. (Disable scenario Binarization, and edit loadouts via ACE Arsenal to ensure 100% satisfaction)
 - Vehicle Ambush/Camo scripts.
 - Vehicle unflipping actions

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ to utilise critical systems of arma 3. Now, it is in continued use by at least f
 # Pack Features
 - Loadout saving and respawn system
 - Automatic ACRE2 Radio setup and respawn handling - based on mission makers specification in init.sqf
+- Localised Radio Jamming for ACRE2 & TFAR - drop a jammer object (or place one live from Zeus) to deny comms in an area, with per-side and (ACRE2) per-band control, falloff and an on-screen "radio jammed" prompt.
 - Custom loadout & logistics system which scrapes the kits of all playable characters to fulfil base logistical needs - such as starter crates and supply crates. (Disable scenario Binarization, and edit loadouts via ACE Arsenal to ensure 100% satisfaction)
 - Vehicle Ambush/Camo scripts.
 - Vehicle unflipping actions

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ to utilise critical systems of arma 3. Now, it is in continued use by at least f
 # Pack Features
 - Loadout saving and respawn system
 - Automatic ACRE2 Radio setup and respawn handling - based on mission makers specification in init.sqf
-- Localised Radio Jamming for ACRE2 & TFAR - drop a jammer object (or place one live from Zeus) to deny comms in an area. Terrain line-of-sight, radio-power burn-through, directional cones, pulsing, per-side and (ACRE2) per-band control; destructible jammers for "blow the tower" objectives, ACE toggle/disable actions and a handheld RDF scanner for EW teams, plus a deliberately loud on-screen jamming HUD so it's never mistaken for a game bug.
+- Localised Radio Jamming for ACRE2 & TFAR - drop a jammer object (or place one live from Zeus) to deny comms in an area. Terrain line-of-sight, radio-power burn-through, directional cones, pulsing, per-side and (ACRE2) per-band control; optional UAV/drone jamming (freeze autonomous drones, cut controlling players' datalinks); destructible jammers for "blow the tower" objectives, ACE toggle/disable actions and a handheld RDF scanner for EW teams, plus a deliberately loud on-screen jamming HUD so it's never mistaken for a game bug.
+- Electronic Warfare toolkit - a one-shot EMP burst (kills NVGs, vehicle engines and TFAR radios in a radius, with an immunity tag) and C-Track style signal trackers (tag a unit/vehicle and a chosen side follows it live on the map). Both scriptable and available as Zeus modules.
 - Custom loadout & logistics system which scrapes the kits of all playable characters to fulfil base logistical needs - such as starter crates and supply crates. (Disable scenario Binarization, and edit loadouts via ACE Arsenal to ensure 100% satisfaction)
 - Vehicle Ambush/Camo scripts.
 - Vehicle unflipping actions

--- a/init.sqf
+++ b/init.sqf
@@ -183,10 +183,27 @@ apply. Full guide: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Ja
 
 The feature installs its radio engines only while enabled; with no jammers placed it has no effect.
 Set Waldo_Jamming_Enable to false to disable it entirely; Waldo_Jamming_Notify controls the on-screen
-"radio jammed" prompt players see when they enter a field.
+jamming meter players see when they enter a field.
+
+Model options (tune the realism/gameplay to taste):
+- Waldo_Jamming_LOS            true  = terrain/hills block the jamming field (line of sight)
+- Waldo_Jamming_BurnThrough    true  = higher-power radios (e.g. PRC-117F) resist jamming, shrinking
+                                       the effective field; Waldo_Jamming_BurnThroughRef is the mW
+                                       reference power (a radio at this power is fully affected)
+- Waldo_Jamming_Curve          "LINEAR" or "INVSQ" edge falloff
+- Waldo_Jamming_Destructible   true  = destroying a jammer's object removes it (EW objectives)
+- Waldo_Jamming_GmOverlay      true  = curators see a floating marker over each jammer
+- Waldo_Jamming_ScanRange      detection range (m) of the handheld RDF "Scan for Radio Jammers" action
 */
 Waldo_Jamming_Enable = true;
 missionNamespace setVariable ["Waldo_Jamming_Notify", true, true];
+missionNamespace setVariable ["Waldo_Jamming_LOS", true, true];
+missionNamespace setVariable ["Waldo_Jamming_BurnThrough", true, true];
+missionNamespace setVariable ["Waldo_Jamming_BurnThroughRef", 500, true];
+missionNamespace setVariable ["Waldo_Jamming_Curve", "LINEAR", true];
+missionNamespace setVariable ["Waldo_Jamming_Destructible", true, true];
+missionNamespace setVariable ["Waldo_Jamming_GmOverlay", true, true];
+missionNamespace setVariable ["Waldo_Jamming_ScanRange", 3000, true];
 if (Waldo_Jamming_Enable) then {
     missionNamespace setVariable ["Waldo_Jamming_Enable", true, true];
     [] call Waldo_fnc_JammingInit;

--- a/init.sqf
+++ b/init.sqf
@@ -163,6 +163,39 @@ missionNamespace setVariable ["Waldo_ACRE2Setup_LRChannels_CIV", _LongRangeRadio
 /*===========================================================================================================================*/
 
 /*
+Localised Radio Jamming (ACRE2 / TFAR)
+
+Area-denial radio jamming for both ACRE2 and TFAR. A "jammer" is any object with a radius: radios
+inside its field (ACRE2) or players standing in it (TFAR) lose comms, with a linear falloff at the
+edge. You can jam everyone or only chosen sides, and (ACRE2 only) restrict it to frequency bands.
+
+Set up jammers however suits you:
+- From an object's init field in Eden:      [this] call Waldo_fnc_Jammer;                  // 300 m, jams all
+                                            [this, 500, "EAST"] call Waldo_fnc_Jammer;      // 500 m, OPFOR only
+- From a trigger / script:                  [myTower, 800, "ALL", [[30,88]]] call Waldo_fnc_Jammer;
+- Live from Zeus ("Waldos Mission Modules"): Radio Jammer - Place / Toggle Nearest / Remove Nearest.
+
+Toggle or remove later with [ref, active] call Waldo_fnc_JammerToggle; and [ref] call Waldo_fnc_JammerRemove;
+(ref = the jammer object or the id returned by Waldo_fnc_Jammer).
+
+ACRE2 note: your ACRE2 signal model must be "LOS Multipath" (the default) or "Arcade" for jamming to
+apply. Full guide: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Jamming
+
+The feature installs its radio engines only while enabled; with no jammers placed it has no effect.
+Set Waldo_Jamming_Enable to false to disable it entirely; Waldo_Jamming_Notify controls the on-screen
+"radio jammed" prompt players see when they enter a field.
+*/
+Waldo_Jamming_Enable = true;
+missionNamespace setVariable ["Waldo_Jamming_Notify", true, true];
+if (Waldo_Jamming_Enable) then {
+    missionNamespace setVariable ["Waldo_Jamming_Enable", true, true];
+    [] call Waldo_fnc_JammingInit;
+};
+
+
+/*===========================================================================================================================*/
+
+/*
 Vehicle function eventhandler
 
 This adds vehicle functions to affected vehicles:

--- a/wiki/Electronic-Warfare-EMP-And-Signal-Trackers.md
+++ b/wiki/Electronic-Warfare-EMP-And-Signal-Trackers.md
@@ -1,0 +1,85 @@
+_Associated Files: `MissionScripts\MissionInit\ElectronicWarfare\emp.sqf`, `empApply.sqf`, `empImmune.sqf`, `tracker.sqf`, `trackerRemove.sqf`, `trackerRender.sqf`, `trackerAttach.sqf`, `MissionScripts\ZenModules\Zen_empModule.sqf`, `Zen_trackerModule.sqf`, `Waldo_fnc_EMP`, `Waldo_fnc_EMPImmune`, `Waldo_fnc_Tracker`, `Waldo_fnc_TrackerAttach`_
+
+# Electronic Warfare — EMP & Signal Trackers
+
+Two self-contained electronic-warfare tools that sit alongside [Radio Jamming](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Jamming): a one-shot **EMP burst** and C-Track style **signal trackers**. Both are scriptable and available as Zeus modules, and neither runs any background loop until you actually use it.
+
+---
+
+# EMP Burst
+
+An electromagnetic pulse fries electronics in a radius for a while — the offensive, one-shot counterpart to a jammer (which is a persistent field). It fires once and reverts on a timer, so it costs nothing to leave available.
+
+## What it hits
+
+Inside the radius, anything **not** made immune:
+
+* **Infantry** lose their night-vision goggles (fried — removed from inventory) and, under TFAR, can't use their radio for the duration.
+* **Vehicles** have their engine cut (fuel drained and restored afterwards — aircraft will drop!).
+* **Players** in range get a **white-out flash** and a clear *"EMP DETONATION — electronics down"* message, so it reads as a deliberate EW event rather than a bug.
+
+## Scripting
+
+```sqf
+[getPosATL myObject, 200, 30] call Waldo_fnc_EMP;   // [position, radius (m), duration (s)]
+```
+
+Defaults: radius `150`, duration `30`.
+
+## Immunity
+
+Protect command vehicles, mission-critical assets or a friendly element:
+
+```sqf
+[this] call Waldo_fnc_EMPImmune;              // in a vehicle's or unit's init field
+[commandVehicle, true] call Waldo_fnc_EMPImmune;
+```
+
+Occupants of an immune vehicle are protected automatically. The flag is broadcast, so it holds for JIP players.
+
+## Zeus
+
+**Modules → Waldos Mission Modules → EMP Detonation** — a dialog for **radius** and **duration**, detonated at the module's position.
+
+---
+
+# Signal Trackers (C-Track)
+
+Plant a tracker on a unit or vehicle and a chosen side follows it **live on the map** — electronic reconnaissance without keeping eyes on the target. The marker is drawn only on the tracking side's clients, so it stays hidden from the side being tracked.
+
+## Planting one
+
+**As a player:** walk up to any unit or vehicle and use the ACE interaction **Plant Signal Tracker**. Your side then sees it on the map.
+
+**From script or a trigger:**
+
+```sqf
+[enemyTruck, west, "Convoy Lead"] call Waldo_fnc_Tracker;   // [target, trackingSide, label]
+[cursorTarget] call Waldo_fnc_TrackerAttach;                // tag what you're looking at, for your side
+```
+
+`trackingSide` accepts a side (`west`/`east`/…), a string (`"WEST"`/`"BLUFOR"`, `"EAST"`/`"OPFOR"`, `"IND"`/`"INDFOR"`, `"CIV"`/`"CIVILIAN"`) or `"ALL"`.
+
+## Removing one
+
+```sqf
+[enemyTruck] call Waldo_fnc_TrackerRemove;   // by object
+[2] call Waldo_fnc_TrackerRemove;            // by tracker id (returned by Waldo_fnc_Tracker)
+```
+
+A tracker also drops itself automatically when its target is killed or deleted.
+
+## Zeus
+
+**Modules → Waldos Mission Modules → Plant Signal Tracker** — a dialog to pick which side sees it; it tags the nearest unit or vehicle to the module.
+
+## Notes
+
+* Markers update every couple of seconds and follow the target's position and facing.
+* Only planted trackers cost anything — there is no per-frame work and no cost when none are placed.
+
+## See also
+
+* [Radio Jamming (ACRE2 / TFAR)](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Jamming) — the persistent-field side of the EW suite, including UAV jamming
+* [Waldos Mission Pack Zeus Modules](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Mission-Pack-Zeus-Modules)
+* [Mission Configuration Reference](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Configuration-Reference)

--- a/wiki/Feature-Tutorials.md
+++ b/wiki/Feature-Tutorials.md
@@ -56,6 +56,7 @@ The basic setup is covered in the [Quickstart Guide](https://github.com/AdamWald
 * [ACRE 2 Automated CEOI](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Automated-CEOI-Document)
 * [ACRE 2 Babel Autoconfig](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Babel-Configuration)
 * [Radio Jamming (ACRE2 / TFAR)](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Jamming)
+* [EW: EMP & Signal Trackers](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Electronic-Warfare-EMP-And-Signal-Trackers)
 
 ## Miscellaneous
 * [Mission Diagnostics](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Diagnostics) — Server-side config sanity check; warns about the common WMP misconfigurations

--- a/wiki/Feature-Tutorials.md
+++ b/wiki/Feature-Tutorials.md
@@ -55,6 +55,7 @@ The basic setup is covered in the [Quickstart Guide](https://github.com/AdamWald
 * [ACRE 2 Short Range Radio Presetting](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE-2-Squad-Level-Radios-AN-PRC%E2%80%90343-Automatic-Setup)
 * [ACRE 2 Automated CEOI](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Automated-CEOI-Document)
 * [ACRE 2 Babel Autoconfig](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Babel-Configuration)
+* [Radio Jamming (ACRE2 / TFAR)](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Jamming)
 
 ## Miscellaneous
 * [Mission Diagnostics](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Diagnostics) — Server-side config sanity check; warns about the common WMP misconfigurations

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -19,6 +19,8 @@ I maintain this wiki regularly and keep it updated with tutorials on the vast ma
 # Pack Features
 - Loadout saving and respawn system
 - Automatic ACRE2 Radio setup and respawn handling - based on mission makers specification in init.sqf
+- [Radio Jamming (ACRE2 / TFAR)](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Jamming) - localised area-denial jamming with terrain LOS, burn-through, directional cones, UAV/drone jamming, destructible emitters and a loud "not a bug" HUD.
+- [EW: EMP & Signal Trackers](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Electronic-Warfare-EMP-And-Signal-Trackers) - a one-shot EMP burst and C-Track style map trackers.
 - Custom loadout & logistics system which scrapes the kits of all playable characters to fulfil base logistical needs - such as starter crates and supply crates. (Disable scenario Binarization, and edit loadouts via ACE Arsenal to ensure 100% satisfaction)
 - Vehicle Ambush/Camo scripts.
 - Vehicle unflipping actions

--- a/wiki/Mission-Configuration-Reference.md
+++ b/wiki/Mission-Configuration-Reference.md
@@ -222,7 +222,9 @@ missionNamespace setVariable ["Waldo_Jamming_GmOverlay", true, true];  // curato
 missionNamespace setVariable ["Waldo_Jamming_ScanRange", 3000, true];  // RDF scan detection range (m)
 ```
 
-On by default; does nothing until a jammer is placed. Drop a jammer from an object init field with `[this] call Waldo_fnc_Jammer;`, from a script/trigger, or live from the Zeus "Radio Jammer" modules. Supports terrain line-of-sight, radio-power burn-through, directional cones, pulsing, destructible "blow the tower" jammers, ACE player actions and a handheld RDF scanner. ACRE2 needs the LOS Multipath or Arcade signal model. See [Radio Jamming](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Jamming) for the full API.
+On by default; does nothing until a jammer is placed. Drop a jammer from an object init field with `[this] call Waldo_fnc_Jammer;`, from a script/trigger, or live from the Zeus "Radio Jammer" modules. Supports terrain line-of-sight, radio-power burn-through, directional cones, pulsing, optional UAV/drone jamming, destructible "blow the tower" jammers, ACE player actions and a handheld RDF scanner. ACRE2 needs the LOS Multipath or Arcade signal model. See [Radio Jamming](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Jamming) for the full API.
+
+The related **EMP burst** (`Waldo_fnc_EMP`) and **signal trackers** (`Waldo_fnc_Tracker`) are on-demand — no init configuration, just script/Zeus calls. See [EW: EMP & Signal Trackers](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Electronic-Warfare-EMP-And-Signal-Trackers).
 
 ### Introduction Text
 

--- a/wiki/Mission-Configuration-Reference.md
+++ b/wiki/Mission-Configuration-Reference.md
@@ -211,11 +211,18 @@ Remove the `/*` and `*/` to enable. See [ACRE2 Babel Configuration](https://gith
 ### Radio Jamming (ACRE2 / TFAR)
 
 ```sqf
-Waldo_Jamming_Enable = true;                                        // false = feature off entirely
-missionNamespace setVariable ["Waldo_Jamming_Notify", true, true];  // on-screen "RADIO JAMMED" prompt
+Waldo_Jamming_Enable = true;                                           // false = feature off entirely
+missionNamespace setVariable ["Waldo_Jamming_Notify", true, true];     // on-screen jamming HUD + chat feedback
+missionNamespace setVariable ["Waldo_Jamming_LOS", true, true];        // terrain blocks the field
+missionNamespace setVariable ["Waldo_Jamming_BurnThrough", true, true];// stronger radios resist jamming
+missionNamespace setVariable ["Waldo_Jamming_BurnThroughRef", 500, true];
+missionNamespace setVariable ["Waldo_Jamming_Curve", "LINEAR", true];  // or "INVSQ"
+missionNamespace setVariable ["Waldo_Jamming_Destructible", true, true];// destroy the object = remove jammer
+missionNamespace setVariable ["Waldo_Jamming_GmOverlay", true, true];  // curators see jammers in-world
+missionNamespace setVariable ["Waldo_Jamming_ScanRange", 3000, true];  // RDF scan detection range (m)
 ```
 
-On by default; does nothing until a jammer is placed. Drop a jammer from an object init field with `[this] call Waldo_fnc_Jammer;`, from a script/trigger, or live from the Zeus "Radio Jammer" modules. ACRE2 needs the LOS Multipath or Arcade signal model. See [Radio Jamming](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Jamming) for the full API.
+On by default; does nothing until a jammer is placed. Drop a jammer from an object init field with `[this] call Waldo_fnc_Jammer;`, from a script/trigger, or live from the Zeus "Radio Jammer" modules. Supports terrain line-of-sight, radio-power burn-through, directional cones, pulsing, destructible "blow the tower" jammers, ACE player actions and a handheld RDF scanner. ACRE2 needs the LOS Multipath or Arcade signal model. See [Radio Jamming](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Jamming) for the full API.
 
 ### Introduction Text
 

--- a/wiki/Mission-Configuration-Reference.md
+++ b/wiki/Mission-Configuration-Reference.md
@@ -208,6 +208,15 @@ Position in the array = channel number. These names appear in the in-game CEOI d
 
 Remove the `/*` and `*/` to enable. See [ACRE2 Babel Configuration](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Babel-Configuration).
 
+### Radio Jamming (ACRE2 / TFAR)
+
+```sqf
+Waldo_Jamming_Enable = true;                                        // false = feature off entirely
+missionNamespace setVariable ["Waldo_Jamming_Notify", true, true];  // on-screen "RADIO JAMMED" prompt
+```
+
+On by default; does nothing until a jammer is placed. Drop a jammer from an object init field with `[this] call Waldo_fnc_Jammer;`, from a script/trigger, or live from the Zeus "Radio Jammer" modules. ACRE2 needs the LOS Multipath or Arcade signal model. See [Radio Jamming](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Jamming) for the full API.
+
 ### Introduction Text
 
 ```sqf

--- a/wiki/Radio-Jamming.md
+++ b/wiki/Radio-Jamming.md
@@ -60,8 +60,23 @@ Want more control? The full form is:
 | 7 | createMarker | Bool | `false` | Place a red "Radio Jammer" map marker on it. |
 | 8 | sector | Array | `[]` | `[]` = omnidirectional, or `[bearing, arc]` for a directional cone facing `bearing` degrees, `arc` degrees wide. |
 | 9 | duty | Array | `[]` | `[]` = constant, or `[onSec, offSec]` to pulse the jammer on and off. |
+| 10 | jamUAV | Bool | `false` | Also jam UAVs/drones in the field (see below). |
 
 `Waldo_fnc_Jammer` returns a numeric **jammer id** you can keep to toggle or remove it later. Calling it again on the same object updates that jammer in place (it never stacks).
+
+## UAV / drone jamming (counter-UAS)
+
+Set the **jamUAV** flag (param 10, or the "Also Jam UAVs / Drones" checkbox in the Zeus module) and the field becomes counter-drone as well as anti-radio:
+
+* **Autonomous drones** inside the field have their AI frozen — they stop flying/driving and hunting, and can be slipped past.
+* **Player-controlled drones** get a **degrading video feed** as the operator flies into the field, and at near-total jamming the **datalink is cut** and the terminal disconnects.
+
+```sqf
+// A 400 m counter-UAS bubble that jams radios AND drones for everyone:
+[this, 400, "ALL", "ALL", 50, 1, true, true, [], [], true] call Waldo_fnc_Jammer;
+```
+
+Just like the radio HUD, UAV jamming is **loud on purpose** — the operator sees a persistent blinking **"UAV LINK JAMMED — not a game bug"** banner and a clear "datalink lost" message, so a frozen or disconnected drone is never written off as one of Arma's UAV glitches. Because it is just a flag on a jammer, the same Toggle/Disable ACE actions, Zeus toggle/remove modules and RDF scan apply to it.
 
 ## The jamming model (global toggles in `init.sqf`)
 
@@ -110,7 +125,7 @@ Three modules live under **Modules → Waldos Mission Modules** (Zeus Enhanced r
 
 | Module | Action |
 |---|---|
-| **Radio Jammer - Place** | Opens a dialog — radius, falloff, strength, affected side, **cone arc + bearing** (arc 360 = omni), **pulsing** and map marker — then spawns an emitter and switches the jammer on. |
+| **Radio Jammer - Place** | Opens a dialog — radius, falloff, strength, affected side, **cone arc + bearing** (arc 360 = omni), **pulsing**, **also jam UAVs** and map marker — then spawns an emitter and switches the jammer on. |
 | **Radio Jammer - Toggle Nearest** | Flips the nearest jammer on/off. |
 | **Radio Jammer - Remove Nearest** | Removes the nearest jammer and deletes its object. |
 

--- a/wiki/Radio-Jamming.md
+++ b/wiki/Radio-Jamming.md
@@ -1,0 +1,101 @@
+_Associated Files: `init.sqf`, `MissionScripts\MissionInit\Jamming\jammingInit.sqf`, `jammerCreate.sqf`, `jammerToggle.sqf`, `jammerRemove.sqf`, `jammingFactor.sqf`, `jammingAcreSignal.sqf`, `jammingTfarLoop.sqf`, `MissionScripts\ZenModules\Zen_jammerPlaceModule.sqf`, `Zen_jammerToggleModule.sqf`, `Zen_jammerRemoveModule.sqf`, `Waldo_fnc_Jammer`, `Waldo_fnc_JammerToggle`, `Waldo_fnc_JammerRemove`_
+
+# Radio Jamming (ACRE2 / TFAR)
+
+Localised radio jamming lets you deny communications in an area. Drop a **jammer** — any object with a radius — and radios inside its field stop working, fading back in through a soft edge as you leave. It works with **both ACRE2 and TFAR**, so you don't have to care which radio mod your unit runs.
+
+Use it for EW objectives ("destroy the jammer to restore comms"), no-comms insertions, roleplay around a signals site, or just to make an area go dark on cue.
+
+## What it does
+
+* **ACRE2** — inside a jammer field, the signal between radios is dragged down toward the noise floor: transmissions get garbled and then drop out entirely. You can restrict a jammer to specific frequency **bands** so, say, only VHF is jammed.
+* **TFAR** — inside a jammer field, a player's receive and transmit ranges are throttled toward zero and, at full strength, the radio is disabled outright. TFAR jamming is **broadband** (there is no per-band option).
+* **Both** — jamming is strongest inside the **radius**, then falls off linearly over the **falloff** distance to nothing. You can jam **everyone** or only **chosen sides**. Players get an on-screen "RADIO JAMMED" prompt when they enter a field (toggleable).
+
+The feature is **on by default** but does nothing until you actually place a jammer, so leaving it enabled costs you nothing.
+
+> **ACRE2 requirement:** your ACRE2 **signal model** must be **LOS Multipath** (the default) or **Arcade**. ACRE2 does not expose the hook this uses under *LOS Simple*, so jamming will silently do nothing on that model.
+
+## The quickest setup (Eden init field)
+
+Place any object (an antenna, a vehicle, a generator), then in its **init field**:
+
+```sqf
+[this] call Waldo_fnc_Jammer;
+```
+
+That's a 300 m jammer that jams everyone on every band. Done.
+
+Want more control? The full form is:
+
+```sqf
+[this, 500, "EAST"] call Waldo_fnc_Jammer;                         // 500 m, jams OPFOR only
+[this, 800, "ALL", [[30, 88]], 50, 1, true, true] call Waldo_fnc_Jammer;  // VHF-only, 800 m + 50 m falloff, with a map marker
+```
+
+## `Waldo_fnc_Jammer` parameters
+
+| # | Parameter | Type | Default | Purpose |
+|---|---|---|---|---|
+| 0 | object | Object | — | The emitter the jammer sits on (its position is the jam centre). |
+| 1 | radius | Number | `300` | Full-strength jamming radius, in metres. |
+| 2 | affectedSides | String / Array | `"ALL"` | `"ALL"`, a side, or an array. Accepts `"WEST"`/`"BLUFOR"`, `"EAST"`/`"OPFOR"`, `"IND"`/`"INDFOR"`, `"CIV"`/`"CIVILIAN"`, or actual sides. Only listed sides are jammed. |
+| 3 | bands | String / Array | `"ALL"` | `"ALL"`, or an array of `[minMHz, maxMHz]` ranges to jam only those bands. **ACRE2 only** — ignored by TFAR. |
+| 4 | falloff | Number | `50` | Extra metres of linear falloff beyond the radius. `0` = a hard edge. |
+| 5 | strength | Number | `1` | Jamming strength at full effect, `0`–`1` (`1` = total blackout). |
+| 6 | active | Bool | `true` | Start switched on. |
+| 7 | createMarker | Bool | `false` | Place a red "Radio Jammer" map marker on it. |
+
+`Waldo_fnc_Jammer` returns a numeric **jammer id** you can keep to toggle or remove it later. Calling it again on the same object updates that jammer in place (it never stacks).
+
+## Turning jammers on/off and removing them
+
+Both take either the jammer **object** or its **id**. They are server-authoritative — safe to call from a trigger, a client or a script.
+
+```sqf
+[myTower, false] call Waldo_fnc_JammerToggle;   // switch off (omit the bool to just flip it)
+[myTower, true]  call Waldo_fnc_JammerToggle;    // switch back on
+
+[myTower]        call Waldo_fnc_JammerRemove;    // remove the jammer, keep the object
+[myTower, true]  call Waldo_fnc_JammerRemove;    // remove the jammer AND delete the object
+```
+
+A classic EW objective — blow the tower, comms come back:
+
+```sqf
+// In the jammer tower's init:
+[this, 600, "WEST"] call Waldo_fnc_Jammer;
+
+// In a trigger that fires when the tower is destroyed:
+[jammerTower] call Waldo_fnc_JammerRemove;
+```
+
+## Zeus usage
+
+Three modules live under **Modules → Waldos Mission Modules** (Zeus Enhanced required):
+
+| Module | Action |
+|---|---|
+| **Radio Jammer - Place** | Opens a dialog (radius, falloff, strength, affected side, map marker), then spawns an emitter and switches the jammer on. |
+| **Radio Jammer - Toggle Nearest** | Flips the nearest jammer on/off. |
+| **Radio Jammer - Remove Nearest** | Removes the nearest jammer and deletes its object. |
+
+The placed emitter is added to the curator, so you can drag or delete it like any Zeus object.
+
+## Global options (`init.sqf`)
+
+```sqf
+Waldo_Jamming_Enable = true;                                        // false = feature off entirely
+missionNamespace setVariable ["Waldo_Jamming_Notify", true, true];  // on-screen "RADIO JAMMED" prompt
+```
+
+## How it works (for the curious)
+
+The jammer list is owned and broadcast by the server, so late-joining players inherit every jammer automatically. Each player runs the engine for whichever radio mod they have — an ACRE2 custom signal function and/or a TFAR loop — reading that live list. A link is jammed when **either** end of it (the radio receiving *or* the radio transmitting) is inside an active field that affects your side and matches the band. That means both "your radio is in the jammed zone" and "the person calling you is standing in a jammer" degrade the call.
+
+## See also
+
+* [ACRE 2 Long Range Radio](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE-2-Long-Range-Radio-Presetting) — radio channel setup
+* [Mission Diagnostics](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Diagnostics) — warns if jamming is enabled with no radio mod loaded
+* [Waldos Mission Pack Zeus Modules](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Mission-Pack-Zeus-Modules)
+* [Mission Configuration Reference](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Configuration-Reference)

--- a/wiki/Radio-Jamming.md
+++ b/wiki/Radio-Jamming.md
@@ -1,4 +1,4 @@
-_Associated Files: `init.sqf`, `MissionScripts\MissionInit\Jamming\jammingInit.sqf`, `jammerCreate.sqf`, `jammerToggle.sqf`, `jammerRemove.sqf`, `jammingFactor.sqf`, `jammingAcreSignal.sqf`, `jammingTfarLoop.sqf`, `MissionScripts\ZenModules\Zen_jammerPlaceModule.sqf`, `Zen_jammerToggleModule.sqf`, `Zen_jammerRemoveModule.sqf`, `Waldo_fnc_Jammer`, `Waldo_fnc_JammerToggle`, `Waldo_fnc_JammerRemove`_
+_Associated Files: `init.sqf`, `MissionScripts\MissionInit\Jamming\jammingInit.sqf`, `jammerCreate.sqf`, `jammerToggle.sqf`, `jammerRemove.sqf`, `jammingFactor.sqf`, `jammingAcreSignal.sqf`, `jammingTfarLoop.sqf`, `jammerInteraction.sqf`, `jammerScan.sqf`, `jammerMapDraw.sqf`, `jammingHud.sqf`, `MissionScripts\ZenModules\Zen_jammerPlaceModule.sqf`, `Zen_jammerToggleModule.sqf`, `Zen_jammerRemoveModule.sqf`, `Waldo_fnc_Jammer`, `Waldo_fnc_JammerToggle`, `Waldo_fnc_JammerRemove`_
 
 # Radio Jamming (ACRE2 / TFAR)
 
@@ -10,11 +10,22 @@ Use it for EW objectives ("destroy the jammer to restore comms"), no-comms inser
 
 * **ACRE2** — inside a jammer field, the signal between radios is dragged down toward the noise floor: transmissions get garbled and then drop out entirely. You can restrict a jammer to specific frequency **bands** so, say, only VHF is jammed.
 * **TFAR** — inside a jammer field, a player's receive and transmit ranges are throttled toward zero and, at full strength, the radio is disabled outright. TFAR jamming is **broadband** (there is no per-band option).
-* **Both** — jamming is strongest inside the **radius**, then falls off linearly over the **falloff** distance to nothing. You can jam **everyone** or only **chosen sides**. Players get an on-screen "RADIO JAMMED" prompt when they enter a field (toggleable).
+* **Both** — jamming is strongest inside the **radius**, then falls off over the **falloff** distance to nothing. You can jam **everyone** or only **chosen sides**, aim it as a **cone**, and make it **pulse**.
 
 The feature is **on by default** but does nothing until you actually place a jammer, so leaving it enabled costs you nothing.
 
 > **ACRE2 requirement:** your ACRE2 **signal model** must be **LOS Multipath** (the default) or **Arcade**. ACRE2 does not expose the hook this uses under *LOS Simple*, so jamming will silently do nothing on that model.
+
+## "Is it jamming or just an Arma bug?" — the feedback is deliberately loud
+
+Arma's radio mods drop comms for all kinds of buggy reasons, so a silent jammer would just look like another glitch. This system makes jamming **unmistakable**:
+
+* A **persistent, blinking HUD banner** appears while you are jammed — drawn on the main display so other scripts' hints can't paint over it. It shows a live **strength %**, a bar, and the line *"Comms loss here is intentional — not a game bug."*
+* A loud **entry message** in system chat when you're first jammed, and a **periodic reminder** every few seconds while it lasts.
+* A green **"COMMS RESTORED"** banner and chat line the moment you leave the field.
+* Players can actively confirm it with the **Scan for Radio Jammers** ACE self-action (see EW Toolkit below).
+
+If you ever want it quieter, set `Waldo_Jamming_Notify` to `false` — but for most missions the loud feedback is the point.
 
 ## The quickest setup (Eden init field)
 
@@ -29,8 +40,10 @@ That's a 300 m jammer that jams everyone on every band. Done.
 Want more control? The full form is:
 
 ```sqf
-[this, 500, "EAST"] call Waldo_fnc_Jammer;                         // 500 m, jams OPFOR only
-[this, 800, "ALL", [[30, 88]], 50, 1, true, true] call Waldo_fnc_Jammer;  // VHF-only, 800 m + 50 m falloff, with a map marker
+[this, 500, "EAST"] call Waldo_fnc_Jammer;                                    // 500 m, jams OPFOR only
+[this, 800, "ALL", [[30, 88]], 50, 1, true, true] call Waldo_fnc_Jammer;      // VHF-only, with a map marker
+[this, 800, "ALL", "ALL", 50, 1, true, true, [90, 60]] call Waldo_fnc_Jammer; // a 60-deg cone facing 090
+[this, 600, "ALL", "ALL", 50, 1, true, false, [], [4, 2]] call Waldo_fnc_Jammer; // pulses 4s on / 2s off
 ```
 
 ## `Waldo_fnc_Jammer` parameters
@@ -45,29 +58,50 @@ Want more control? The full form is:
 | 5 | strength | Number | `1` | Jamming strength at full effect, `0`–`1` (`1` = total blackout). |
 | 6 | active | Bool | `true` | Start switched on. |
 | 7 | createMarker | Bool | `false` | Place a red "Radio Jammer" map marker on it. |
+| 8 | sector | Array | `[]` | `[]` = omnidirectional, or `[bearing, arc]` for a directional cone facing `bearing` degrees, `arc` degrees wide. |
+| 9 | duty | Array | `[]` | `[]` = constant, or `[onSec, offSec]` to pulse the jammer on and off. |
 
 `Waldo_fnc_Jammer` returns a numeric **jammer id** you can keep to toggle or remove it later. Calling it again on the same object updates that jammer in place (it never stacks).
 
-## Turning jammers on/off and removing them
+## The jamming model (global toggles in `init.sqf`)
+
+These let you tune how realistic/gamey the jamming feels. All are on by default.
+
+| Flag | Default | Effect |
+|---|---|---|
+| `Waldo_Jamming_LOS` | `true` | **Terrain line-of-sight** — a hill or ridge between the jammer and a radio blocks the field. Put a jammer on high ground for reach; tuck behind terrain to hide from it. |
+| `Waldo_Jamming_BurnThrough` | `true` | **Power burn-through** — higher-power radios (e.g. a PRC-117F) resist jamming, shrinking the effective radius, while handhelds die fast. |
+| `Waldo_Jamming_BurnThroughRef` | `500` | Reference radio power in mW — a radio at this power is fully affected; more powerful radios burn through. |
+| `Waldo_Jamming_Curve` | `"LINEAR"` | Falloff shape at the edge: `"LINEAR"` or `"INVSQ"` (inverse-square feel — sharper near the centre). |
+| `Waldo_Jamming_Destructible` | `true` | Destroying a jammer's object **removes the jammer automatically** — blow the tower, comms come back, no trigger needed. |
+| `Waldo_Jamming_GmOverlay` | `true` | **Curators** see a floating marker (and facing line for cones) over every jammer. Ordinary players never see it. |
+| `Waldo_Jamming_ScanRange` | `3000` | Detection range (m) of the handheld RDF scan action. |
+
+## EW toolkit (for players, no Zeus needed)
+
+Every jammer and every player gets ACE actions so an EW team can play the cat-and-mouse in the field:
+
+| Action | Where | Who | What it does |
+|---|---|---|---|
+| **Toggle Radio Jammer** | on the jammer object | anyone | Switches that jammer on/off. |
+| **Disable Radio Jammer** | on the jammer object | engineers | Destroys the emitter (which, with destructible jammers on, removes it). |
+| **Scan for Radio Jammers** | self-interaction (ACE) | anyone | Reports the **bearing**, coarse **range** and **signal strength** to the nearest active jammer. Take bearings from two spots to triangulate the source. |
+
+## Turning jammers on/off and removing them from script
 
 Both take either the jammer **object** or its **id**. They are server-authoritative — safe to call from a trigger, a client or a script.
 
 ```sqf
 [myTower, false] call Waldo_fnc_JammerToggle;   // switch off (omit the bool to just flip it)
-[myTower, true]  call Waldo_fnc_JammerToggle;    // switch back on
-
 [myTower]        call Waldo_fnc_JammerRemove;    // remove the jammer, keep the object
 [myTower, true]  call Waldo_fnc_JammerRemove;    // remove the jammer AND delete the object
 ```
 
-A classic EW objective — blow the tower, comms come back:
+A classic EW objective is now automatic — because jammers are destructible by default, you don't even need a trigger:
 
 ```sqf
-// In the jammer tower's init:
+// In the jammer tower's init - blow it up in-game and comms come back on their own:
 [this, 600, "WEST"] call Waldo_fnc_Jammer;
-
-// In a trigger that fires when the tower is destroyed:
-[jammerTower] call Waldo_fnc_JammerRemove;
 ```
 
 ## Zeus usage
@@ -76,22 +110,23 @@ Three modules live under **Modules → Waldos Mission Modules** (Zeus Enhanced r
 
 | Module | Action |
 |---|---|
-| **Radio Jammer - Place** | Opens a dialog (radius, falloff, strength, affected side, map marker), then spawns an emitter and switches the jammer on. |
+| **Radio Jammer - Place** | Opens a dialog — radius, falloff, strength, affected side, **cone arc + bearing** (arc 360 = omni), **pulsing** and map marker — then spawns an emitter and switches the jammer on. |
 | **Radio Jammer - Toggle Nearest** | Flips the nearest jammer on/off. |
 | **Radio Jammer - Remove Nearest** | Removes the nearest jammer and deletes its object. |
 
-The placed emitter is added to the curator, so you can drag or delete it like any Zeus object.
+The placed emitter is added to the curator, so you can drag or delete it like any Zeus object, and (with the GM overlay on) you'll see it floating-marked in the world.
 
 ## Global options (`init.sqf`)
 
 ```sqf
 Waldo_Jamming_Enable = true;                                        // false = feature off entirely
-missionNamespace setVariable ["Waldo_Jamming_Notify", true, true];  // on-screen "RADIO JAMMED" prompt
+missionNamespace setVariable ["Waldo_Jamming_Notify", true, true];  // on-screen jamming HUD + chat feedback
+// plus the model toggles in the table above
 ```
 
 ## How it works (for the curious)
 
-The jammer list is owned and broadcast by the server, so late-joining players inherit every jammer automatically. Each player runs the engine for whichever radio mod they have — an ACRE2 custom signal function and/or a TFAR loop — reading that live list. A link is jammed when **either** end of it (the radio receiving *or* the radio transmitting) is inside an active field that affects your side and matches the band. That means both "your radio is in the jammed zone" and "the person calling you is standing in a jammer" degrade the call.
+The jammer list is owned and broadcast by the server, so late-joining players inherit every jammer automatically. Each player runs the engine for whichever radio mod they have — an ACRE2 custom signal function and/or a TFAR loop — reading that live list through a shared calculator (`Waldo_fnc_JammingFactor`) that applies the whole model (duty cycle, sides, band, cone, terrain LOS, burn-through, falloff). A link is jammed when **either** end of it (the radio receiving *or* the radio transmitting) is inside an active field that affects your side and matches the band. That means both "your radio is in the jammed zone" and "the person calling you is standing in a jammer" degrade the call.
 
 ## See also
 

--- a/wiki/Waldos-Mission-Pack-Zeus-Modules.md
+++ b/wiki/Waldos-Mission-Pack-Zeus-Modules.md
@@ -58,7 +58,7 @@ Below is an example of the custom mission end screen:
 
 Three modules drive the [Radio Jamming](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Jamming) system live in-game (works with ACRE2 and TFAR):
 
-* **Radio Jammer - Place** — opens a dialog to set the jamming **radius**, **falloff**, **strength**, the **side** it jams and whether to drop a **map marker**, then spawns an emitter at the module position and switches it on. The emitter is added to the curator so it can be dragged or deleted like any Zeus object.
+* **Radio Jammer - Place** — opens a dialog to set the jamming **radius**, **falloff**, **strength**, the **side** it jams, a directional **cone arc + bearing** (arc 360 = omnidirectional), whether it **pulses**, and whether to drop a **map marker**, then spawns an emitter at the module position and switches it on. The emitter is added to the curator so it can be dragged or deleted like any Zeus object.
 * **Radio Jammer - Toggle Nearest** — flips the nearest jammer on or off (no dialog).
 * **Radio Jammer - Remove Nearest** — removes the nearest jammer and deletes its emitter.
 

--- a/wiki/Waldos-Mission-Pack-Zeus-Modules.md
+++ b/wiki/Waldos-Mission-Pack-Zeus-Modules.md
@@ -62,4 +62,11 @@ Three modules drive the [Radio Jamming](https://github.com/AdamWaldie/WaldosMiss
 * **Radio Jammer - Toggle Nearest** — flips the nearest jammer on or off (no dialog).
 * **Radio Jammer - Remove Nearest** — removes the nearest jammer and deletes its emitter.
 
-See the [Radio Jamming](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Jamming) page for the full scripting API and the ACRE2 signal-model requirement.
+The Place dialog also offers a directional **cone**, **pulsing**, and an **also jam UAVs / drones** option (counter-UAS). See the [Radio Jamming](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Jamming) page for the full scripting API and the ACRE2 signal-model requirement.
+
+# EMP & Signal Tracker Modules
+
+Two more electronic-warfare modules (full detail on the [EW: EMP & Signal Trackers](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Electronic-Warfare-EMP-And-Signal-Trackers) page):
+
+* **EMP Detonation** — a dialog for **radius** and **duration**, then detonates an electromagnetic pulse at the module position: infantry in range lose NVGs and TFAR radio use, vehicles have their engines cut, and players get a white-out flash and clear message. Units/vehicles marked with `Waldo_fnc_EMPImmune` are spared.
+* **Plant Signal Tracker** — tags the nearest unit or vehicle so a chosen side follows it live on the map (hidden from the tracked side).

--- a/wiki/Waldos-Mission-Pack-Zeus-Modules.md
+++ b/wiki/Waldos-Mission-Pack-Zeus-Modules.md
@@ -53,3 +53,13 @@ However, this variation allows the zeus to end the mission utilising a custom en
 
 Below is an example of the custom mission end screen:
 ![Mission End Screen Example](https://i.imgur.com/xmK9I1e.png)
+
+# Radio Jammer Modules
+
+Three modules drive the [Radio Jamming](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Jamming) system live in-game (works with ACRE2 and TFAR):
+
+* **Radio Jammer - Place** — opens a dialog to set the jamming **radius**, **falloff**, **strength**, the **side** it jams and whether to drop a **map marker**, then spawns an emitter at the module position and switches it on. The emitter is added to the curator so it can be dragged or deleted like any Zeus object.
+* **Radio Jammer - Toggle Nearest** — flips the nearest jammer on or off (no dialog).
+* **Radio Jammer - Remove Nearest** — removes the nearest jammer and deletes its emitter.
+
+See the [Radio Jamming](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Jamming) page for the full scripting API and the ACRE2 signal-model requirement.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -45,6 +45,7 @@
     * [ACRE 2 Automated CEOI](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Automated-CEOI-Document)
     * [ACRE 2 Babel Autoconfig](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Babel-Configuration)
     * [Radio Jamming (ACRE2 / TFAR)](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Jamming)
+    * [EW: EMP & Signal Trackers](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Electronic-Warfare-EMP-And-Signal-Trackers)
     * **Miscellaneous**
     * [Mission Diagnostics](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Diagnostics)
     * [Cover / Loading Screen Generation](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Cover-Loading-Screen-Generation)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -44,6 +44,7 @@
     * [ACRE 2 Short Range Radio](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE-2-Squad-Level-Radios-AN-PRC%E2%80%90343-Automatic-Setup)
     * [ACRE 2 Automated CEOI](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Automated-CEOI-Document)
     * [ACRE 2 Babel Autoconfig](https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE2-Babel-Configuration)
+    * [Radio Jamming (ACRE2 / TFAR)](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Jamming)
     * **Miscellaneous**
     * [Mission Diagnostics](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Diagnostics)
     * [Cover / Loading Screen Generation](https://github.com/AdamWaldie/WaldosMissionPack/wiki/Cover-Loading-Screen-Generation)


### PR DESCRIPTION
**When merged this pull request will:**

**Radio jamming (ACRE2 & TFAR) — the core**
- Add localised, area-denial radio jamming for **both ACRE2 and TFAR** — a jammer is any world object with a radius; radios inside its field lose comms with a linear falloff at the edge
- Add `Waldo_fnc_Jammer` (server-authoritative create/register) with radius, per-side targeting, per-band jamming (ACRE2), falloff, strength, active toggle, map marker, **directional cone** (`[bearing, arc]`), **duty-cycle pulsing** (`[on, off]`) and a **jam-UAV** flag; calling it again on the same object updates in place
- Add `Waldo_fnc_JammerToggle` / `Waldo_fnc_JammerRemove` (by object or id, server-authoritative)
- ACRE2 engine (`Waldo_fnc_JammingAcreSignal`) installs an `acre_api_fnc_setCustomSignalFunc` hook that attenuates ACRE2's own signal core; TFAR engine (`Waldo_fnc_JammingTfarLoop`) drives `tf_receivingDistanceMultiplicator` / `tf_sendingDistanceMultiplicator` / `tf_unable_to_use_radio`; both share `Waldo_fnc_JammingFactor` and pass through untouched when no jammers exist
- Server-authoritative broadcast registry (`Waldo_Jamming_Registry`), mirroring the Safestart pattern, so JIP players inherit every jammer

**Heavy model**
- **Terrain line-of-sight** occlusion (`terrainIntersectASL`), **radio-power burn-through** (stronger radios shrink the field), **linear/inverse-square** falloff curves — all global toggles in `init.sqf`

**EW toolkit (players)**
- **Destructible jammers** — a Killed handler auto-deregisters a destroyed emitter, so "blow the tower to restore comms" needs no trigger
- ACE interaction on jammer objects (**Toggle** / **Disable**), a handheld **RDF scanner** ACE self-action (`Waldo_fnc_JammerScan`) reporting bearing/range/strength, and a **GM Draw3D overlay** (curators only)

**UAV / UGV jamming (counter-UAS)**
- A jammer with `jamUAV` set freezes autonomous drones' AI (`Waldo_fnc_JammingUavServer`, server) and degrades then severs a controlling player's datalink (`Waldo_fnc_JammingUavClient`, client)
- Same deliberately loud feedback as radio jamming (see below)

**EMP burst**
- `Waldo_fnc_EMP` — one-shot area pulse (strips NVGs, cuts TFAR radios, kills vehicle engines for a duration with revert, white-out flash + message), `Waldo_fnc_EMPImmune` exemption tag, and an **EMP Detonation** Zeus module. No polling loops — free to leave available

**Signal trackers (C-Track)**
- `Waldo_fnc_Tracker` — tag a unit/vehicle so a chosen side follows it live via **side-local** map markers (hidden from the tracked side); ACE **Plant Signal Tracker** action + Zeus module; auto-drops dead targets

**Feedback — deliberately unmistakable** (Arma radio/UAV bugs otherwise look identical to jamming)
- A persistent, blinking HUD banner on the mission display (`Waldo_fnc_JammingHud`, IDCs 5310/5311) that other hints can't overwrite, showing a live strength %, a bar, and an explicit **"not a game bug"** line — for both radio and UAV jamming — backed by entry banners, a periodic chat reminder and a "COMMS/LINK RESTORED" clear

**Zeus modules** (all under "Waldos Mission Modules"): Radio Jammer — Place / Toggle Nearest / Remove Nearest, EMP Detonation, Plant Signal Tracker

**Wiring & docs**
- Register all functions and Zeus modules; add the model/notify flags to `init.sqf`; add a jamming section to Mission Diagnostics; new `MissionScripts/MissionInit/Jamming/` and `MissionScripts/MissionInit/ElectronicWarfare/` folders
- Documented to the standard upheld in existing files: in-file headers on every script, CLAUDE.md (feature guide + directory layout + ACRE2/TFAR API notes + ZEN list + file list), README, and the wiki — new **Radio-Jamming** and **Electronic-Warfare-EMP-And-Signal-Trackers** pages plus updates to the sidebar, Feature Tutorials, Home, Mission Configuration Reference and Zeus Modules pages
- Both validators (`sqf_validator.py`, `config_style_checker.py`) pass — 557 SQF files, 0 errors

**Notes**
- The whole suite is inert until used — engines pass through with an empty registry, EMP/trackers have no background loops when unplaced.
- ACRE2 requires the **LOS Multipath** (default) or **Arcade** signal model; the custom signal hook is not called under *LOS Simple* (documented in-file and in the wiki).
- Design cross-checked against Antistasi radio towers and Crows Electronic Warfare (closest-jammer-wins, destructible emitter, all-frequency area denial) — matched and extended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxegSWNygNiS8sGtzQ6rYk