### PR TITLE
Disable ACE Hearing volume update in init.sqf

### DIFF
--- a/init.sqf
+++ b/init.sqf
@@ -108,6 +108,12 @@ ACE_maxWeightCarry = 6000;
 
 /*===========================================================================================================================*/
 
+// Note that its due to Ace Hearing fucking with CBA & Vanilla audio commands (https://github.com/acemod/ACE3/issues/4029)
+ace_hearing_disableVolumeUpdate = true;
+
+
+/*===========================================================================================================================*/
+
 /*
 AI Tweak setup
 These commands initiate Waldos AI Tweaks. It is an Either/OR situation, where the DAY OR NIGHT mode can be active per mission.


### PR DESCRIPTION
**When merged this pull request will:**
- Set `ace_hearing_disableVolumeUpdate = true;` in `init.sqf`
- Prevent ACE Hearing's volume update from conflicting with CBA & vanilla audio commands ([acemod/ACE3#4029](https://github.com/acemod/ACE3/issues/4029))

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQeZ9Zm3sUhUr7eJVvwNqt)_