### PR TITLE
Add mission-pack-config skill for configuring every WMP feature

### DIFF
--- a/.claude/skills/mission-pack-config/SKILL.md
+++ b/.claude/skills/mission-pack-config/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: mission-pack-config
+description: Configures WaldosMissionPack (WMP) — the Arma 3 mission scripting starter framework in this repo — for a specific mission. Covers every WMP system — loadout/logistics, AI rebalance, ACRE2 radio setup, paradrop, radio jamming/EMP/signal trackers, MHQ, respawn options, ENDEX/AAR, safestart, mission diagnostics, tasks/objectives, VVD, Zeus Enhanced modules, the Waldos Economy Systems suite, table minigames, interaction minigames, UI notifications, and the description.ext mission-maker checklist. Use this whenever the user wants to set up, enable, tune, or debug any WMP feature, wants "a mission configured with X", asks what a WMP variable or function does, or is editing init.sqf/initServer.sqf/initPlayerLocal.sqf/description.ext/economyConfig.sqf for this pack — even if they only name one feature, since features interact (e.g. ACRE2 setup depends on mission.sqm loadouts, Economy depends on Zeus Enhanced). Always check this skill before hand-writing WMP config from memory — the reference files are the faithful, current spec.
+---
+
+# WMP Mission Pack Configuration
+
+You are configuring WaldosMissionPack for a real mission. **Assume by default
+that you are working inside someone's own mission project, not the WMP
+development repo** — the normal user of this skill downloaded a WMP release
+zip and dropped its contents into their own `.vr`/`.altis`/etc. mission
+folder in Eden Editor. That has real consequences:
+
+- The mission folder will **not** contain `releaseVerificationAndDeployment/`
+  or any of its validators — that whole folder is dev tooling explicitly
+  excluded from every release build. Never assume `sqf_validator.py`,
+  `config_style_checker.py`, or `performance_audit.py` exist or can be run;
+  check before referencing them, and only expect them if you can confirm
+  you're actually inside the WMP dev repo itself (e.g. this repo).
+- **`mission.sqm` is never edited directly, by anyone, under any
+  circumstance.** It is Eden Editor's own saved binary-adjacent project
+  file; WMP only *reads* it at mission start to scrape loadouts. Every
+  change that touches it — placing objects, editing unit loadouts in ACE
+  Arsenal, syncing a Game Logic, moving something in 3D space, disabling
+  Binarize — is exclusively an Eden Editor GUI action for the user to
+  perform. This is instruction mode, always, with no exceptions.
+
+Mission makers using this pack are not scripters — they configure it through
+init files and Eden Editor, so precision matters more than cleverness: get
+variable names, function signatures, and defaults exactly right by reading
+the reference file for the feature in question rather than recalling it.
+`CLAUDE.md` at the WMP dev repo's root is the ultimate source of truth (you
+may not have access to it from inside a user's mission project — that's what
+the `references/` files are for); the files under `references/` are
+condensed, faithful extracts from it, split per feature so you don't have to
+load a 1000-line file for a one-feature request. If you do have `CLAUDE.md`
+available and it disagrees with a reference file, `CLAUDE.md` wins — treat
+that as a sign the reference file has drifted and needs updating.
+
+## Step 1: work out what you're actually able to do here
+
+Before touching any feature, decide which of the three output modes applies —
+this determines the *shape* of everything you produce, so get it right first:
+
+1. **Direct-edit mode** — you have file-edit tools (Edit/Write) and a shell
+   against the user's actual mission project folder. Edit `init.sqf`,
+   `initServer.sqf`, `initPlayerLocal.sqf`, `description.ext`, or
+   `MissionConfig/economyConfig.sqf` directly, then do the post-edit check in
+   Step 4 (which validators to run, if any, depends on what's actually
+   present in that folder — don't assume).
+2. **Patch mode** — you can see the files (or the user pasted their file
+   contents into chat) but have no execution tool, or editing isn't
+   appropriate yet (e.g. you're drafting for review). Produce exact snippets
+   plus a precise insertion point: which file, and which existing line/block
+   the snippet goes after or replaces. Never say "add this to init.sqf"
+   without saying *where* — mission makers will not know where variables like
+   `Waldo_AIRebalance_Enable` or `Waldo_Economy_Enable` already have a home.
+3. **Instruction mode** — always applies on top of the other two, for the
+   steps in Arma itself that no assistant can perform, chief among them
+   anything touching `mission.sqm`: placing objects and Game Logics in Eden
+   Editor, syncing objects, editing unit loadouts in ACE Arsenal, unchecking
+   mission Binarize, saving the mission. Also covers clicking a Zeus module
+   in a running mission. State these as a numbered checklist and do not
+   imply you've done them — you never edit `mission.sqm`, in any mode.
+
+If you're running as the ChatGPT wrapper (see `chatgpt/INSTRUCTIONS.md`),
+direct-edit mode is never available — you only have patch + instruction mode,
+and you'll need to ask the user to paste their current file contents before
+you can give a precise insertion point.
+
+## Step 2: find out what's actually in play
+
+Many WMP features silently no-op without their mod — spending effort
+configuring ACRE2 channels for a unit that doesn't have ACRE2 is wasted work,
+and the user may not think to mention it. Read `references/mod-detection.md`
+and either check the repo (mod-dependent code is always guarded by a
+`CfgPatches` check — grep for it) or ask the user directly:
+
+- CBA_A3 and ACE3 are **required** — assume present.
+- ACRE2, TFAR, Zeus Enhanced (ZEN), LAMBS are **optional** — ask, or check
+  what the user's `@mods` list / server config implies.
+
+Also ask (or infer from the request) which features they actually want
+configured. Don't silently configure the whole pack when they asked for one
+thing — but do mention features that depend on what they're touching (e.g.
+if they're setting up loadout crates, mention that ACE Arsenal editing of
+unit loadouts in Eden, not vanilla loadouts, is what feeds the crates).
+
+## Step 3: route to the feature reference
+
+Each file below is a condensed spec for one system: its config variables and
+defaults, its callable functions and params, the Zeus module(s) if any, and
+its known gotchas. Read only the ones relevant to the request.
+
+| Feature | Reference | Notes |
+|---|---|---|
+| Loadout & logistics (supply/medical crates, mission.sqm scraping) | `references/loadout-logistics.md` | Everything else depends on this |
+| AI rebalance (day/night skill profiles) | `references/ai-rebalance.md` | |
+| ACRE2 radio setup | `references/acre2.md` | Requires mod; depends on loadout system for group names |
+| Paradrop (HALO / static-line) | `references/paradrop.md` | |
+| Radio jamming (ACRE2 + TFAR) | `references/jamming.md` | |
+| EMP burst | `references/emp.md` | |
+| Signal trackers (C-Track) | `references/trackers.md` | |
+| MHQ / mobile command post | `references/mhq.md` | Eden Editor placement + sync required |
+| Respawn options | `references/respawn.md` | Never touch `respawnOnStart` |
+| ENDEX / After-Action Report | `references/endex-aar.md` | |
+| Safestart | `references/safestart.md` | |
+| Mission diagnostics | `references/diagnostics.md` | |
+| Tasks / objectives helper | `references/tasks.md` | |
+| Virtual Vehicle Depot (VVD) | `references/vvd.md` | WIP — warn the user |
+| Zeus Enhanced modules (registration overview) | `references/zeus-modules.md` | |
+| Waldos Economy Systems (Resource/Research/Build/Buy + Command) | `references/economy/README.md` → sub-files | Large — only load the sub-namespace(s) needed |
+| Table minigames + interaction minigames | `references/minigames.md` | |
+| UI notifications / recovery | `references/ui-notifications.md` | |
+| `description.ext` mission-maker checklist | `references/description-ext.md` | |
+
+## Step 4: after editing (direct-edit mode only)
+
+Check first whether `releaseVerificationAndDeployment/` actually exists in
+the project you're editing — it ships only in the WMP *development* repo,
+never in a release zip, so it usually won't be there in a mission maker's
+own project. If it's present:
+
+```bash
+python3 releaseVerificationAndDeployment/sqf_validator.py
+python3 releaseVerificationAndDeployment/config_style_checker.py
+```
+
+and, if you added or changed anything that loops, polls, or broadcasts
+repeatedly (a `waitUntil`, a `spawn` with a `while {true}`, a `remoteExec`
+inside a loop):
+
+```bash
+python3 releaseVerificationAndDeployment/performance_audit.py
+```
+
+Report validator output to the user rather than assuming success. If a
+validator fails, fix the underlying issue (tabs, missing semicolons, bracket
+mismatch) — don't work around it.
+
+If those scripts aren't present (the normal case for an end-user mission),
+there's no automated safety net — self-check by eye against the conventions
+below before telling the user the edit is done: no tab characters, every
+statement ends `;`, brackets/braces balance, and the file still has its
+header docblock if you added one. Say plainly that you couldn't run the
+pack's own validators, so a manual read of the changed section in-editor is
+still worth doing.
+
+## Rules that apply regardless of mode
+
+- **Never edit `mission.sqm`.** Not as a "quick fix," not to "just add one
+  object." Any change to it is an Eden Editor GUI action for the user —
+  route it through instruction mode, always.
+- **Never change `respawnOnStart`** in `description.ext` — it must stay `-1`;
+  the loadout-saving system depends on it.
+- **New `.sqf` files** should keep the standard header docblock (Author /
+  one-line description / Arguments with types+defaults / Return Value /
+  Example) — copy the format from any existing script under
+  `MissionScripts/`. If the file starts with `#include` lines, the header
+  goes *after* them. This is good practice in any mission project, not just
+  the WMP dev repo.
+- **New functions you want auto-preloaded** need a matching class entry in
+  `MissionScripts/WaldosFunctions.sqf` (`class Waldo { ... }`, following the
+  `Waldo_fnc_FunctionName` naming convention) — registration and file
+  creation are two separate steps, do both. A script called directly from an
+  object's init field doesn't need this.
+- **The CLAUDE.md/README/wiki documentation standard is a WMP-dev-repo-only
+  concern.** It only applies if you happen to be working inside the actual
+  WMP development repository (this repo) and are adding a genuinely new
+  feature to the pack itself — not when you're configuring an existing
+  feature for someone's mission, and not when those files don't exist in the
+  project you're in at all (the normal case for an end user's mission).
+- **Global state** lives in `missionNamespace` via
+  `setVariable ["Name", value, true]` (the `true` broadcasts to clients) —
+  keep the existing prefix convention (`Waldo_` general, `Logi_` logistics,
+  `WALDO_` all-caps for flags/thresholds) rather than inventing a new one.
+- Configuration belongs in the init files (`init.sqf` shared, `initServer.sqf`
+  server-only, `initPlayerLocal.sqf` per-player) or `MissionConfig/economyConfig.sqf`
+  — never hardcode mission-specific values inside `MissionScripts/` implementation
+  files themselves.
+
+## When you're unsure
+
+If a reference file doesn't cover something the user is asking about, or
+you're not confident a variable/function still exists as described, read the
+relevant section of `CLAUDE.md` directly (or grep the actual `.sqf` under
+`MissionScripts/`) rather than guessing — mission makers copy what you give
+them verbatim into a live mission, and a wrong classname or param order fails
+silently or breaks a briefing at the worst time.

--- a/.claude/skills/mission-pack-config/chatgpt/INSTRUCTIONS.md
+++ b/.claude/skills/mission-pack-config/chatgpt/INSTRUCTIONS.md
@@ -1,0 +1,68 @@
+You are a configuration assistant for WaldosMissionPack (WMP), an Arma 3
+mission scripting starter framework. Your knowledge files are the same
+`references/*.md` used by the Claude version of this assistant — one file
+per WMP feature (loadout/logistics, AI rebalance, ACRE2, paradrop, jamming,
+EMP, trackers, MHQ, respawn, ENDEX/AAR, safestart, diagnostics, tasks, VVD,
+Zeus modules, the Economy Systems suite, minigames, UI notifications,
+description.ext) plus `mod-detection.md`. Route each request to the
+relevant file(s) before answering — don't answer WMP config questions from
+general knowledge, since exact variable names, function params, and defaults
+matter and this pack is not something you were trained on directly.
+
+## The one thing that's different from the Claude version
+
+**You have no filesystem access to the user's actual mission project.** You
+cannot read their `init.sqf`, cannot edit anything, and cannot see their
+`mission.sqm`. This means:
+
+- You always operate in **patch mode + instruction mode**, never
+  direct-edit mode. Every code change you produce is a snippet the user
+  copies themselves — never claim to have "added" or "edited" anything.
+- Because you can't see their files, you can't know *where* a snippet
+  should go without asking. **Ask the user to paste the relevant section of
+  their `init.sqf` / `initServer.sqf` / `initPlayerLocal.sqf` /
+  `description.ext`** (whichever file the feature touches) before giving a
+  final snippet — a snippet with no insertion point is not useful to
+  someone who isn't a scripter. If they've already pasted enough of the
+  file, skip asking again.
+- **`mission.sqm` is never something you edit or ask them to paste for you
+  to modify.** Any WMP feature that needs Eden Editor work — placing
+  objects, syncing a Game Logic, editing loadouts in ACE Arsenal, toggling
+  Binarize off — is a numbered instruction list for the user to carry out
+  themselves in the Arma 3 Eden Editor. State these clearly; never imply you
+  performed them.
+- You cannot run WMP's validators (`sqf_validator.py`,
+  `config_style_checker.py`, `performance_audit.py`) — they don't ship in a
+  WMP release anyway (dev-only tooling), so this isn't a capability gap
+  specific to you. Do your own manual check instead: no tabs, every
+  statement ends `;`, brackets balance, and any new `.sqf` file keeps the
+  standard header docblock (Author / description / Arguments / Return Value
+  / Example — copy the format from an existing script if the user can paste
+  one).
+
+## Rules carried over from the Claude version
+
+- **Never suggest changing `respawnOnStart`** in `description.ext` — it must
+  stay `-1`, the loadout-saving system depends on it.
+- Unit loadouts must be edited via **ACE Arsenal in Eden Editor** — vanilla
+  default loadouts produce empty/incomplete supply crates. This is the most
+  common root cause when a user reports empty crates.
+- Mission **Binarization must be disabled** (Eden Editor → mission
+  Properties → uncheck Binarize) for `mission.sqm` to be readable by the
+  loadout scanner.
+- Keep the existing global-variable prefix convention: `Waldo_` general,
+  `Logi_` logistics, `WALDO_` all-caps for flags/thresholds — don't invent a
+  new prefix.
+- Many features silently do nothing without their mod (ACRE2, TFAR, Zeus
+  Enhanced). Check `mod-detection.md` and ask which the user has before
+  configuring something that depends on one.
+
+## When you don't know
+
+If a reference file doesn't cover something, say so plainly rather than
+guessing at a classname, function signature, or param order — the user will
+paste what you give them directly into a live mission, and a wrong value
+fails silently or breaks something at the worst possible time (usually
+during an event). Point them to the WMP wiki
+(https://github.com/AdamWaldie/WaldosMissionPack/wiki) for anything the
+reference files don't cover.

--- a/.claude/skills/mission-pack-config/references/acre2.md
+++ b/.claude/skills/mission-pack-config/references/acre2.md
@@ -1,0 +1,43 @@
+# ACRE2 radio setup
+
+Requires the ACRE2 mod (`acre_main` in `CfgPatches`) — check `mod-detection.md`
+first if unsure it's in play.
+
+## Config (`init.sqf`)
+
+```sqf
+private _RadioSetups = [
+    ["Viking-1-1", [1,5]],   // [group name, [LR channel numbers]]
+    ["Viking 5",   [2,7]],
+    ["Banshee",    [4,1]]
+];
+[_RadioSetups] call Waldo_fnc_ACRE2Init;
+```
+
+- **Group names must match exactly** what's set in the Eden Editor group
+  name field — this is the #1 source of "radios aren't assigning" reports.
+  If it isn't working, ask the user to confirm the exact Eden group name
+  character-for-character (case and spacing matter).
+- Channel numbers are **1-indexed** positions into
+  `Waldo_ACRE2Setup_LRChannels_BLUFOR/OPFOR/IND/CIV` (set earlier in
+  `init.sqf`) — not raw channel numbers. `[1,5]` means "first and fifth
+  entries in that side's channel array," so the array must have at least 5
+  entries for that example to resolve.
+- Short-range (AN/PRC-343) radios are assigned automatically based on squad
+  numerical designations — no config needed for those.
+- CEOI (the radio reference card) auto-populates in the map screen from this
+  same setup; no separate configuration.
+
+## Known limitation
+
+Channel *naming* via `setPresetChannelField "label"` does not display
+in-game (it causes radio inconsistency) — this is why the labelling code in
+`ACRE2Init.sqf` is commented out. Channel names only ever show in the CEOI
+map entry; the radios themselves are numbered only. Don't try to "fix" this
+by re-enabling that code — it's a known ACRE2 limitation, not a WMP bug.
+
+## Jamming interaction
+
+If the mission also uses WMP's radio jamming (see `jamming.md`), the ACRE2
+signal model must be **LOS Multipath** (default) or **Arcade** — jamming's
+custom signal hook is never called under *LOS Simple*.

--- a/.claude/skills/mission-pack-config/references/ai-rebalance.md
+++ b/.claude/skills/mission-pack-config/references/ai-rebalance.md
@@ -1,0 +1,25 @@
+# AI rebalance (AITweak)
+
+Config lives in `init.sqf`:
+
+```sqf
+Waldo_AIRebalance_Enable = true;
+Waldo_AIRebalance_Profile = "LEGACY"; // LEGACY | PUBLIC | STANDARD | VETERAN
+["DAY", Waldo_AIRebalance_Profile] call Waldo_fnc_AITweak;
+```
+
+- First arg is `"DAY"` or `"NIGHT"` — NIGHT reduces unaided (no-NVG) spotting
+  more strongly than NVG-assisted spotting, so call it again at
+  dusk/dawn transitions if the mission has a day/night cycle worth tuning for.
+- `LEGACY` preserves the pack's original, established balance — pick this if
+  the mission has been running with WMP before and shouldn't feel different.
+- `PUBLIC`, `STANDARD`, `VETERAN` are lower-lethality/balanced alternatives
+  for new missions; missions can layer faction- and role-specific hash-map
+  overrides on top of whichever profile is chosen (ask if the user wants
+  this level of granularity — it's an advanced option, not needed by default).
+- All-machine initialiser by design: AI ownership and detonation-event
+  locality can move across server, client, and headless-client machines, so
+  don't restructure this to run server-only.
+- Runtime changes are also available via **Waldos Mission Modules** in Zeus,
+  which routes through `Waldo_fnc_FeatureRuntimeApply` — same effect as
+  editing `init.sqf`, useful for adjusting mid-mission without a restart.

--- a/.claude/skills/mission-pack-config/references/description-ext.md
+++ b/.claude/skills/mission-pack-config/references/description-ext.md
@@ -1,0 +1,31 @@
+# description.ext mission-maker checklist
+
+Fields every mission maker should edit before shipping a mission:
+
+```
+author          = "YOURNAMEHERE";
+onLoadName      = "Mission Pack v4.8.0";   // mission title
+onLoadMission   = "YOURTEXTHERE";
+maxPlayers      = 31;                       // set to your playercount
+respawnDelay    = 20;                       // seconds
+```
+
+Replace `Pictures\loading.jpg` with a custom loading screen image if the
+mission wants its own cover (the WMP dev repo generates this
+programmatically from `onLoadName`'s version string — that generator itself
+lives in `releaseVerificationAndDeployment/`, which is dev-only tooling and
+won't be present in a mission maker's own project; for an end-user mission,
+just drop in a replacement JPG).
+
+## Never touch
+
+`respawnOnStart` **must stay `-1`** — the loadout-saving system depends on
+it. This is the single most important "don't touch this" in the whole pack;
+flag it explicitly if a user's request would change it (e.g. "I want players
+to spawn once and not respawn at all" needs a different mechanism, not this
+field).
+
+## Custom end screen
+
+If configuring `Waldo_fnc_ENDEX`'s custom end path (see `endex-aar.md`),
+`CfgDebriefing` → `End1` also lives in `description.ext`.

--- a/.claude/skills/mission-pack-config/references/diagnostics.md
+++ b/.claude/skills/mission-pack-config/references/diagnostics.md
@@ -1,0 +1,34 @@
+# Mission diagnostics
+
+Read-only server + client health check at mission start, run after the
+loadout scan. Every RPT entry uses one searchable frame:
+
+```
+[WMP DIAG][run=...][node=SERVER|CLIENT:<owner>][area=...][feature=...][level=...][event=...]
+```
+
+A hosted server also surfaces warnings via `systemChat`.
+
+## Config (`initServer.sqf`)
+
+```sqf
+// Set false to silence startup diagnostics in a released mission.
+missionNamespace setVariable ["Waldo_RunDiagnostics", true, true];
+```
+
+For a released/live mission (not QA), it's reasonable to suggest setting
+this `false` to avoid RPT noise and player-facing warning chat — mention
+this as an option rather than a default recommendation, since it's also
+useful for the user to leave on while first configuring the pack.
+
+## What it checks
+
+Distinguishes `LOADED`, `ACTIVE`, `DISABLED`, `UNCONFIGURED`,
+`UNAVAILABLE`, `ERROR`. Covers representative public APIs, mod dependencies,
+loadouts, configured classes, mission flow, MHQ, VVD, electronic warfare,
+party games, interaction equipment, Economy, Zeus registration, local HUD
+state, 3D markers, and ACE-vs-vanilla actions.
+
+The latest report broadcasts as `Waldo_Diagnostics_LastReport`:
+`[warningCount, finishedAt, serverChecks, clientReports, runId]` — useful if
+scripting something that should wait for or react to the diagnostic pass.

--- a/.claude/skills/mission-pack-config/references/economy/README.md
+++ b/.claude/skills/mission-pack-config/references/economy/README.md
@@ -1,0 +1,35 @@
+# Waldos Economy Systems — index
+
+A self-contained, **pub-Zeus** RTS-style economy suite: Resource / Research /
+Build / Buy, plus Ground Command. 449 functions across six sub-namespaces —
+this is the largest single system in WMP, so read only the sub-file(s) the
+request actually touches:
+
+| Sub-namespace | File | Covers |
+|---|---|---|
+| Core / bootstrap / Zeus infra | `core.md` | Enabling the suite, presets, commitment mode, Zeus menu/dialog infra, authority model |
+| Resource | `resource.md` | Resource types, crates, capturable zones |
+| Research | `research.md` | Research Center, catalog, prerequisites |
+| Build | `build.md` | Build catalog, construction, upgrades, RADAR |
+| Buy | `buy.md` | Purchase terminals, drop points |
+| Ground Command | `command.md` | Trusted-player permissions for spending/research/build |
+
+**Always start with `core.md`** even for a single-subsystem request — it
+covers the enable flag, the authority model every subsystem depends on, and
+whether Zeus Enhanced is even required for what the user wants to do.
+
+## Zeus Enhanced dependency
+
+Without ZEN, the suite still runs server-side (income, research, production,
+request handling) but exposes **no in-game authoring menu** — the mission
+maker must hand-author `MissionConfig/economyConfig.sqf` instead. Check
+`../mod-detection.md` before assuming the Zeus menu route is available.
+
+## Architecture note (for context, not something to reconfigure)
+
+Registered under `class Waldo` in `WaldosFunctions.sqf`, callable as
+`Waldo_fnc_EcoCore_*`, `Waldo_fnc_EcoResource_*`, `Waldo_fnc_EcoResearch_*`,
+`Waldo_fnc_EcoBuild_*`, `Waldo_fnc_EcoBuy_*`, `Waldo_fnc_EcoCommand_*`.
+Bootstrap is `Waldo_fnc_EcoInit`
+(`MissionScripts/EconomySystems/economyInit.sqf`). Global state uses the
+`WaldoEco<System>_` variable prefix.

--- a/.claude/skills/mission-pack-config/references/economy/build.md
+++ b/.claude/skills/mission-pack-config/references/economy/build.md
@@ -1,0 +1,33 @@
+# Economy — Build system
+
+Read `core.md` first for the enable flow and authority model.
+
+## What it does
+
+A build catalog (classname/cost/requirements/upkeep/production/storage/
+speed boosts), construction jobs, upgrades, build limits, plus a RADAR
+feature.
+
+## Setup entry points
+
+```sqf
+setBuildCatalog       // define buildable classes and their cost/requirement/upkeep profile
+```
+
+Or designate an existing Eden-placed vehicle as a construction vehicle:
+
+```sqf
+[this] call Waldo_fnc_EcoBuild_registerConstructionVehicle;   // any vehicle
+```
+
+**Construction intentionally converts and consumes its source vehicle** —
+this is deliberate, not a bug to work around. The confirmation UI warns
+before the action, and a timed notice names the vehicle consumed afterward.
+If a user is surprised their construction vehicle "disappeared," this is
+why.
+
+## Function namespace
+
+Callable as `Waldo_fnc_EcoBuild_*`. Full function list isn't enumerated in
+`CLAUDE.md` — check script headers under `MissionScripts/EconomySystems/Build/`
+or the wiki for exhaustive param detail beyond the entry points above.

--- a/.claude/skills/mission-pack-config/references/economy/buy.md
+++ b/.claude/skills/mission-pack-config/references/economy/buy.md
@@ -1,0 +1,30 @@
+# Economy — Buy system
+
+Read `core.md` first for the enable flow and authority model.
+
+## What it does
+
+Purchase vehicles with configurable drop points and requirements.
+
+## Setup entry points
+
+```sqf
+setPurchaseCatalog     // define purchasable vehicles and requirements
+createDropPoint        // where purchased vehicles arrive
+```
+
+Or designate an existing Eden-placed object as a purchase terminal:
+
+```sqf
+[this] call Waldo_fnc_EcoBuy_registerTerminal;   // on a Land_Laptop_unfolded_F
+```
+
+## Object tagging
+
+Purchase terminal: `Land_Laptop_unfolded_F`.
+
+## Function namespace
+
+Callable as `Waldo_fnc_EcoBuy_*`. Full function list isn't enumerated in
+`CLAUDE.md` — check script headers under `MissionScripts/EconomySystems/Buy/`
+or the wiki for exhaustive param detail beyond the entry points above.

--- a/.claude/skills/mission-pack-config/references/economy/command.md
+++ b/.claude/skills/mission-pack-config/references/economy/command.md
@@ -1,0 +1,18 @@
+# Economy — Ground Command
+
+Read `core.md` first for the enable flow and authority model.
+
+## What it does
+
+Designates trusted players who may spend resources, order research, or
+manage builds on behalf of a side — the permissions layer over the other
+three systems. Without this, decide whether the mission wants Economy
+actions open to everyone on a side or gated to specific trusted players;
+ask if unclear, since it changes who can spend a side's shared resources.
+
+## Function namespace
+
+Callable as `Waldo_fnc_EcoCommand_*`. Full function list isn't enumerated
+in `CLAUDE.md` — check script headers under
+`MissionScripts/EconomySystems/Command/` or the wiki for exhaustive param
+detail.

--- a/.claude/skills/mission-pack-config/references/economy/core.md
+++ b/.claude/skills/mission-pack-config/references/economy/core.md
@@ -1,0 +1,103 @@
+# Economy — core / bootstrap / authority model
+
+## Enabling (OFF by default — missions that don't use it pay no cost)
+
+```sqf
+// init.sqf - runs on all machines, self-branches server authority vs. client menu:
+Waldo_Economy_Enable = true;
+if (Waldo_Economy_Enable) then {
+    [] spawn Waldo_fnc_EcoInit;
+};
+```
+
+Or drop the **`[WMP] Waldos Economy Systems`** composition (in
+`WMP_Compositions/`) into the editor — its object boots the suite from its
+own init field independent of this flag. This is the simplest path for a
+mission maker who just wants it running — mention it as the default
+recommendation over hand-editing `init.sqf` unless they want more control.
+
+**Place only one Economy Systems object per mission** — this is an Eden
+Editor placement rule (instruction mode).
+
+## Editor / script-time setup (no Zeus needed)
+
+`Waldo_fnc_EcoInit` calls `Waldo_fnc_EcoCore_applyMakerConfig`, which reads
+optional maker variables once on the server authority (broadcast, so
+JIP/rejoining players inherit them) and applies them via the existing
+import/preset functions. Set in `initServer.sqf`:
+
+```sqf
+// A bundled preset:
+missionNamespace setVariable ["Waldo_Economy_Preset", "MEDIUM", true];   // LOW | MEDIUM | HIGH
+missionNamespace setVariable ["Waldo_Economy_PresetSides", [["WEST","NATO"],["EAST","CSAT"],["GUER","AAF"]], true];
+// or a full configuration exported from the Zeus "Export" tool (wins over a preset):
+missionNamespace setVariable ["Waldo_Economy_ConfigString", "...", true];
+// optional perf toggle:
+missionNamespace setVariable ["Waldo_Economy_CommitmentMode", true, true];
+```
+
+For drag-and-go, the preset-specific compositions **`[WMP] Waldos Economy
+Systems - Low/Medium/High Preset`** set `Waldo_Economy_Preset` in their
+object init and boot the suite — recommend these over manual variable
+setting for a mission maker who just wants a working default fast.
+
+## Full hand-authored economy (`MissionConfig/economyConfig.sqf`)
+
+The dedicated authoring file (registered as `Waldo_fnc_EcoMakerSetup`, run
+once on the authority by `applyMakerConfig` after presets). Defines catalogs
+and places world objects via server-authoritative helpers:
+`addResourceType`, `setResearchCatalog`, `setBuildCatalog`,
+`setPurchaseCatalog`, `createResourceZone`, `spawnResourceCrate`,
+`spawnResearchCenter`, `createDropPoint`. Ships a gated worked example
+(`_useExample`) — point the user at it as a template rather than writing a
+catalog from scratch.
+
+Editor-placed vanilla objects can be designated from their init field (no
+addon required — true Eden modules would need one, which WMP is not):
+
+```sqf
+[this] call Waldo_fnc_EcoResearch_registerCenter;         // on a Land_Research_HQ_F
+[this] call Waldo_fnc_EcoBuy_registerTerminal;             // on a Land_Laptop_unfolded_F
+[this] call Waldo_fnc_EcoBuild_registerConstructionVehicle; // on any vehicle
+```
+
+## Authority model (read this before editing any Economy code)
+
+All shared state (catalogs, side resources, zones, jobs) and all global
+world-object/marker creation are gated by
+`Waldo_fnc_EcoCore_canRunAuthority` / `canRunBackgroundAuthority`, which
+return **`isServer`** — the server is the single authority, background
+loops (income, production, research progress, request processing) run
+exactly once. Client-only work (ZEN module registration, ACE action setup,
+dialogs, request *publishing*) is gated by `hasInterface`.
+
+Because ZEN custom-module code runs on the **curator's client**, the seven
+object-creation functions (research center, resource crate, resource zone,
+building, construction vehicle, purchase laptop, drop point) forward
+themselves to the server via `remoteExec [..., 2]` when called off the
+authority — this is what makes placement work on a **dedicated** server, not
+just SP/listen-host. If extending Economy code: mutate shared state only
+under `canRunAuthority` and broadcast it; never gate client-local work on
+`canRunAuthority`; route any new world-object creation through the
+authority the same way.
+
+## Operational notes
+
+- `Waldo_fnc_EcoCore_isActive` — whether the suite is running; gate
+  dependent scripts on this.
+- Failed player actions (insufficient resources / unmet requirements / no
+  drop point) report via `systemChat` to the actor
+  (`Waldo_fnc_EcoCore_notifyActor`) — not silent failure.
+- **Commitment mode** is a performance toggle only: ON freezes live
+  config-catalog refresh polling in the Zeus menus to cut server load. Turn
+  it on once the economy is configured; it doesn't affect gameplay.
+- **Purge** removes the suite for the rest of the mission (sets a broadcast
+  purged flag that also stops JIP re-init) — it is not a reset. Restart the
+  mission to run the economy again after a purge. Don't suggest Purge as a
+  way to "reload" the economy mid-mission.
+- **Economy Setup Builder** (Resource/Research/Construction/Purchasing
+  domain builders) translates Zeus-authored settings/placements into
+  readable calls to the same public functions used in
+  `economyConfig.sqf` — good for a mission maker who authored live in Zeus
+  and now wants a permanent, restart-safe config file. Portable catalogue
+  strings remain available via Config Copy and Import.

--- a/.claude/skills/mission-pack-config/references/economy/research.md
+++ b/.claude/skills/mission-pack-config/references/economy/research.md
@@ -1,0 +1,32 @@
+# Economy — Research system
+
+Read `core.md` first for the enable flow and authority model.
+
+## What it does
+
+A Research Center where a side spends resources on custom research entries
+with costs, prerequisites, and mutual exclusivity.
+
+## Setup entry points
+
+```sqf
+setResearchCatalog       // define the research catalog (cost/prereqs/exclusivity)
+spawnResearchCenter       // world object hosting the research UI
+```
+
+Or designate an existing Eden-placed vanilla object:
+
+```sqf
+[this] call Waldo_fnc_EcoResearch_registerCenter;   // on a Land_Research_HQ_F
+```
+
+## Object tagging
+
+Research center: `Land_Research_HQ_F`.
+
+## Function namespace
+
+Callable as `Waldo_fnc_EcoResearch_*`. As with Resource, the full function
+list isn't enumerated in `CLAUDE.md` — go to the script headers under
+`MissionScripts/EconomySystems/Research/` or the wiki for exhaustive param
+detail beyond the entry points above.

--- a/.claude/skills/mission-pack-config/references/economy/resource.md
+++ b/.claude/skills/mission-pack-config/references/economy/resource.md
@@ -1,0 +1,36 @@
+# Economy — Resource system
+
+Read `core.md` first for the enable flow and authority model — this file
+only covers what's specific to Resource.
+
+## What it does
+
+Define arbitrary resources (name/colour/icon/storage cap), spawn
+collectable resource crates, and create capturable zones that passively
+generate resources (with deposit caps). Per-side storage limits apply.
+
+## Setup entry points
+
+```sqf
+addResourceType        // define a resource in the catalog (name/colour/icon/storage cap)
+createResourceZone      // capturable zone, passive generation, deposit cap
+spawnResourceCrate      // collectable world crate
+```
+
+These are called from `MissionConfig/economyConfig.sqf` (hand-authored) or
+produced by the Zeus "Economy Setup Builder" export (see `core.md`). World
+objects created this way are gated through the server authority — see
+`core.md`'s authority section before adding new resource-related object
+creation.
+
+## Object tagging
+
+Resource crates are tagged by class: `Land_PlasticCase_01_medium_F`.
+
+## Function namespace
+
+Callable as `Waldo_fnc_EcoResource_*`. The exhaustive function list isn't
+enumerated in `CLAUDE.md` — if a specific function's exact params are
+needed beyond the setup entry points above, check the script header in
+`MissionScripts/EconomySystems/Resource/` if the project has it, or the
+Waldos Economy Systems wiki pages.

--- a/.claude/skills/mission-pack-config/references/emp.md
+++ b/.claude/skills/mission-pack-config/references/emp.md
@@ -1,0 +1,26 @@
+# EMP burst
+
+One-shot electromagnetic pulse — an area electronics kill, the offensive
+counterpart to the (persistent) jammer. Server-authoritative; runs no
+polling loops (fires once, reverts on a timer) so it's safe to leave
+available in every mission.
+
+```sqf
+[getPosATL myObject, 200, 30] call Waldo_fnc_EMP;   // [position, radius(m), duration(s)]
+[commandVehicle] call Waldo_fnc_EMPImmune;          // exempt a unit/vehicle (occupants inherit)
+```
+
+## Effects in radius (non-immune)
+
+- Infantry lose NVGs and (TFAR) radio use for the duration.
+- Vehicles have their engine cut (fuel drained, restored after).
+- Every affected **player** gets a white-out flash.
+
+Set `Waldo_EMP_NotifyAffectedPlayers = true` for an explicit local
+disruption notice — defaults off. Applied per-entity on its owning machine
+via `Waldo_fnc_EMPApply`.
+
+## Zeus
+
+**EMP Detonation** module (dialog: radius / duration). Parameters are
+written to RPT, not chat.

--- a/.claude/skills/mission-pack-config/references/endex-aar.md
+++ b/.claude/skills/mission-pack-config/references/endex-aar.md
@@ -1,0 +1,56 @@
+# ENDEX / mission end + After-Action Report
+
+```sqf
+[] spawn Waldo_fnc_ENDEX;
+```
+
+Freezes the mission: broadcasts "ENDEX ENDEX ENDEX", locks all weapons (ACE
+safety mode), heals all players, deletes fired rounds, sets all AI to
+CARELESS/BLUE, makes all players invincible. Also reachable via the Zeus
+Enhanced **Call Endex** module.
+
+## AAR is part of the same flow, not a separate feature
+
+The ENDEX hint shows an After-Action Report automatically if AAR tracking is
+running. Tracking starts on its own from `initServer.sqf` via
+`[] call Waldo_fnc_AARTrack`, which registers a single `EntityKilled`
+handler (fires on all machines, so server-side registration still captures
+every kill). If `Waldo_AAR_StartTime` is unset, ENDEX just omits the AAR
+block — no separate toggle needed for the common case.
+
+```sqf
+Waldo_ENDEX_ReportDuration // seconds the combined end report stays visible, default 45
+```
+
+## What the AAR reports
+
+Duration, KIA per side, player losses, vehicles lost per side, WIA per side,
+friendly-fire incidents, an objective summary, and a top-fraggers
+leaderboard. Each line is omitted automatically when its tally is empty —
+nothing to configure there.
+
+- Vehicle losses / friendly fire / fraggers all come from the same
+  `EntityKilled` handler reading `_killer`/`_instigator`: same-side kill =
+  friendly fire; enemy kill by a human player feeds the leaderboard
+  (`Waldo_AAR_Frags`).
+- **WIA requires ACE medical.** An `ace_unconscious` listener in `init.sqf`
+  forwards each unit's first unconsciousness to the server via
+  `Waldo_fnc_AARWound`. Without ACE medical loaded, WIA simply won't count —
+  not a bug, just a dependency to be aware of.
+- Objective summary populates automatically from `Waldo_fnc_CreateObjective`
+  / `Waldo_fnc_SetObjectiveState` (see `tasks.md`) — no separate wiring.
+
+## Custom end screen
+
+Configure `CfgDebriefing` → `End1` in `description.ext`, then trigger with:
+
+```sqf
+[[], "End1"] call BIS_fnc_endMission;
+```
+
+## Relationship to Safestart
+
+ENDEX and Safestart keep separate authoritative state — a Safestart lift
+never removes an active ENDEX freeze. For rehearsals/QA,
+`[] call Waldo_fnc_ENDEXReset` removes ENDEX-owned handlers without lifting
+an active Safestart. See `safestart.md`.

--- a/.claude/skills/mission-pack-config/references/jamming.md
+++ b/.claude/skills/mission-pack-config/references/jamming.md
@@ -1,0 +1,88 @@
+# Radio jamming (ACRE2 + TFAR)
+
+Localised, area-denial jamming. A *jammer* is any world object with a
+radius; radios inside lose comms with linear falloff at the edge. Enabled by
+default (`Waldo_Jamming_Enable = true` in `init.sqf`) but **has zero effect
+until a jammer is placed** — safe to leave on in every mission.
+
+## Architecture
+
+Server-authoritative registry (`Waldo_Jamming_Registry`), client-local
+engines. Placing/toggling/removing jammers always goes through the server
+(calls forward automatically if made from a client). Each client installs
+the radio engines from `init.sqf` (JIP-safe) — the ACRE2 custom signal
+function and/or TFAR throttle loop, plus an on-screen jammed watcher.
+
+## Placing a jammer
+
+```sqf
+// Object init field, simple form:
+[this] call Waldo_fnc_Jammer;                         // 300m, jams everyone, all bands
+[this, 500, "EAST"] call Waldo_fnc_Jammer;             // 500m, OPFOR only
+// Full params, from a trigger/script:
+[myTower, 800, "ALL", [[30, 88]], 50, 1, true, true, [90, 60], [4, 2], true] call Waldo_fnc_Jammer;
+// params: [object, radius, affectedSides, bands, falloff, strength, active, createMarker, sector, duty, jamUAV]
+```
+
+Returns a numeric jammer id.
+
+- `affectedSides`: `"ALL"`, a side, or an array; accepts side values or
+  strings (`"WEST"/"BLUFOR"`, `"EAST"/"OPFOR"`, `"IND"/"INDFOR"`,
+  `"CIV"/"CIVILIAN"`).
+- `bands`: `"ALL"` or array of `[minMHz, maxMHz]` ranges — **ACRE2 only**,
+  TFAR jamming is always broadband regardless of this param.
+- `sector`: `[]` for omni, `[bearing, arc]` for a directional cone.
+- `duty`: `[]` constant, or `[onSec, offSec]` to pulse.
+- `jamUAV`: also jams drones in the field (see UAV section below).
+
+## Managing jammers (server-authoritative, safe from a client)
+
+```sqf
+[myTower, false] call Waldo_fnc_JammerToggle;   // switch off (omit bool to flip)
+[myTower, true]  call Waldo_fnc_JammerRemove;   // remove + delete the object
+```
+
+## Global model flags (`init.sqf`)
+
+| Flag | Default | Effect |
+|---|---|---|
+| `Waldo_Jamming_LOS` | `true` | Terrain between jammer and radio blocks the field |
+| `Waldo_Jamming_BurnThrough` | `true` | Higher-power radios resist jamming (effective radius shrinks by `(power/ref)^0.35`) |
+| `Waldo_Jamming_BurnThroughRef` | `500` | Reference radio power (mW) |
+| `Waldo_Jamming_Curve` | `"LINEAR"` | Falloff shape: `"LINEAR"` or `"INVSQ"` |
+| `Waldo_Jamming_Destructible` | `true` | Destroying the jammer object auto-deregisters it |
+| `Waldo_Jamming_GmOverlay` | `false` | Curator-only Draw3D marker/facing-line over each jammer |
+| `Waldo_Jamming_ScanRange` | `3000` | Detection range (m) of the handheld RDF ACE self-action |
+
+```sqf
+Waldo_Jamming_Enable = true;                                          // false = feature off entirely
+missionNamespace setVariable ["Waldo_Jamming_Notify", true, true];    // on-screen "radio jammed" prompt
+```
+
+## Player-facing actions
+
+Every jammer object gets ACE actions **Toggle Radio Jammer** (anyone) and
+**Disable Radio Jammer** (engineers, destroys it). Every player gets an ACE
+self-action **Scan for Radio Jammers** (`Waldo_fnc_JammerScan`) reporting
+bearing / coarse range / strength to the nearest active emitter.
+
+## UAV / UGV jamming (`jamUAV = true`)
+
+Drones in the field are jammed too: the server freezes autonomous drone AI
+(`Waldo_fnc_JammingUavServer`); a controlling player's client
+(`Waldo_fnc_JammingUavClient`) degrades the video feed as the link weakens
+and severs the terminal link at near-total jamming, showing a persistent
+`UAV LINK DEGRADED` panel (IDC 5311) then a separate datalink-loss notice. A
+UAV with an actively connected player remains an engine edge case with no
+guaranteed teardown — mention this caveat if a user is relying on it.
+
+## Model requirement
+
+ACRE2 jamming only works under signal model **LOS Multipath** (default) or
+**Arcade** — never under *LOS Simple* (see `acre2.md`).
+
+## Zeus ("Waldos Mission Modules")
+
+**Jammer: Place New Emitter** (full dialog matching the script params above,
+plus per-emitter curator 3D marker and emitter class), **Jammer: Toggle
+Nearest Emitter**, **Jammer: Delete Nearest Emitter**.

--- a/.claude/skills/mission-pack-config/references/loadout-logistics.md
+++ b/.claude/skills/mission-pack-config/references/loadout-logistics.md
@@ -1,0 +1,44 @@
+# Loadout & logistics system
+
+This is the foundation almost everything else depends on — configure it
+first, or at least understand it before touching ACRE2, crates, or Zeus
+logistics modules.
+
+## How it works
+
+`initServer.sqf` scans **every playable unit placed in Eden Editor**
+(`Waldo_fnc_SideBaseLoadoutSetup`) by reading `mission.sqm`, extracts
+weapons/ammo/clothing/items, deduplicates, and stores the result globally per
+side: `Logi_MissionSQMArray_West/East/Ind/Civ`. These arrays power supply
+crate contents, limited ACE arsenals, and Zeus logistics modules.
+
+## The one rule mission makers must follow
+
+**Unit loadouts must be edited using ACE Arsenal in Eden Editor.** Vanilla
+default loadouts produce empty or incomplete crates — this is the single
+most common WMP support question. If a user says crates are empty, this is
+the first thing to check (that, and whether Binarize is disabled).
+
+**Mission Binarization must be disabled**: right-click the mission in the
+editor → Properties → uncheck Binarize. Without this, `mission.sqm` isn't
+readable as text and the whole scan silently produces nothing. Both of these
+are Eden Editor GUI steps — instruction mode, never something you do
+directly, and never something achieved by editing `mission.sqm`.
+
+## Config (`initServer.sqf`)
+
+```sqf
+missionNamespace setVariable ["Logi_SupplyBoxClass", "B_supplyCrate_F", true];
+missionNamespace setVariable ["Logi_MedicalBoxClass", "ACE_medicalSupplyCrate_advanced", true];
+```
+
+These just set the classnames used when supply/medical crates are spawned
+(by Zeus modules or scripts) — swap in whatever crate object the mission
+uses.
+
+## TFAR note
+
+`missionFileLookup.sqf` also reads the `radio` inventory slot from
+`mission.sqm`, so TFAR radios placed via Eden's native radio assignment flow
+in the loadout automatically end up in supply crates too, with no extra
+config.

--- a/.claude/skills/mission-pack-config/references/mhq.md
+++ b/.claude/skills/mission-pack-config/references/mhq.md
@@ -1,0 +1,23 @@
+# MHQ / Mobile Command Post
+
+Setup is mostly Eden Editor work — **instruction mode** for steps 1-4.
+
+1. Place a vehicle (or static object) with a variable name, e.g. `MHQ_1`.
+2. Place a Game Logic near it.
+3. Place the tent/crate objects to be deployed and **sync each one to the
+   Logic** (not the vehicle) — this is the step users most often get wrong
+   (syncing to the vehicle instead of the Logic silently breaks deployment).
+4. Raise ground-placed objects ~1ft if using a vehicle, to account for
+   suspension settling.
+5. In the vehicle's init field (this part is a script call, safe to hand
+   over as a paste-in snippet):
+
+```sqf
+[this] call Waldo_fnc_MHQSetup;
+// or with options:
+[this, true, true, 180, 4] call Waldo_fnc_MHQSetup;
+// params: [vehicle, modernAudio, enableLogistics, logiBearing, logiDistance]
+```
+
+Players get ACE3 "Deploy/Tear Down Command Post" actions. Deployed state
+creates a named respawn point and map marker automatically.

--- a/.claude/skills/mission-pack-config/references/minigames.md
+++ b/.claude/skills/mission-pack-config/references/minigames.md
@@ -1,0 +1,125 @@
+# Waldos Mini Games — table games + interaction challenges
+
+Two complementary but independent systems under one feature name. Ask which
+one the user actually means — "minigames" is used for both, and they have
+different enable flags and setup paths. Full tutorial:
+https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Mini-Games
+
+## 1. Table games (multiplayer, seated)
+
+Twelve games: Battleship, Who's Who: Vehicles, Shotgun Roulette, Blackjack,
+Texas Hold'em, Five-Card Draw, Liar's Dice, Chess, Checkers, Connect Four,
+Rock Paper Scissors, UNO. Players walk up to a supported table object, seat
+(up to four), vote for a game, play. Server-authoritative; JIP-safe.
+
+Enable in `init.sqf`:
+
+```sqf
+Waldo_MiniGames_Enable = true;
+if (Waldo_MiniGames_Enable) then {
+    [] call Waldo_fnc_MiniGamesInit;
+};
+```
+
+Tables are detected **by class**: `Land_CampingTable_F`,
+`Land_CampingTable_small_F`, `Land_CampingTable_small_white_F`,
+`Land_TablePlastic_01_F`. If the user wants a different table object to
+work, that means adding its classname to `Waldo_MG_CFG_TABLE_CLASSES` in
+`MissionScripts/MiniGames/engine/config.sqf` — not something achievable
+purely from `init.sqf`. Other tuning constants (`Waldo_MG_CFG_*`) live in
+the same file.
+
+## 2. Field equipment procedures (single-player, generic interaction hook)
+
+Ten pass/fail procedures that gate any object interaction: `wirecut`,
+`minesweeper`, `keypad`, `lockpick`, `circuit`, `repair`, `radiotune`,
+`pressure`, `sequence`, `commandinput`. Each has distinct diegetic
+equipment, not a shared window. Works independently of table games —
+`Waldo_MiniGames_Enable = false` doesn't disable these; they register on
+first use.
+
+### Simple setup (recommended default)
+
+Eden Editor object init field:
+
+```sqf
+[this, "repair"] call Waldo_fnc_MiniGameInteractionSetup;
+```
+
+This wrapper supplies the action, equipment profile, icon, and default
+config; allows retries after failure; consumes the action after success;
+broadcasts `Waldo_MG_InteractionState` / `Waldo_MG_InteractionResult` (and
+legacy `Waldo_MG_InteractionComplete` / `Waldo_MG_InteractionFailed`
+booleans). Uses ACE where available, vanilla `addAction` as fallback with
+matching state.
+
+### Difficulty and presentation
+
+`difficulty`: `easy` | `standard` | `hard` | `expert` — changes workload,
+tolerance, and time, never legibility or accessible state cues. A supplied
+positional `config` overrides the difficulty preset entirely.
+
+Presentation hashmap (curated, doesn't touch difficulty): `preset`, `skin`
+(`default`, `olive`, `charcoal`, `sand`, `naval`, `hazard`), `actionTitle`,
+`manufacturer`, `model`, `title`, `briefing`, `objective`, `activation`,
+`controls`, `hint`, `statusText`, result/abort wording, `soundProfile`
+(`equipment` | `silent`), optional `texturePreset` (`olive`, `charcoal`,
+`naval`, `sand`) or explicit `texture` with opacity clamped `0..0.32`
+(default `0.14`). Never suggest exposing raw control positions or semantic
+colours in a mission-maker config — those stay template-owned so
+customization can't produce clipped or colour-only states.
+
+### Ready-made wrapper: bomb defuse
+
+```sqf
+[this] call Waldo_fnc_BombDefuseSetup;
+```
+
+Adds a "Defuse Bomb" interaction (wire-cut challenge) with
+detonate-on-failure. Pass an options array for `wireCount`, `timeLimit`,
+`detonateOnFailure`, `explosive`, etc. if the default needs tuning.
+
+### Generic hook (for custom success/failure logic)
+
+```sqf
+[object, challengeId, config, onSuccess, onFailure, options] call Waldo_fnc_MiniGameInteraction;
+```
+
+Call from the object's **init field** (runs on all machines). Success/failure
+callbacks run on the **server**, each receiving `[object, actor, success,
+result]` — use this when the outcome needs to drive something authoritative
+(spawning a follow-on event, changing an objective state) beyond the
+built-in state broadcasts.
+
+### Reading state (safe for ACE conditions — unscheduled, no side effects)
+
+```sqf
+[object] call Waldo_fnc_MiniGameInteractionGetState;
+[object, "RUNNING"] call Waldo_fnc_MiniGameInteractionStateIs;
+[object] call Waldo_fnc_MiniGameInteractionGetResult;
+```
+
+`Waldo_fnc_MiniGameInteractionReset` is server-only; normal reset refuses a
+`RUNNING` attempt, forced reset invalidates it.
+
+### Accessibility (per-player, never changes difficulty)
+
+```sqf
+[] call Waldo_fnc_MiniGameAccessibility;
+```
+
+Local high-contrast, colourblind, large-text, outlines, reduced-motion, and
+audio-caption preferences.
+
+### Standalone / custom challenges
+
+- `Waldo_fnc_MiniGameChallenge` — run a challenge with no object, local
+  callbacks.
+- `Waldo_fnc_MiniGameRegisterChallenge` — register a new challenge (opener
+  contract `[_config, _resolve]`) if the built-in ten don't fit.
+- `Waldo_fnc_MiniGameInteractionTableSetup` — a separate opt-in Field
+  Equipment picker placed on a table; stays local, does not enter table-game
+  voting/seating/active-game state.
+- `Waldo_fnc_MiniGameEquipmentGallery` — developer visual-review picker for
+  all ten procedures, useful when a user wants to preview equipment styles
+  before committing to one.

--- a/.claude/skills/mission-pack-config/references/mod-detection.md
+++ b/.claude/skills/mission-pack-config/references/mod-detection.md
@@ -1,0 +1,47 @@
+# Mod detection
+
+WMP features guard themselves at the top of their scripts with a
+`CfgPatches` check and silently no-op (sometimes with a `systemChat` notice,
+sometimes fully silent) if the mod isn't loaded. Configuring a feature whose
+mod isn't present isn't harmful, but it is wasted effort and can confuse a
+mission maker who doesn't understand why nothing happened.
+
+## Required (assume present, don't ask)
+
+- **CBA_A3** — event system backbone, used everywhere.
+- **ACE3** — interaction menus, medical, arsenal, cargo/dragging, fortify,
+  safe-mode locking. ~80 call sites across the pack.
+
+## Optional (ask the user, or check their mod list / server config)
+
+| Mod | CfgPatches class checked | Powers |
+|---|---|---|
+| ACRE2 | `acre_main` | Radio channel auto-assignment, jamming's custom signal hook |
+| TFAR | `task_force_radio` or `tfar_core` | Jamming's distance-multiplier throttle (no scripting setup needed otherwise — Eden Editor native) |
+| Zeus Enhanced (ZEN) | `zen_main` | The entire "Waldos Mission Modules" Zeus menu, all Economy Zeus authoring |
+| LAMBS series | (varies by module) | Not directly integrated by WMP scripts; complements AI behaviour generally |
+
+## How to check in a live project
+
+```sqf
+if (isClass(configFile >> "CfgPatches" >> "acre_main")) then { ... };
+```
+
+If you have shell access to the mission's mod list / server launch config,
+grep for these mod folder names instead of asking. Otherwise just ask the
+user which of ACRE2 / TFAR / ZEN they're running — it's a fast question and
+avoids configuring dead code.
+
+## Consequences for common combinations
+
+- **No ZEN**: Economy Systems still runs server-side (income, research,
+  production, request handling) but has zero in-game authoring UI — the user
+  must hand-author `MissionConfig/economyConfig.sqf` instead. All 15 core +
+  19 Economy Zeus modules simply don't register.
+- **No ACRE2, no TFAR**: jamming's engines never install (both are gated),
+  so `Waldo_fnc_Jammer` etc. can still be placed but have no radios to
+  affect.
+- **ACE2 signal model set to "LOS Simple"**: ACRE2 jamming's custom hook is
+  never called even with ACRE2 present — the signal model must be
+  *LOS Multipath* (default) or *Arcade*. Worth checking explicitly if a user
+  reports jamming "not working" with ACRE2 installed.

--- a/.claude/skills/mission-pack-config/references/paradrop.md
+++ b/.claude/skills/mission-pack-config/references/paradrop.md
@@ -1,0 +1,34 @@
+# Paradrop (HALO / static-line)
+
+Most "Plane"-class assets get HALO/static-line jump actions automatically —
+no per-vehicle config needed in the common case.
+
+## Config (`initServer.sqf`)
+
+```sqf
+missionNamespace setVariable ["WALDO_STATIC_MINALTITUDE", 180, true];  // metres
+missionNamespace setVariable ["WALDO_STATIC_MAXALTITUDE", 350, true];
+missionNamespace setVariable ["WALDO_STATIC_MAXSPEED", 310, true];     // km/h
+missionNamespace setVariable ["WALDO_STATIC_STATICCHUTE", "rhs_d6_Parachute", true];
+missionNamespace setVariable ["WALDO_PARA_HALOALTITUDE", 1000, true];
+missionNamespace setVariable ["WALDO_PARA_HALOCHUTE", "B_Parachute", true];
+```
+
+- Static-line jumps only activate within the altitude/speed window above —
+  if a user reports "no jump option," check the aircraft's actual altitude
+  and speed against these thresholds first.
+- `WALDO_STATIC_STATICCHUTE` / `WALDO_PARA_HALOCHUTE` are parachute
+  classnames — swap for a mod's chute (e.g. an RHS one) if the mission uses
+  one instead of vanilla.
+
+## Custom / non-auto-detecting aircraft
+
+If a vehicle doesn't get the jump action automatically (custom mod aircraft
+sometimes don't), add to its **Eden Editor init field**:
+
+```sqf
+[this] call Waldo_fnc_VehicleJumpSetup;
+```
+
+This is a script call, not a `mission.sqm` edit — safe to give the user as a
+paste-into-init-field snippet even though it's placed via Eden.

--- a/.claude/skills/mission-pack-config/references/respawn.md
+++ b/.claude/skills/mission-pack-config/references/respawn.md
@@ -1,0 +1,31 @@
+# Respawn options
+
+`respawnOnStart = -1` in `description.ext` must **never** be changed — the
+loadout-saving system depends on it. If a user asks to "fix respawn" or
+change respawn behaviour, this specific setting is off-limits regardless of
+what else changes.
+
+Two optional behaviours in `initPlayerLocal.sqf` are commented out by
+default — uncomment whichever the mission wants:
+
+```sqf
+// Save loadout when closing ACE Arsenal (respawn with chosen kit):
+["ace_arsenal_displayClosed", {
+    [player, [missionNamespace, "Waldo_Player_Inventory"]] call BIS_fnc_saveInventory;
+}] call CBA_fnc_addEventHandler;
+
+// Respawn with what you died with (instead of starting kit):
+["CAManBase", "Killed", {
+    params ["_unit"];
+    if (_unit == player) then {
+        [_unit, [player, "Waldo_Player_Inventory"]] call BIS_fnc_saveInventory;
+    };
+}] call CBA_fnc_addClassEventHandler;
+```
+
+These are mutually meaningful choices, not a checklist to enable both
+blindly: "save on arsenal close" means players keep whatever kit they last
+built in Arsenal; "respawn with what you died with" means the death-moment
+inventory becomes the new spawn kit. Ask which behaviour the mission wants
+before uncommenting — enabling both can produce confusing double-saves
+depending on order of events.

--- a/.claude/skills/mission-pack-config/references/safestart.md
+++ b/.claude/skills/mission-pack-config/references/safestart.md
@@ -1,0 +1,41 @@
+# Safestart
+
+Freezes all players at mission start — the reversible mirror of ENDEX.
+While active: weapons safe, every shot/grenade/launcher/vehicle-weapon round
+is deleted, players take/deal no damage, players are confined to a safe
+zone, and an on-screen banner shows (with a live countdown if a timer is
+running). JIP and respawning players are re-frozen automatically.
+
+## Config (`initServer.sqf`) — auto-starts by default
+
+```sqf
+missionNamespace setVariable ["Waldo_SafeStart_Confine", true, true];   // safe-zone confinement on/off
+missionNamespace setVariable ["Waldo_SafeStart_Radius", 75, true];      // per-player radius (metres)
+missionNamespace setVariable ["Waldo_SafeStart_ZoneMarker", "", true];  // marker name for one shared zone (else per-player anchor)
+missionNamespace setVariable ["Waldo_SafeStart_AutoStart", true, true]; // false = no safestart at start
+```
+
+If a shared zone marker is used, it must exist in the mission (an Eden
+Editor placement — instruction mode). If left `""`, each player gets a
+per-player radius anchor instead — no marker needed.
+
+## Scripting API (server-authoritative, safe from a client)
+
+```sqf
+[true]  call Waldo_fnc_SafeStart;        // activate
+[false] call Waldo_fnc_SafeStart;        // go live (admin overrule; also cancels any countdown)
+[300]   call Waldo_fnc_SafeStartTimer;   // go live automatically in 300s (banner shows the clock)
+```
+
+Manual and timed go-live notices explain which protections were removed and
+stay visible for `Waldo_SafeStart_GoLiveHintDuration` seconds (default 12).
+
+## Relationship to ENDEX
+
+Separate authoritative state — see `endex-aar.md`.
+
+## Zeus ("Waldos Mission Modules")
+
+**Safestart - Activate**, **Safestart - Go Live (Lift)**, and **Safestart -
+Start Go-Live Countdown** (seconds, displayed as `MM:SS`; the Lift module
+can overrule the countdown at any time).

--- a/.claude/skills/mission-pack-config/references/tasks.md
+++ b/.claude/skills/mission-pack-config/references/tasks.md
@@ -1,0 +1,29 @@
+# Tasks / objectives helper
+
+A thin, JIP-safe wrapper over the BIS task framework for mission makers
+driving objectives from SQF/triggers rather than Eden's task module or the
+Zeus task module (both remain valid GUI alternatives — mention this isn't
+the only way to make tasks if the user seems to want the simpler Eden route
+instead). Server-authoritative — calling from a client forwards automatically.
+
+```sqf
+// Create an assigned task with a persistent map marker at the destination:
+["secure_lz", west, "Secure the LZ", "Clear and hold the landing zone.", getMarkerPos "lz1"]
+    call Waldo_fnc_CreateObjective;
+
+// Later, resolve it (also removes the helper-created marker):
+["secure_lz", "SUCCEEDED"] call Waldo_fnc_SetObjectiveState;
+```
+
+Params for `Waldo_fnc_CreateObjective`:
+`[taskId, owner, title, description, destination, state, createMarker, taskType]`
+(only the first five are required).
+
+This feeds the AAR's objective summary automatically (see `endex-aar.md`) —
+no separate wiring needed once objectives are created/resolved through
+these two functions.
+
+For exact optional-param behaviour, check the script headers in
+`MissionScripts/MissionFlowAndUi/createObjective.sqf` and
+`setObjectiveState.sqf` if available in the project — those headers are the
+authoritative param list.

--- a/.claude/skills/mission-pack-config/references/trackers.md
+++ b/.claude/skills/mission-pack-config/references/trackers.md
@@ -1,0 +1,20 @@
+# Signal trackers (C-Track)
+
+Plant a tracker on a unit or vehicle and a chosen side follows it live on
+the map — electronic recon. Server-authoritative registry
+(`Waldo_Tracker_Registry`, JIP-safe) with a light server prune loop that
+drops trackers whose target dies. Markers render **locally** on each
+tracking client (`Waldo_fnc_TrackerRender`), so they stay invisible to the
+tracked side.
+
+```sqf
+[enemyTruck, west, "Convoy Lead"] call Waldo_fnc_Tracker;   // [target, trackingSide, label]
+[cursorTarget] call Waldo_fnc_TrackerAttach;                // plant on what you're looking at, tracked by your own side
+[enemyTruck] call Waldo_fnc_TrackerRemove;                  // remove
+```
+
+## Player / Zeus access
+
+Players get an ACE **Plant Signal Tracker** action on units and vehicles.
+Zeus gets a **Plant Signal Tracker** module (attaches to the nearest unit,
+tracked by a chosen side).

--- a/.claude/skills/mission-pack-config/references/ui-notifications.md
+++ b/.claude/skills/mission-pack-config/references/ui-notifications.md
@@ -1,0 +1,34 @@
+# WMP UI notifications and recovery
+
+Padded, safe-zone-aware notification card, callable directly by mission
+makers:
+
+```sqf
+["OBJECTIVE UPDATED", "Secure the relay station.", "INFO", 10, "TOP", "OBJECTIVE", "JOINT OPERATIONS"]
+    call Waldo_fnc_ShowUiNotification;
+```
+
+Args: `[title, message, state, duration, placement, channel, source]`.
+
+- `state`: `INFO`, `SUCCESS`, `WARNING`, or `ERROR`.
+- `duration`: `0` = persistent (stays until replaced or cleared).
+- A screen `placement` has one owner — a newer card replaces rather than
+  overlaps an older one in the same spot. If two features both want a
+  persistent card in the same placement, they'll fight each other; pick
+  distinct placements or accept the replace-on-newer behaviour.
+- Client-local, dedicated-server safe.
+
+## Recovery
+
+```sqf
+[] call Waldo_fnc_ClearUiPanels;
+```
+
+Repeat-safe local recovery of all WMP-owned overlays/displays — use this if
+a player's screen has a stuck WMP panel rather than trying to hunt down
+which specific feature left it there.
+
+Players get **WMP Interface > Clear Stuck WMP UI** as an ACE self-action
+already; vanilla `addAction` installs automatically only when ACE
+interaction is unavailable. No setup needed — it runs on JIP and respawn
+with no authority scheduler or public state to configure.

--- a/.claude/skills/mission-pack-config/references/vvd.md
+++ b/.claude/skills/mission-pack-config/references/vvd.md
@@ -1,0 +1,28 @@
+# Virtual Vehicle Depot (VVD) — WIP, not recommended for live missions
+
+Always tell the user this is explicitly marked work-in-progress before
+configuring it, and suggest **ACE Garage** instead for a fully stable
+vehicle-spawning experience unless they specifically need VVD's feature set.
+
+```sqf
+[spawnerObject, helipad, types, allowedSides, sideCheck, removeUavs, range, script]
+    call Waldo_fnc_VVDInit;
+// types: ["Auto"], ["Ground"], ["All"] or specific type strings
+// allowedSides: ["ALL"], ["BLUFOR"], ["OPFOR"], ["INDEP"], ["CIV"]
+```
+
+## Known limitation
+
+Depot vehicles and their (UAV) crew are created with
+`createVehicle`/`createVehicleCrew` on whichever client pressed spawn.
+Vehicle removal routes deletion to the vehicle's owning machine via
+`Waldo_fnc_VVDPurgeVehicle` specifically because a client-side
+`deleteVehicle`/`deleteVehicleCrew` issued from a *different* machine
+silently no-ops on the remote object — this owner-routing fixes the
+dominant cause of orphaned UAV crew, but a UAV with a player actively
+connected via a terminal remains an engine edge case with no guaranteed
+teardown.
+
+If the user reports orphaned/duplicate vehicles or crew, this is the first
+thing to check — and if VVD is core to their mission design, recommend
+thorough testing with their exact mod set before relying on it live.

--- a/.claude/skills/mission-pack-config/references/zeus-modules.md
+++ b/.claude/skills/mission-pack-config/references/zeus-modules.md
@@ -1,0 +1,41 @@
+# Zeus Enhanced modules — registration overview
+
+Requires Zeus Enhanced (`zen_main`); silently does nothing without it.
+
+```sqf
+[] call Waldo_fnc_ZenInitModules; // already called for interface clients in initPlayerLocal.sqf
+```
+
+Registers the **"Waldos Mission Modules"** category. This overview file
+lists what's registered and which reference file covers configuring the
+underlying feature — use it to route a "what Zeus modules does WMP add"
+question, not as the primary config doc for any one feature.
+
+| Zeus module | Calls | Detail in |
+|---|---|---|
+| Player Supply Crate | `Waldo_fnc_ZenSupplySpawner` | `loadout-logistics.md` |
+| Field Hospital Crate | `Waldo_fnc_ZenMedicalSpawner` | `loadout-logistics.md` |
+| Call Endex | `remoteExec ["Waldo_fnc_ENDEX", 0, true]` | `endex-aar.md` |
+| Custom Mission End | `["end1"] remoteExec ["BIS_fnc_endMission", 0, true]` | `endex-aar.md` |
+| Fortify Budget Manager | `Waldo_fnc_FortifyBudgetModule` | ACE fortify budget, see CLAUDE.md ACE3 section |
+| Spawn AI Convoy | `Waldo_fnc_ZenConvoyModule` → `Waldo_fnc_SimpleAiConvoy` | turns nearest crewed land-vehicle group into a managed convoy |
+| Loadout Save Point | `Waldo_fnc_ZenLoadoutSaveModule` | `respawn.md` |
+| Safestart - Activate | `[true] remoteExec ["Waldo_fnc_SafeStart", 2]` | `safestart.md` |
+| Safestart - Go Live (Lift) | `[false] remoteExec ["Waldo_fnc_SafeStart", 2]` | `safestart.md` |
+| Safestart - Start Go-Live Countdown | `Waldo_fnc_ZenSafeStartTimer` | `safestart.md` |
+| Radio Jammer - Place | `Waldo_fnc_ZenJammerPlace` | `jamming.md` |
+| Radio Jammer - Toggle Nearest | `Waldo_fnc_ZenJammerToggle` | `jamming.md` |
+| Radio Jammer - Remove Nearest | `Waldo_fnc_ZenJammerRemove` | `jamming.md` |
+| EMP Detonation | `Waldo_fnc_ZenEMP` | `emp.md` |
+| Plant Signal Tracker | `Waldo_fnc_ZenTracker` | `trackers.md` |
+
+Waldos Economy Systems registers its own separate, larger set of Zeus
+modules (15 core + 19 Economy) — see `economy/README.md`, not this file.
+
+## Static vs runtime verification
+
+A repo-side static parity checker (`zeus_script_parity_checker.py`, in the
+WMP dev repo only) verifies registration wiring exists — it does not prove
+in-engine usability. If a user reports a Zeus module "not working" despite
+correct registration, the next step is checking runtime placement/locality
+in an actual Zeus session, not re-reading this file.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,13 @@ jobs:
           args: release/WMP_Exemplar_Mission-${{ steps.get_version.outputs.VERSION }}.zip application/zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Release Claude Mission Config Skill
+        continue-on-error: true
+        uses: JasonEtco/upload-to-release@master
+        with:
+          args: release/Claude_Mission_Config_Skill-${{ steps.get_version.outputs.VERSION }}.zip application/zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   sync-main-version:
     name: Sync main branch version and cover image

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,11 @@ python3 releaseVerificationAndDeployment/build.py --deploy
 python3 releaseVerificationAndDeployment/build.py --build config_ExemplarMission.json
 ```
 
-Build config: `releaseVerificationAndDeployment/config.json` defines an explicit `include` allowlist and the output name/version. New repository folders do not ship unless deliberately added. The builder rejects QA/tooling folders and runtime logs before and after archive creation; patch releases use the same allowlist. Output zips land in `release/`. The deploy workflow uploads the main WMP pack, patch, Compositions, and Unit Insignias. The dormant Exemplar build remains available manually but is not currently produced by `deploy.sh`.
+Build config: `releaseVerificationAndDeployment/config.json` defines an explicit `include` allowlist and the output name/version. New repository folders do not ship unless deliberately added. The builder rejects QA/tooling folders and runtime logs before and after archive creation; patch releases use the same allowlist. Output zips land in `release/`. The deploy workflow uploads the main WMP pack, patch, Compositions, Unit Insignias, and the Claude Mission Config Skill. The dormant Exemplar build remains available manually but is not currently produced by `deploy.sh`.
+
+### Claude Mission Config Skill (separate release item)
+
+`.claude/skills/mission-pack-config/` — a Claude Skill (usable with Claude Code or Claude.ai) that guides configuring every WMP feature for a mission. It is **not** included in the main WMP pack build (`config.json` deliberately excludes `.claude`); it ships as its own zip via `releaseVerificationAndDeployment/config_claudeSkill.json` (`scriptName: "Claude Mission Config Skill"`, `include: [".claude", "LICENSE"]`), built in `deploy.sh` alongside the other special builds and uploaded to the release as `Claude_Mission_Config_Skill-<version>.zip`. Unzipping it into a mission project drops `.claude/skills/mission-pack-config/` at that project's root, same layout as this repo. See the wiki's **Claude Mission Config Skill** page for usage with both Claude and ChatGPT, and `.claude/skills/mission-pack-config/SKILL.md` for the skill's own routing logic and per-feature reference files.
 
 ### Full development audit mission
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ to utilise critical systems of arma 3. Now, it is in continued use by at least f
 - Extensively documented files to learn how it works, and make use of this pack!
 - Mission Pack Compositions to hasten the learning and mission building process
 - Auto-generated cover/loading screen - the title and version are rendered programmatically from description.ext and kept in sync on every push and release.
+- Claude Mission Config Skill - a separate downloadable release item that teaches an AI assistant (Claude or ChatGPT) how to configure every feature in this pack for your mission, with per-feature reference docs and clear guidance on what it can safely edit for you versus what still needs doing by hand in Eden Editor.
 
 
 # QuickStart Guide

--- a/releaseVerificationAndDeployment/config.json
+++ b/releaseVerificationAndDeployment/config.json
@@ -6,7 +6,6 @@
             "MissionScripts",
             "MissionConfig",
             "Pictures",
-            ".claude",
             "description.ext",
             "init.sqf",
             "initPlayerLocal.sqf",

--- a/releaseVerificationAndDeployment/config.json
+++ b/releaseVerificationAndDeployment/config.json
@@ -6,6 +6,7 @@
             "MissionScripts",
             "MissionConfig",
             "Pictures",
+            ".claude",
             "description.ext",
             "init.sqf",
             "initPlayerLocal.sqf",

--- a/releaseVerificationAndDeployment/config_claudeSkill.json
+++ b/releaseVerificationAndDeployment/config_claudeSkill.json
@@ -1,0 +1,9 @@
+{
+    "build" : {
+        "scriptName": "Claude Mission Config Skill",
+        "include": [
+            ".claude",
+            "LICENSE"
+        ]
+    }
+}

--- a/releaseVerificationAndDeployment/deploy.sh
+++ b/releaseVerificationAndDeployment/deploy.sh
@@ -24,6 +24,7 @@ python3 releaseVerificationAndDeployment/build.py --deploy
 # Special Builds
 #python3 releaseVerificationAndDeployment/build.py --build config_ExemplarMission.json --deploy
 python3 releaseVerificationAndDeployment/build.py --build config_unitInsignias.json --deploy
+python3 releaseVerificationAndDeployment/build.py --build config_claudeSkill.json --deploy
 
 sed -i "s/DEVBUILD/${VERSION_TAG}/g" WMP_Compositions/*/header.sqe
 

--- a/wiki/Claude-Mission-Config-Skill.md
+++ b/wiki/Claude-Mission-Config-Skill.md
@@ -1,0 +1,53 @@
+# Claude Mission Config Skill
+
+> **Use this page when:** you want an AI assistant (Claude or ChatGPT) to help configure WMP features for your own mission.
+
+_Associated Files: `.claude/skills/mission-pack-config/SKILL.md`, `.claude/skills/mission-pack-config/references/*.md`, `.claude/skills/mission-pack-config/chatgpt/INSTRUCTIONS.md`_
+
+The Claude Mission Config Skill teaches an AI assistant how WMP's features are configured — variable names, function signatures, defaults, and known gotchas — so it can help you set up loadouts, ACRE2, jamming, the Economy suite, and everything else in this pack without guessing. It's built from the same source of truth as the rest of this documentation, split into one short reference file per feature so the assistant only has to read the parts relevant to what you're asking about.
+
+It ships as its **own separate download**, not inside the main WMP pack zip — look for `Claude_Mission_Config_Skill-<version>.zip` on the [releases page](https://github.com/AdamWaldie/WaldosMissionPack/releases) alongside the main pack, patch, Compositions, and Unit Insignias zips.
+
+## What it can and can't do for you
+
+The skill is honest about its own limits, and you should expect it to say so rather than pretend:
+
+- It can write and explain the exact `init.sqf` / `initServer.sqf` / `initPlayerLocal.sqf` / `description.ext` / `MissionConfig\economyConfig.sqf` snippets a feature needs, and — if it's running with file-editing tools against your actual mission project — apply them directly.
+- It will **never edit `mission.sqm`**, under any circumstance. Placing objects, syncing a Game Logic, editing unit loadouts in ACE Arsenal, and disabling Binarization are Eden Editor steps only you can do; the skill gives you a precise checklist instead of pretending to do them.
+- It will never touch `respawnOnStart` — that must stay `-1` for the loadout-saving system to work.
+- If you're using it inside your own mission project (the normal case — you downloaded a WMP release and dropped it in), it won't assume WMP's own validator scripts are available, because those are development tooling that never ships in a release. It'll do a manual sanity check of any script it writes instead.
+
+## Setup with Claude
+
+**Claude Code** (the CLI, or Claude Code on the web): unzip `Claude_Mission_Config_Skill-<version>.zip` into the root of your mission project, so you end up with `.claude/skills/mission-pack-config/` alongside your `init.sqf` and `mission.sqm`. Claude Code auto-discovers project skills under `.claude/skills/` — just ask it to configure a WMP feature (e.g. *"set up ACRE2 radios for my Viking squad on channels 1 and 5"*) and it will consult the skill automatically.
+
+**Claude.ai / Claude Desktop**: the same `.claude/skills/mission-pack-config/` folder can be uploaded as a Project's knowledge, or its `SKILL.md` and `references/*.md` pasted in directly if your workflow doesn't support folder uploads. Claude won't have file access to your mission project unless you're in an environment that grants it, so expect it to hand you snippets to paste yourself rather than edit files for you — this is the "patch mode" the skill describes internally.
+
+## Setup with ChatGPT
+
+ChatGPT has no equivalent to Claude Code's project-skill auto-discovery and no filesystem access to your mission project, so the skill ships a second, purpose-written entry point for it: `.claude/skills/mission-pack-config/chatgpt/INSTRUCTIONS.md`.
+
+1. Create a [Custom GPT](https://chatgpt.com/gpts/editor) (or a Project, if you're using ChatGPT's Projects feature).
+2. Paste the contents of `chatgpt/INSTRUCTIONS.md` into the Custom GPT's **Instructions** field.
+3. Upload every file under `references/` (including the `economy/` subfolder) as **Knowledge** files.
+4. Start asking it to help configure features, the same way you would with Claude.
+
+Because ChatGPT can't see your mission project, it will ask you to paste the relevant section of your `init.sqf` (or whichever file a feature touches) before giving you a snippet with a precise insertion point — that's expected, not a limitation of the skill itself.
+
+## Example prompts
+
+- *"Enable the AI rebalance system with the VETERAN profile for a new mission."*
+- *"Walk me through setting up a Mobile Command Post — what do I need to do in Eden versus in script?"*
+- *"My supply crates are empty, what's wrong?"* (this is almost always the ACE Arsenal loadout issue — see [Logistics, Starter Crates, and Quartermaster](Logistics-System,-Starter-Crates-And-Quartermaster))
+- *"Set up a radio jammer that only affects OPFOR within 500m and can be destroyed."*
+- *"I want the Economy suite running with a Medium preset for three sides — what do I put in initServer.sqf?"*
+
+## See also
+
+- [Mission Configuration Reference](Mission-Configuration-Reference)
+- [Feature Configuration Files](Feature-Configuration-Files)
+- [Coding and Documentation Standards](Coding-Standards)
+
+<!-- WMP-WIKI-NAV -->
+---
+[Wiki home](Home) · [Quickstart](Quickstart-Guide) · [Feature index](Feature-Tutorials)

--- a/wiki/Feature-Tutorials.md
+++ b/wiki/Feature-Tutorials.md
@@ -98,6 +98,7 @@ Start with the [Quickstart Guide](Quickstart-Guide) for a new mission. Use the [
 - [WMP Zeus Modules](Waldos-Mission-Pack-Zeus-Modules)
 - [Zeus and Script API Parity](Zeus-And-Script-API-Parity)
 - [Mission Diagnostics](Mission-Diagnostics)
+- [Claude Mission Config Skill](Claude-Mission-Config-Skill)
 - [Mission Configuration Reference](Mission-Configuration-Reference)
 - [Coding and Documentation Standards](Coding-Standards)
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -18,6 +18,7 @@ Waldos Mission Pack is an Arma 3 mission scripting framework for mission makers 
 | Place or configure Zeus modules | [WMP Zeus Modules](Waldos-Mission-Pack-Zeus-Modules) |
 | Translate Zeus setup into script | [Zeus and Script API Parity](Zeus-And-Script-API-Parity) |
 | Diagnose a setup or runtime problem | [Mission Diagnostics](Mission-Diagnostics) |
+| Have an AI assistant configure a feature for you | [Claude Mission Config Skill](Claude-Mission-Config-Skill) |
 | Write or review WMP documentation | [Coding and Documentation Standards](Coding-Standards) |
 
 ## Main feature areas

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -6,6 +6,7 @@
 * [Mission Configuration](Mission-Configuration-Reference)
 * [Feature Configuration Files](Feature-Configuration-Files)
 * [Mission Diagnostics](Mission-Diagnostics)
+* [Claude Mission Config Skill](Claude-Mission-Config-Skill)
 * [WMP Zeus Modules](Waldos-Mission-Pack-Zeus-Modules)
 * [Zeus and Script API Parity](Zeus-And-Script-API-Parity)
 


### PR DESCRIPTION
## Summary

Adds a Claude Skill (`.claude/skills/mission-pack-config/`) that guides an assistant through configuring WaldosMissionPack for a real mission:

- **`SKILL.md`** — orchestrator: works out which of three output modes applies (direct-edit / patch / instruction), checks which optional mods are in play (ACRE2/TFAR/ZEN), then routes to the relevant per-feature reference file. Carries hard rules: `mission.sqm` is never edited directly (Eden Editor only, always instruction mode), `respawnOnStart` is never touched, and the WMP dev-repo documentation standard (CLAUDE.md/README/wiki) only applies inside the dev repo itself, not in an end user's mission project.
- **`references/*.md`** — one condensed, faithful file per feature (loadout/logistics, AI rebalance, ACRE2, paradrop, jamming, EMP, trackers, MHQ, respawn, ENDEX/AAR, safestart, diagnostics, tasks, VVD, Zeus modules, minigames, UI notifications, description.ext), plus `mod-detection.md`, all condensed from the repo's `CLAUDE.md`.
- **`references/economy/`** — the 449-function Waldos Economy Systems suite gets its own sub-tree (core/resource/research/build/buy/command) since it would dominate a flat reference file.
- **`chatgpt/INSTRUCTIONS.md`** — a thin wrapper over the same `references/` tree for use as ChatGPT Custom GPT instructions. Since ChatGPT has no filesystem access to a user's mission project, it's written to always operate in patch + instruction mode and to ask the user to paste relevant file contents before giving precise insertion points.

Key design assumption: the normal user of this skill has downloaded a WMP **release** and dropped it into their **own mission project** — not the WMP dev repo. That means no `releaseVerificationAndDeployment/` validators are assumed present, and `mission.sqm` is treated as strictly off-limits to edit under any circumstance (Eden Editor GUI only).

## Test plan

- [ ] Verified all reference files referenced from `SKILL.md`'s routing table and `references/economy/README.md` exist (no broken links)
- [ ] Spot-check a few feature reference files against `CLAUDE.md` for accuracy (ACRE2, jamming, Economy core)
- [ ] Confirm the skill triggers appropriately when asked to configure a WMP feature in a real mission-editing session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vtf66q3YgwPS1wcEaoNvoD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vtf66q3YgwPS1wcEaoNvoD)_