### PR TITLE
Fix tag-authoritative release packaging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@master
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -60,3 +60,39 @@ jobs:
           args: release/WMP_Exemplar_Mission-${{ steps.get_version.outputs.VERSION }}.zip application/zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  sync-main-version:
+    name: Sync main branch version and cover image
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Get the version
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Pillow (cover image generator)
+        run: pip install Pillow
+      - name: Bump description.ext to the release version
+        run: python3 releaseVerificationAndDeployment/set_description_version.py "${{ steps.get_version.outputs.VERSION }}"
+      - name: Regenerate cover image from description.ext
+        run: python3 releaseVerificationAndDeployment/generateLoadingScreen.py
+      - name: Commit and push if either file changed
+        run: |
+          if git diff --quiet -- description.ext Pictures/loading.jpg; then
+            echo "description.ext and cover image already match this release; nothing to commit."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add description.ext Pictures/loading.jpg
+            git commit -m "ci: bump version to ${{ steps.get_version.outputs.VERSION }} and refresh cover image [skip ci]"
+            git push origin HEAD:main
+          fi

--- a/releaseVerificationAndDeployment/deploy.sh
+++ b/releaseVerificationAndDeployment/deploy.sh
@@ -3,20 +3,12 @@
 set -e
 
 VERSION_TAG=$*
-
-# Guard (Waldos Mission Pack release ordering):
-# The visible cover (Pictures/loading.jpg, rendered from description.ext's onLoadName) must
-# already match this release tag before we pack. If it doesn't, the version was not bumped on
-# main first, so update-cover.yml has not refreshed the README/committed cover for this tag.
-DESC_VERSION=$(python3 releaseVerificationAndDeployment/generateLoadingScreen.py --print-version)
 TAG_VERSION=${VERSION_TAG#v}      # strip an optional leading "v"
 TAG_CORE=${TAG_VERSION%%-*}       # drop a prerelease suffix (e.g. 4.8.0-rc1 -> 4.8.0)
-if [ "$DESC_VERSION" != "$TAG_CORE" ]; then
-  echo "ERROR: description.ext version (v${DESC_VERSION}) does not match release tag (${VERSION_TAG})." >&2
-  echo "Bump onLoadName in description.ext to v${TAG_CORE} and let update-cover.yml refresh" >&2
-  echo "Pictures/loading.jpg on main before publishing this release." >&2
-  exit 1
-fi
+
+# The release tag is authoritative. Update only this workflow checkout before packaging so the
+# shipped mission title and generated cover always match without requiring a pre-release commit.
+python3 releaseVerificationAndDeployment/set_description_version.py "${TAG_CORE}"
 
 mkdir release/
 

--- a/releaseVerificationAndDeployment/set_description_version.py
+++ b/releaseVerificationAndDeployment/set_description_version.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+Author: WaldoTheWarfighter
+Rewrites the version number inside description.ext's onLoadName field in place while preserving
+the rest of the mission title and file. The release workflow uses this helper so the release tag
+is the single source of truth for the packaged version and generated loading screen.
+
+Arguments:
+  version - version to write, such as 4.8.1, v4.8.1 or v4.8.1RC.
+  --desc  - optional description.ext path (default: repository description.ext).
+
+Return Value:
+  Exits zero after updating the file, or non-zero when the file/version field cannot be read.
+
+Example:
+  python3 releaseVerificationAndDeployment/set_description_version.py v4.8.1RC
+
+Current callers:
+  .github/workflows/deploy.yml and releaseVerificationAndDeployment/deploy.sh.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+PROJECT_ROOT = os.path.dirname(SCRIPT_DIR)
+DEFAULT_DESC = os.path.join(PROJECT_ROOT, "description.ext")
+VERSION_PATTERN = re.compile(r'(onLoadName\s*=\s*"[^"]*v)(\d+\.\d+(?:\.\d+)?)("[^;]*;)')
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Set the version rendered in description.ext's onLoadName."
+    )
+    parser.add_argument("version", help='Version to write, e.g. "4.8.1" or "v4.8.1RC"')
+    parser.add_argument("--desc", default=DEFAULT_DESC)
+    args = parser.parse_args()
+
+    # description.ext uses the numeric mission-pack version. The full tag, including RC/prerelease
+    # text, remains available to package names and the cover generator invoked by deploy.sh.
+    match = re.match(r"^[vV]?(\d+\.\d+(?:\.\d+)?)", args.version)
+    if not match:
+        sys.exit("ERROR: release version must start with X.Y or X.Y.Z: " + args.version)
+    version = match.group(1)
+
+    try:
+        with open(args.desc, "r", encoding="utf-8", errors="replace") as handle:
+            text = handle.read()
+    except OSError as exc:
+        sys.exit("ERROR: cannot read description.ext ({}): {}".format(args.desc, exc))
+
+    new_text, count = VERSION_PATTERN.subn(r"\g<1>" + version + r"\g<3>", text, count=1)
+    if count == 0:
+        sys.exit("ERROR: could not find a version to replace in onLoadName in " + args.desc)
+    if new_text != text:
+        with open(args.desc, "w", encoding="utf-8") as handle:
+            handle.write(new_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/releaseVerificationAndDeployment/test_full_arma_audit.py
+++ b/releaseVerificationAndDeployment/test_full_arma_audit.py
@@ -31,6 +31,8 @@ SQF_VALIDATOR = importlib.util.module_from_spec(SQF_VALIDATOR_SPEC)
 assert SQF_VALIDATOR_SPEC and SQF_VALIDATOR_SPEC.loader
 SQF_VALIDATOR_SPEC.loader.exec_module(SQF_VALIDATOR)
 
+VERSION_HELPER_PATH = ROOT / "releaseVerificationAndDeployment" / "set_description_version.py"
+
 
 class FullAuditTests(unittest.TestCase):
     @staticmethod
@@ -44,6 +46,44 @@ class FullAuditTests(unittest.TestCase):
         release_config = json.loads((ROOT / "releaseVerificationAndDeployment" / "config.json").read_text(encoding="utf-8"))
         self.assertTrue(license_text.startswith("MIT License"))
         self.assertIn("LICENSE", release_config["build"]["include"])
+
+    def test_release_tag_updates_version_cover_then_packages_and_syncs_main(self):
+        deploy = (ROOT / "releaseVerificationAndDeployment" / "deploy.sh").read_text(
+            encoding="utf-8"
+        )
+        workflow = (ROOT / ".github" / "workflows" / "deploy.yml").read_text(
+            encoding="utf-8"
+        )
+        version_update = deploy.index("set_description_version.py")
+        cover_update = deploy.index("generateLoadingScreen.py")
+        package_build = deploy.index("build.py --deploy")
+        self.assertLess(version_update, cover_update)
+        self.assertLess(cover_update, package_build)
+        self.assertNotIn("description.ext version", deploy)
+        self.assertTrue(VERSION_HELPER_PATH.is_file())
+        self.assertIn("sync-main-version:", workflow)
+        self.assertIn("needs: build", workflow)
+        self.assertIn("set_description_version.py", workflow)
+        self.assertIn("generateLoadingScreen.py", workflow)
+        self.assertIn("$GITHUB_OUTPUT", workflow)
+        self.assertNotIn("::set-output", workflow)
+
+    def test_release_version_helper_accepts_rc_tag_without_persisting_suffix(self):
+        helper_spec = importlib.util.spec_from_file_location(
+            "set_description_version", VERSION_HELPER_PATH
+        )
+        helper = importlib.util.module_from_spec(helper_spec)
+        assert helper_spec and helper_spec.loader
+        helper_spec.loader.exec_module(helper)
+        source = 'onLoadName = "Waldo Mission Pack v4.8.0";\n'
+        match = re.match(r"^[vV]?(\d+\.\d+(?:\.\d+)?)", "v4.8.1RC")
+        self.assertIsNotNone(match)
+        updated, count = helper.VERSION_PATTERN.subn(
+            r"\g<1>" + match.group(1) + r"\g<3>", source, count=1
+        )
+        self.assertEqual(1, count)
+        self.assertIn("v4.8.1", updated)
+        self.assertNotIn("RC", updated)
 
     def test_sqf_validator_rejects_known_engine_invalid_commands(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Outcome

Restores the release flow so the published tag is authoritative:

1. Update the packaged description.ext version from the tag.
2. Regenerate the loading-screen cover using the full tag, including RC text.
3. Build and upload the release packages.
4. After a successful build, synchronise the numeric mission version and regenerated cover back to main.

## Root cause

The merged audit PR replaced the tag-driven update with a strict pre-bump gate. Release 4.8.1RC therefore stopped before packaging because description.ext still contained 4.8.0.

## Verification

- Full audit: 96 tests passed.
- 4.8.1RC smoke test: mission title became 4.8.1; generated cover retained 4.8.1RC.
- Regression checks enforce version -> cover -> package ordering and reject deprecated set-output usage.
- git diff --check passes.
