### PR TITLE
Expand composition catalogue and harden ACRE startup

### DIFF
--- a/MissionConfig/acreConfig.sqf
+++ b/MissionConfig/acreConfig.sqf
@@ -35,6 +35,19 @@
  * frequencies. Shipped PRC-148/152/117F presets share frequencies at matching channel numbers;
  * BF-888S and SEM52SL use separate nets. PRC-77 and SEM70 can share an explicit common frequency.
  *
+ * RADIO COMPATIBILITY - READ BEFORE ADDING OR REUSING A NET:
+ * - ACRE_PRC343 uses [block, channel]. It does not use the named long-range net rows.
+ * - ACRE_PRC148, ACRE_PRC152 and ACRE_PRC117F use numbered channels. Matching channel numbers on
+ *   their official side presets are interoperable, so they may share PLT/AIR/CAS nets.
+ * - ACRE_BF888S is a 16-channel radio in a different band. Give it a BF-only net such as BF_LOCAL.
+ * - ACRE_SEM52SL is a 12-channel radio in a different band. Give it a SEM52-only net.
+ * - ACRE_PRC77 and ACRE_SEM70 use explicit MHz. They may share a net only where that frequency is
+ *   valid for both radios; 34.000 MHz is a valid shared example.
+ * - Unknown and vehicle-rack radios are deliberately preserved and never guessed.
+ * A group may list all these keys together. WMP filters them by class: a PRC-152 cannot consume
+ * BF_LOCAL or LEGACY. A supported carried radio with no compatible tuning is reported by class and
+ * occurrence and left unchanged; WMP does not silently force it onto channel 1.
+ *
  * GROUPS AND OPTIONAL RADIO TEMPLATES
  * A group is [editor group ID, ordered fallback net keys, PRC-343 [block,channel] or [], explicit
  * assignments]. An assignment is [base class, same-type occurrence, target, ear]. Explicit rows are
@@ -240,21 +253,21 @@ createHashMapFromArray [
                     ]
                 ],
                 [
-                    "BF_LOCAL", // internal net key.
+                    "BF_LOCAL", // SPECIAL RADIO ONLY: BF-888S. Not interchangeable with PRC channels.
                     "LOCAL BF", // player-facing name.
                     [
                         ["ACRE_BF888S", 4] // the BF-888S uses its own channel 4; this does not consume PRC channels.
                     ]
                 ],
                 [
-                    "SEM_LOCAL", // internal net key.
+                    "SEM_LOCAL", // SPECIAL RADIO ONLY: SEM52SL. Not interchangeable with BF/PRC channels.
                     "LOCAL SEM", // player-facing name.
                     [
                         ["ACRE_SEM52SL", 4] // the SEM52SL uses its own channel 4.
                     ]
                 ],
                 [
-                    "LEGACY", // internal net key; rename this if a clearer mission name is available.
+                    "LEGACY", // FREQUENCY RADIO ONLY: PRC-77/SEM70; the MHz value must suit each radio.
                     "LEGACY", // player-facing name.
                     [
                         ["ACRE_PRC77", 34.000], // frequency radio: tune PRC-77 to 34.000 MHz.

--- a/MissionScripts/Logistics/FieldResupply/fieldResupplySetupHubLocal.sqf
+++ b/MissionScripts/Logistics/FieldResupply/fieldResupplySetupHubLocal.sqf
@@ -18,12 +18,39 @@
  * [_hub] remoteExecCall ["Waldo_fnc_FieldResupplySetupHubLocal", -2, "FieldHub_Main"];
  *
  * Current caller: FieldResupplyRegisterHub through an object-keyed JIP remote call.
+ * Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Optional-Feature-Extensions#field-resupply
  */
 
 params [["_hub", objNull, [objNull]]];
 if !(hasInterface) exitWith {false};
 if (isNull _hub || {_hub getVariable ["Waldo_FieldResupply_LocalSetup", false]}) exitWith {false};
 _hub setVariable ["Waldo_FieldResupply_LocalSetup", true];
+private _inspectHub = {
+    params ["_target"];
+    private _stock = _target getVariable ["Waldo_FieldResupply_Stock", -1];
+    private _side = _target getVariable ["Waldo_FieldResupply_Side", sideUnknown];
+    [
+        "FIELD RESUPPLY HUB",
+        format [
+            "Refills assigned Field Resupply carriers. Stock: %1. Serviced side: %2.",
+            if (_stock < 0) then {"Unlimited"} else {str _stock},
+            if (_side isEqualTo sideUnknown) then {"All sides"} else {str _side}
+        ],
+        "INFO",
+        "FIELD_RESUPPLY_HUB"
+    ] call Waldo_fnc_FeatureNotifyLocal;
+};
+private _infoId = _hub addAction [
+    "<t color='#79C7FF'>Field Resupply Hub</t>",
+    _inspectHub,
+    [],
+    1.6,
+    true,
+    false,
+    "",
+    "_this distance _target <= 4",
+    4
+];
 private _statement = {params ["_target", "_caller"]; [_caller, "REFILL", [_target]] remoteExecCall ["Waldo_fnc_FieldResupplyServerHandle", 2]};
 private _condition = {
     params ["_target", "_caller"];
@@ -39,10 +66,10 @@ if (isClass (configFile >> "CfgPatches" >> "ace_interact_menu")) then {
         ["ACE_MainActions", "Waldo_FieldResupply_Category"],
         ["ACE_MainActions", "Waldo_FieldResupply_Category", "Waldo_FieldResupply_Refill"]
     ]];
-    _hub setVariable ["Waldo_FieldResupply_ActionIds", []];
+    _hub setVariable ["Waldo_FieldResupply_ActionIds", [_infoId]];
 } else {
     private _action = _hub addAction ["Refill Field Resupply Carrier", _statement, [], 1.5, true, true, "", "_this distance _target <= 4 && {_this getVariable ['Waldo_FieldResupply_MaxCrates', 0] > 0} && {backpack _this != ''}", 4];
-    _hub setVariable ["Waldo_FieldResupply_ActionIds", [_action]];
+    _hub setVariable ["Waldo_FieldResupply_ActionIds", [_infoId, _action]];
     _hub setVariable ["Waldo_FieldResupply_ACEActionPaths", []];
 };
 true

--- a/MissionScripts/MissionFlowAndUi/runDiagnosticsClient.sqf
+++ b/MissionScripts/MissionFlowAndUi/runDiagnosticsClient.sqf
@@ -15,6 +15,7 @@
  *
  * Example:
  * ["diag_01"] call Waldo_fnc_RunDiagnosticsClient;
+ * Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Diagnostics
  */
 if (!hasInterface) exitWith {false};
 params [["_runId", "", [""]]];
@@ -66,10 +67,37 @@ if (_acreEnabled) then {
     private _groupIndex = _groups findIf {(_x select 0) == _groupKey};
     private _radios = if (isNil "acre_api_fnc_getCurrentRadioList") then {[]} else {[] call acre_api_fnc_getCurrentRadioList};
     private _unique = _radios select {"_ID_" in toUpper _x};
+    private _profiles = [_acreConfig] call Waldo_fnc_ACRE2GetRadioProfiles;
+    private _profileClasses = _profiles apply {toUpperANSI (_x select 0)};
+    private _inventoryRadios = (items player + assignedItems player) select {
+        private _item = toUpperANSI _x;
+        (_profileClasses findIf {_item == _x || {_item find (_x + "_ID_") == 0}}) >= 0
+    };
+    private _acreApiReady = !isNil "acre_api_fnc_isInitialized" && {[] call acre_api_fnc_isInitialized};
+    private _edenRadioSetup = player getVariable ["acre_sys_radio_setup", ""];
     private _last = missionNamespace getVariable ["Waldo_ACRE2_LastApplication", []];
     private _lastOk = count _last > 0 && {_last select 0};
-    private _state = if (!_planValid || {_sideIndex < 0} || {_groupIndex < 0} || {_radios isEqualTo []} || {!_lastOk}) then {"ERROR"} else {"ACTIVE"};
-    ["radio", "acre-player-presetting", _state, format ["rawGroup='%1' normalized=%2 side=%3 planRevision=%4 sideMatch=%5 groupMatch=%6 radios=%7 unique=%8 loadoutGeneration=%9 restoredGeneration=%10 lastApplication=%11", _rawGroup, _groupKey, _sideKey, if (_planValid) then {_plan select 1} else {-1}, _sideIndex >= 0, _groupIndex >= 0, _radios, count _unique, missionNamespace getVariable ["Waldo_ACRE2_LoadoutGeneration", -1], missionNamespace getVariable ["Waldo_ACRE2_RestoredRadioGeneration", -1], _last]] call _add;
+    private _expectsRadios = !(_inventoryRadios isEqualTo []);
+    private _state = if (!_planValid || {_sideIndex < 0} || {_groupIndex < 0} || {_expectsRadios && {(_radios isEqualTo [] || {!_lastOk})}}) then {"ERROR"} else {if (_expectsRadios) then {"ACTIVE"} else {"UNCONFIGURED"}};
+    private _plainFinding = if (!_planValid) then {"The server did not publish a valid ACRE plan."} else {
+        if (_sideIndex < 0) then {format ["No ACRE side block matches %1.", _sideKey]} else {
+            if (_groupIndex < 0) then {format ["Group '%1' is not listed in acreConfig.sqf.", _rawGroup]} else {
+                if (_expectsRadios && {!_acreApiReady}) then {"ACRE has not finished converting the player's carried radios to unique IDs."} else {
+                    if (_expectsRadios && {_radios isEqualTo []}) then {"Supported radio items exist in the inventory, but ACRE returned no current radios."} else {
+                        if (_expectsRadios && {!_lastOk}) then {format ["The radio plan was not applied successfully: %1", _last param [5, []]]} else {
+                            if (_expectsRadios) then {"Carried radios and the configured group plan were applied."} else {"This player carries no supported ACRE radio; no assignment is required."}
+                        }
+                    }
+                }
+            }
+        }
+    };
+    ["radio", "acre-player-presetting", _state, format ["finding=%1 rawGroup='%2' normalized=%3 side=%4 planRevision=%5 sideMatch=%6 groupMatch=%7 inventoryRadios=%8 currentRadios=%9 unique=%10 acreReady=%11 edenRadioSetup=%12 loadoutGeneration=%13 restoredGeneration=%14 lastApplication=%15 readinessFailure=%16", _plainFinding, _rawGroup, _groupKey, _sideKey, if (_planValid) then {_plan select 1} else {-1}, _sideIndex >= 0, _groupIndex >= 0, _inventoryRadios, _radios, count _unique, _acreApiReady, _edenRadioSetup, missionNamespace getVariable ["Waldo_ACRE2_LoadoutGeneration", -1], missionNamespace getVariable ["Waldo_ACRE2_RestoredRadioGeneration", -1], _last, missionNamespace getVariable ["Waldo_ACRE2_LastReadinessFailure", []]]] call _add;
+    if !(_edenRadioSetup isEqualTo "") then {
+        ["radio", "acre-eden-radio-attribute", "ERROR", format ["This unit has an Eden ACRE Radio Setup attribute (%1). It can overwrite acreConfig.sqf during startup. Clear that unit attribute and let WMP own the initial assignment.", _edenRadioSetup]] call _add;
+    } else {
+        ["radio", "acre-eden-radio-attribute", "LOADED", "No conflicting Eden ACRE Radio Setup attribute is present."] call _add;
+    };
 } else {
     ["radio", "acre-player-presetting", if (_acreLoaded) then {"DISABLED"} else {"UNAVAILABLE"}, format ["loaded=%1 configEnabled=%2", _acreLoaded, _acreConfig getOrDefault ["enabled", false]]] call _add;
 };

--- a/MissionScripts/MissionInit/ACRE2/acre2ApplyPlayerPlan.sqf
+++ b/MissionScripts/MissionInit/ACRE2/acre2ApplyPlayerPlan.sqf
@@ -18,6 +18,7 @@
  * Example: [true, "RESPAWN"] call Waldo_fnc_ACRE2ApplyPlayerPlan;
  * Result: applicable carried-radio occurrences receive the authored baseline once for this loadout.
  * Current callers: Waldo_fnc_ACRE2SchedulePlayerRefresh and persistence fallback.
+ * Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE-2-Long-Range-Radio-Presetting
  */
 params [["_force", false, [true]], ["_reason", "MANUAL", [""]], ["_retryAllowed", true, [true]]];
 if (!hasInterface || {isNull player} || {!(isClass (configFile >> "CfgPatches" >> "acre_main"))}) exitWith {false};
@@ -60,6 +61,17 @@ private _tuningFor = {
 };
 private _normaliseEar = {params ["_value"]; private _ear = toUpper _value; if (_ear == "BOTH") then {"CENTER"} else {_ear}};
 private _defaultEar = {params ["_profile", "_occurrence"]; private _ears = _profile select 2; _ears select (((_occurrence - 1) min ((count _ears) - 1)) max 0)};
+private _profileClasses = _profiles apply {toUpperANSI (_x select 0)};
+private _inventoryRadios = (items player + assignedItems player) select {
+    private _item = toUpperANSI _x;
+    (_profileClasses findIf {_item == _x || {_item find (_x + "_ID_") == 0}}) >= 0
+};
+if (!(_inventoryRadios isEqualTo []) && {_radios isEqualTo []}) exitWith {
+    private _message = format ["Supported radio items exist in the inventory (%1), but ACRE returned no unique carried radios.", _inventoryRadios];
+    missionNamespace setVariable ["Waldo_ACRE2_LastApplication", [false, _reason, _sideKey, _groupKey, [], [_message], [], []]];
+    diag_log format ["[WMP ACRE] %1", _message];
+    false
+};
 
 // Apply the first matching side-scoped override. MERGE updates assignment identities; REPLACE starts clean.
 {
@@ -117,6 +129,15 @@ private _typeCounts = createHashMap;
         } forEach _netKeys;
         if (count _compatibleNets >= _occurrence) then {
             _resolved pushBack [_radioId, _base, _occurrence, (_compatibleNets select (_occurrence - 1)) select 0, [_profile, _occurrence] call _defaultEar];
+        } else {
+            _success = false;
+            _problems pushBack format [
+                "%1#%2 is carried, but group %3 has only %4 compatible named net(s). Add a tuning for this radio class or an explicit assignment.",
+                _base,
+                _occurrence,
+                _groupKey,
+                count _compatibleNets
+            ];
         };
     };
 } forEach _radios;

--- a/MissionScripts/MissionInit/ACRE2/acre2SchedulePlayerRefresh.sqf
+++ b/MissionScripts/MissionInit/ACRE2/acre2SchedulePlayerRefresh.sqf
@@ -15,6 +15,7 @@
  * Example: ["RESPAWN", true] call Waldo_fnc_ACRE2SchedulePlayerRefresh;
  * Result: one bounded local refresh applies Babel/CEOI and, when permitted, the radio baseline.
  * Current callers: ACRE initialisation, respawn, player-unit and group lifecycle handlers.
+ * Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE-2-Long-Range-Radio-Presetting
  */
 params [["_reason", "MANUAL", [""]], ["_applyPlan", true, [true]]];
 if (!hasInterface || {isNull player}) exitWith {false};
@@ -23,7 +24,10 @@ missionNamespace setVariable ["Waldo_ACRE2_RefreshToken", _token];
 missionNamespace setVariable ["Waldo_ACRE2_RefreshApplyPlan", (missionNamespace getVariable ["Waldo_ACRE2_RefreshApplyPlan", false]) || {_applyPlan}];
 [_token, _reason] spawn {
     params ["_token", "_reason"];
-    private _deadline = diag_tickTime + 30;
+    // ACRE documents isInitialized as the point at which carried base radios have become unique
+    // IDs. Large modsets and Eden-defined radio attributes can legitimately take longer than the
+    // rest of mission init, so this asynchronous waiter allows two minutes without blocking WMP.
+    private _deadline = diag_tickTime + 120;
     waitUntil {
         uiSleep 0.1;
         private _plan = missionNamespace getVariable ["Waldo_ACRE2_Plan", []];
@@ -42,17 +46,45 @@ missionNamespace setVariable ["Waldo_ACRE2_RefreshApplyPlan", (missionNamespace 
     private _plan = missionNamespace getVariable ["Waldo_ACRE2_Plan", []];
     if (diag_tickTime >= _deadline || {count _plan < 4} || {!([] call acre_api_fnc_isInitialized)}) exitWith {
         missionNamespace setVariable ["Waldo_ACRE2_RefreshApplyPlan", false];
-        diag_log format ["[WMP ACRE] %1 refresh timed out; mission startup continues.", _reason];
+        private _acreReady = !isNil "acre_api_fnc_isInitialized" && {[] call acre_api_fnc_isInitialized};
+        private _currentRadios = if (isNil "acre_api_fnc_getCurrentRadioList") then {[]} else {[] call acre_api_fnc_getCurrentRadioList};
+        private _config = missionNamespace getVariable ["Waldo_ACRE2_Config", createHashMap];
+        private _profiles = [_config] call Waldo_fnc_ACRE2GetRadioProfiles;
+        private _profileClasses = _profiles apply {toUpperANSI (_x select 0)};
+        private _inventoryRadios = (items player + assignedItems player) select {
+            private _item = toUpperANSI _x;
+            (_profileClasses findIf {_item == _x || {_item find (_x + "_ID_") == 0}}) >= 0
+        };
+        private _detail = if (!_acreReady && {!(_inventoryRadios isEqualTo [])}) then {
+            format ["ACRE did not finish converting carried radios to unique IDs within 120 seconds. Carried radio classes: %1.", _inventoryRadios]
+        } else {
+            if (count _plan < 4) then {"The server ACRE plan did not arrive."} else {format ["ACRE reported ready but returned no usable carried radios: %1.", _currentRadios]}
+        };
+        missionNamespace setVariable ["Waldo_ACRE2_LastReadinessFailure", [_reason, _acreReady, _inventoryRadios, _currentRadios, _detail]];
+        diag_log format ["[WMP ACRE] %1 refresh timed out: %2 Mission startup continues.", _reason, _detail];
+        if (_config getOrDefault ["notifyAssignmentProblems", true]) then {
+            ["ACRE2 SETUP", _detail + " Run WMP Diagnostics and check the ACRE radio configuration.", "WARNING", "ACRE2_READINESS"] call Waldo_fnc_FeatureNotifyLocal;
+        };
+        // Initial setup owns the baseline and must not be silently abandoned. This asynchronous
+        // retry does not block mission startup and coalesces through the refresh token.
+        if (_reason in ["INITIAL", "INITIAL_LATE"]) then {
+            ["INITIAL_LATE", true] call Waldo_fnc_ACRE2SchedulePlayerRefresh;
+        };
     };
     private _applyPlan = missionNamespace getVariable ["Waldo_ACRE2_RefreshApplyPlan", false];
     missionNamespace setVariable ["Waldo_ACRE2_RefreshApplyPlan", false];
     private _config = missionNamespace getVariable ["Waldo_ACRE2_Config", createHashMap];
     if !(missionNamespace getVariable ["Waldo_ACRE2_PresetNamesReady", false]) then {[_config] call Waldo_fnc_ACRE2ApplyPresetNames};
-    if (_applyPlan) then {[true, _reason] call Waldo_fnc_ACRE2ApplyPlayerPlan};
+    private _planApplied = true;
+    if (_applyPlan) then {_planApplied = [true, _reason] call Waldo_fnc_ACRE2ApplyPlayerPlan};
     [] call Waldo_fnc_ACRE2ApplyBabel;
     [] call Waldo_fnc_ACRE2BuildCEOI;
-    if (_reason in ["INITIAL", "PERSISTENCE_BASELINE", "PERSISTENCE_RESTORE_FALLBACK"]) then {
+    if (_planApplied && {_reason in ["INITIAL", "INITIAL_LATE", "PERSISTENCE_BASELINE", "PERSISTENCE_RESTORE_FALLBACK"]}) then {
         [false] call Waldo_fnc_SaveLoadout;
+    };
+    if (!_planApplied && {_reason in ["INITIAL", "INITIAL_LATE"]}) then {
+        diag_log "[WMP ACRE] Initial radio plan failed; the respawn baseline was not saved.";
+        ["ACRE2 SETUP", "The initial radio plan was not applied, so WMP did not save a channel-1 respawn baseline. Run WMP Diagnostics for the exact radio/net mismatch.", "WARNING", "ACRE2_INITIAL_FAILED"] call Waldo_fnc_FeatureNotifyLocal;
     };
 };
 true

--- a/WMP_Compositions/README.md
+++ b/WMP_Compositions/README.md
@@ -21,6 +21,8 @@ copies of feature logic.
 
 1. Place the composition in Eden and keep its objects separated as supplied.
 2. Read the nearby Eden comment before changing an init field.
+   Every shipped comment links directly to the matching WMP wiki article; keep that URL when you
+   copy or adapt the example.
 3. Change only the clearly named side, range, stock, key, class or toggle arguments.
 4. Call WMP's documented public setup function directly. Its implementation owns server authority,
    client-local setup and JIP replay; mission makers should not add an `isServer` wrapper unless the
@@ -47,8 +49,13 @@ copies of feature logic.
 | Mass AttachTo / Vehicle Mounted Weapon | Vehicle construction helpers |
 | Halo and Static Line Paradrop Examples | Boarding and aircraft jump setup |
 | Radio Jammer Example | Server-owned, movable jammer fixture |
-| Hazardous Emitter Example | Dangerous moving-object hazard with visible transition feedback |
+| Hazardous Zone Example | Reliable fixed-area hazard with visible transition feedback and real danger |
 | Tactical Display Example | Supported map-board access point |
+| Bomb Defusal Example | Standard wire-cutting challenge with an explosive failure consequence |
+| Construction Objects Example | ACE construction supply object with modern construction audio |
+| Electronic Warfare Examples | EMP immunity and side-restricted signal tracking fixtures |
+| Object Scaling Example | Supported Simple Object conversion and scale setup |
+| Custom 3D Marker Example | Object-anchored, side-aware world marker with readable options |
 | Economy Systems and Low/Medium/High | Runtime enablement and optional preset |
 | Teleport Script Example | Paired local addActions |
 
@@ -58,6 +65,5 @@ Dynamic AO and Dynamic AA are server-authoritative generated systems; Zeus or sc
 clearer and safer than shipping pre-spawned clusters. Improved helicopter landing is an automatic AI
 handler driven by waypoints. Accessibility, treatment feedback and UI themes are player-interface
 features. Persistence depends on server extensions and mission policy. Rally points are player-role
-state. Object scaling is target-specific and may convert decorative objects to simple objects. Those
-features remain documented through MissionConfig, public calls, the full audit mission and focused
+state. Those features remain documented through MissionConfig, public calls, the full audit mission and focused
 Zeus modules where appropriate.

--- a/WMP_Compositions/[WMP]AutoFortify_Setup_Example/composition.sqe
+++ b/WMP_Compositions/[WMP]AutoFortify_Setup_Example/composition.sqe
@@ -18,7 +18,7 @@ class items
 					position[]={-4.9328613,0.00084686279,-8.871582};
 					angles[]={0.0023920804,0,0};
 				};
-				title="AutoFortify Example";
+				title="AutoFortify Example. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Automatic-ACE-Fortify-Setup";
 				description="Remember to make sure players have a fortify tool!";
 				id=38;
 				atlOffset=7.6293945e-006;
@@ -296,7 +296,7 @@ class items
 			skill=0.2;
 		};
 		id=203;
-		type="Land_BagFenceLong";
+		type="Land_BagFence_Long_F";
 	};
 	class Item5
 	{
@@ -313,7 +313,7 @@ class items
 			skill=0.2;
 		};
 		id=208;
-		type="Land_BagFenceRound";
+		type="Land_BagFence_Round_F";
 	};
 	class Item6
 	{
@@ -330,7 +330,7 @@ class items
 			skill=0.2;
 		};
 		id=209;
-		type="Land_BagFenceShort";
+		type="Land_BagFence_Short_F";
 	};
 	class Item7
 	{
@@ -381,7 +381,7 @@ class items
 			skill=0.2;
 		};
 		id=198;
-		type="Hedgehog";
+		type="Land_CzechHedgehog_01_new_F";
 		atlOffset=7.6293945e-006;
 	};
 };

--- a/WMP_Compositions/[WMP]Basic_Mobile_Respawn_Vehicle/composition.sqe
+++ b/WMP_Compositions/[WMP]Basic_Mobile_Respawn_Vehicle/composition.sqe
@@ -17,7 +17,7 @@ class items
 				{
 					position[]={-0.90039063,0.089553595,1.3945313};
 				};
-				title="Mobile Respawn Vehicle With ACE Arsenal & Loadout saving";
+				title="Mobile Respawn Vehicle With ACE Arsenal & Loadout saving. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Loadout-Saving-and-Respawn";
 				id=1;
 				atlOffset=0.089553595;
 			};

--- a/WMP_Compositions/[WMP]Basic_Player_Controlled_Zeus/composition.sqe
+++ b/WMP_Compositions/[WMP]Basic_Player_Controlled_Zeus/composition.sqe
@@ -101,7 +101,7 @@ class items
 		{
 			position[]={-0.5390625,0,-0.84179688};
 		};
-		title="Properly Setup Zeus";
+		title="Properly Setup Zeus. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Mission-Pack-Zeus-Modules";
 		id=7007;
 	};
 	class Item2

--- a/WMP_Compositions/[WMP]Bomb_Defusal_Example/composition.sqe
+++ b/WMP_Compositions/[WMP]Bomb_Defusal_Example/composition.sqe
@@ -1,0 +1,26 @@
+version=54;
+center[]={0,0,0};
+class items
+{
+	items=2;
+	class Item0
+	{
+		dataType="Object";
+		side="Empty";
+		class PositionInfo {position[]={0,0,0};};
+		class Attributes
+		{
+			name="WMP_DefusalBomb";
+			init="[this] call Waldo_fnc_BombDefuseSetup;";
+		};
+		id=1;
+		type="Land_Device_disassembled_F";
+	};
+	class Item1
+	{
+		dataType="Comment";
+		class PositionInfo {position[]={0,-3,0};};
+		title="Bomb Defusal: adds the standard wire-cutting challenge and explosive failure consequence. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Bomb-Defusal";
+		id=2;
+	};
+};

--- a/WMP_Compositions/[WMP]Bomb_Defusal_Example/header.sqe
+++ b/WMP_Compositions/[WMP]Bomb_Defusal_Example/header.sqe
@@ -1,5 +1,5 @@
 version=54;
-name="[WMP] Hazardous Zone Example";
+name="[WMP] Bomb Defusal Example";
 author="WaldoTheWarfighter";
 category="Waldos Mission Pack Compositions - Combat Systems";
-requiredAddons[]={"A3_Structures_F_Exp_Industrial_Port"};
+requiredAddons[]={"A3_Structures_F_Items_Electronics"};

--- a/WMP_Compositions/[WMP]Construction_Objects_Example/composition.sqe
+++ b/WMP_Compositions/[WMP]Construction_Objects_Example/composition.sqe
@@ -1,0 +1,26 @@
+version=54;
+center[]={0,0,0};
+class items
+{
+	items=2;
+	class Item0
+	{
+		dataType="Object";
+		side="Empty";
+		class PositionInfo {position[]={0,0,0};};
+		class Attributes
+		{
+			name="WMP_ConstructionSupply";
+			init="[this, true] call Waldo_fnc_ConstructionObjects;";
+		};
+		id=1;
+		type="B_supplyCrate_F";
+	};
+	class Item1
+	{
+		dataType="Comment";
+		class PositionInfo {position[]={0,-3,0};};
+		title="Construction Objects: ACE construction supply using modern construction audio. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Construction-Objects";
+		id=2;
+	};
+};

--- a/WMP_Compositions/[WMP]Construction_Objects_Example/header.sqe
+++ b/WMP_Compositions/[WMP]Construction_Objects_Example/header.sqe
@@ -1,0 +1,5 @@
+version=54;
+name="[WMP] Construction Objects Example";
+author="WaldoTheWarfighter";
+category="Waldos Mission Pack Compositions - Logistics";
+requiredAddons[]={"A3_Weapons_F_Ammoboxes"};

--- a/WMP_Compositions/[WMP]Custom_3D_Marker_Example/composition.sqe
+++ b/WMP_Compositions/[WMP]Custom_3D_Marker_Example/composition.sqe
@@ -1,0 +1,26 @@
+version=54;
+center[]={0,0,0};
+class items
+{
+	items=2;
+	class Item0
+	{
+		dataType="Object";
+		side="Empty";
+		class PositionInfo {position[]={0,0,0};};
+		class Attributes
+		{
+			name="WMP_MarkerAnchor";
+			init="[""composition_marker"", this, [[""text"", ""SIGNAL RELAY""], [""offset"", [0,0,3]], [""distance"", 100], [""sides"", [""ALL""]]]] call Waldo_fnc_Create3DMarker;";
+		};
+		id=1;
+		type="Land_TTowerSmall_1_F";
+	};
+	class Item1
+	{
+		dataType="Comment";
+		class PositionInfo {position[]={0,-4,0};};
+		title="Custom 3D Marker: labels the relay for all sides within 100 m. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Custom-3D-World-Markers";
+		id=2;
+	};
+};

--- a/WMP_Compositions/[WMP]Custom_3D_Marker_Example/header.sqe
+++ b/WMP_Compositions/[WMP]Custom_3D_Marker_Example/header.sqe
@@ -1,0 +1,5 @@
+version=54;
+name="[WMP] Custom 3D Marker Example";
+author="WaldoTheWarfighter";
+category="Waldos Mission Pack Compositions - Interface";
+requiredAddons[]={"A3_Structures_F_Ind_Transmitter_Tower"};

--- a/WMP_Compositions/[WMP]Economy_Systems/composition.sqe
+++ b/WMP_Compositions/[WMP]Economy_Systems/composition.sqe
@@ -25,7 +25,7 @@ class items
 		{
 			position[]={0,0,2};
 		};
-		title="Waldos Economy Systems - leave this object placed. It boots the Resource/Research/Build/Buy + Ground Command suite. Open Zeus and use the 'Waldos Economy Systems' menu. See the WMP wiki for setup and the import/export config strings.";
+		title="Waldos Economy Systems - leave this object placed. It boots the Resource/Research/Build/Buy + Ground Command suite. Open Zeus and use the 'Waldos Economy Systems' menu. See the WMP wiki for setup and the import/export config strings. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Economy-Systems";
 		id=2;
 	};
 };

--- a/WMP_Compositions/[WMP]Economy_Systems_Preset_High/composition.sqe
+++ b/WMP_Compositions/[WMP]Economy_Systems_Preset_High/composition.sqe
@@ -25,7 +25,7 @@ class items
 		{
 			position[]={0,0,2};
 		};
-		title="Waldos Economy Systems - HIGH preset. Boots the suite and loads the HIGH preset (WEST=NATO, EAST=CSAT, INDEP=AAF by default). Manage it live in the Zeus 'Waldos Economy Systems' menu. Place only one Economy Systems object per mission.";
+		title="Waldos Economy Systems - HIGH preset. Boots the suite and loads the HIGH preset (WEST=NATO, EAST=CSAT, INDEP=AAF by default). Manage it live in the Zeus 'Waldos Economy Systems' menu. Place only one Economy Systems object per mission. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Economy-Systems-Setup-And-Configuration";
 		id=2;
 	};
 };

--- a/WMP_Compositions/[WMP]Economy_Systems_Preset_Low/composition.sqe
+++ b/WMP_Compositions/[WMP]Economy_Systems_Preset_Low/composition.sqe
@@ -25,7 +25,7 @@ class items
 		{
 			position[]={0,0,2};
 		};
-		title="Waldos Economy Systems - LOW preset. Boots the suite and loads the LOW preset (WEST=NATO, EAST=CSAT, INDEP=AAF by default). Manage it live in the Zeus 'Waldos Economy Systems' menu. Place only one Economy Systems object per mission.";
+		title="Waldos Economy Systems - LOW preset. Boots the suite and loads the LOW preset (WEST=NATO, EAST=CSAT, INDEP=AAF by default). Manage it live in the Zeus 'Waldos Economy Systems' menu. Place only one Economy Systems object per mission. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Economy-Systems-Setup-And-Configuration";
 		id=2;
 	};
 };

--- a/WMP_Compositions/[WMP]Economy_Systems_Preset_Medium/composition.sqe
+++ b/WMP_Compositions/[WMP]Economy_Systems_Preset_Medium/composition.sqe
@@ -25,7 +25,7 @@ class items
 		{
 			position[]={0,0,2};
 		};
-		title="Waldos Economy Systems - MEDIUM preset. Boots the suite and loads the MEDIUM preset (WEST=NATO, EAST=CSAT, INDEP=AAF by default). Manage it live in the Zeus 'Waldos Economy Systems' menu. Place only one Economy Systems object per mission.";
+		title="Waldos Economy Systems - MEDIUM preset. Boots the suite and loads the MEDIUM preset (WEST=NATO, EAST=CSAT, INDEP=AAF by default). Manage it live in the Zeus 'Waldos Economy Systems' menu. Place only one Economy Systems object per mission. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Economy-Systems-Setup-And-Configuration";
 		id=2;
 	};
 };

--- a/WMP_Compositions/[WMP]Electronic_Warfare_Examples/composition.sqe
+++ b/WMP_Compositions/[WMP]Electronic_Warfare_Examples/composition.sqe
@@ -1,0 +1,39 @@
+version=54;
+center[]={0,0,0};
+class items
+{
+	items=3;
+	class Item0
+	{
+		dataType="Object";
+		side="Empty";
+		class PositionInfo {position[]={-4,0,0};};
+		class Attributes
+		{
+			name="WMP_EMPImmuneVehicle";
+			init="[this] call Waldo_fnc_EMPImmune;";
+		};
+		id=1;
+		type="B_MRAP_01_F";
+	};
+	class Item1
+	{
+		dataType="Object";
+		side="Empty";
+		class PositionInfo {position[]={4,0,0};};
+		class Attributes
+		{
+			name="WMP_TrackedVehicle";
+			init="[this, west, ""Tracked Vehicle""] call Waldo_fnc_Tracker;";
+		};
+		id=2;
+		type="B_MRAP_01_F";
+	};
+	class Item2
+	{
+		dataType="Comment";
+		class PositionInfo {position[]={0,-5,0};};
+		title="Electronic Warfare: left vehicle is EMP-immune; right vehicle is tracked by WEST. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Electronic-Warfare-EMP-And-Signal-Trackers";
+		id=3;
+	};
+};

--- a/WMP_Compositions/[WMP]Electronic_Warfare_Examples/header.sqe
+++ b/WMP_Compositions/[WMP]Electronic_Warfare_Examples/header.sqe
@@ -1,5 +1,5 @@
 version=54;
-name="[WMP] Hazardous Zone Example";
+name="[WMP] Electronic Warfare Examples";
 author="WaldoTheWarfighter";
 category="Waldos Mission Pack Compositions - Combat Systems";
-requiredAddons[]={"A3_Structures_F_Exp_Industrial_Port"};
+requiredAddons[]={"A3_Soft_F_MRAP_01"};

--- a/WMP_Compositions/[WMP]Field_Resupply_Hub_Example/composition.sqe
+++ b/WMP_Compositions/[WMP]Field_Resupply_Hub_Example/composition.sqe
@@ -20,7 +20,7 @@ class items
 	{
 		dataType="Comment";
 		class PositionInfo {position[]={0,-3,0};};
-		title="Field Resupply hub: unlimited stock and all sides. Assign portable crates to infantry with ZEN or [unit, currentCrates, maximumCrates] call Waldo_fnc_FieldResupplyAssignCarrier.";
+		title="Field Resupply hub: unlimited stock and all sides. Assign portable crates to infantry with ZEN or [unit, currentCrates, maximumCrates] call Waldo_fnc_FieldResupplyAssignCarrier. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Optional-Feature-Extensions#field-resupply";
 		id=2;
 	};
 };

--- a/WMP_Compositions/[WMP]Hazardous_Emitter_Example/composition.sqe
+++ b/WMP_Compositions/[WMP]Hazardous_Emitter_Example/composition.sqe
@@ -10,8 +10,8 @@ class items
 		class PositionInfo {position[]={0,0,0};};
 		class Attributes
 		{
-			name="WMP_HazardEmitter";
-			init="[""composition_hazard"", this, 15, createHashMapFromArray [[""type"", ""TOXIC""], [""label"", ""Toxic Leak""], [""rate"", 2], [""decay"", 0.5], [""notifyTransitions"", true], [""damageThresholds"", [[8, 0.03], [20, 0.08]]], [""fatalExposure"", 45], [""damageType"", ""stab""]]] call Waldo_fnc_HazardRegisterEmitter;";
+			name="WMP_HazardZoneCentre";
+			init="[""composition_hazard"", [getPosATL this, 15], createHashMapFromArray [[""type"", ""TOXIC""], [""label"", ""Toxic Leak""], [""rate"", 2], [""decay"", 0.5], [""intensityMode"", ""CONSTANT""], [""notifyTransitions"", true], [""damageThresholds"", [[8, 0.03], [20, 0.08]]], [""fatalExposure"", 45], [""damageType"", ""stab""]]] call Waldo_fnc_HazardRegisterZone;";
 		};
 		id=1;
 		type="Land_GasTank_01_yellow_F";
@@ -20,7 +20,7 @@ class items
 	{
 		dataType="Comment";
 		class PositionInfo {position[]={0,-4,0};};
-		title="Hazardous emitter: 15 m toxic leak with entry/exit warnings, staged injury and fatal exposure. Edit the profile in the object's init field to represent another hazard.";
+		title="Hazardous zone: fixed 15 m toxic area with entry/exit warnings, constant exposure, staged injury and fatal exposure. Edit the profile in the object's init field to represent another hazard; use HazardRegisterEmitter for a moving source. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Optional-Feature-Systems#hazardous-environments";
 		id=2;
 	};
 };

--- a/WMP_Compositions/[WMP]Logistics_Spawner_Example/composition.sqe
+++ b/WMP_Compositions/[WMP]Logistics_Spawner_Example/composition.sqe
@@ -17,7 +17,7 @@ class items
 				{
 					position[]={-0.064453125,1.4305115e-006,1.3242188};
 				};
-				title="Logistics spawner setup - west";
+				title="Logistics spawner setup - west. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Logistics-System,-Starter-Crates-And-Quartermaster";
 				id=9;
 				atlOffset=1.4305115e-006;
 			};

--- a/WMP_Compositions/[WMP]MHQ_BASIC_EXAMPLE/composition.sqe
+++ b/WMP_Compositions/[WMP]MHQ_BASIC_EXAMPLE/composition.sqe
@@ -53,7 +53,7 @@ class items
 				{
 					position[]={0.79296875,0,4.2929688};
 				};
-				title="Mobile HQ Example (WIP)";
+				title="Mobile HQ Example (WIP). Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mobile-Command-Post-With-Integrated-Logistics-System";
 				description="MobileHQVehicle - MHQ vehicle" \n """MobileHeadQuartersLayer"" - Eden Editor Layer for additional objects" \n "" \n "This is an Extreme example, it works best with smaller, basic structures." \n "" \n "This also has the logistics system enabled, which requires both the boolean variable set to true, as well as an invisible helipad from the base game being present (""Land_HelipadEmpty_F"")";
 				id=70;
 				atlOffset=0.063899279;

--- a/WMP_Compositions/[WMP]Medical_Crates_Collection/composition.sqe
+++ b/WMP_Compositions/[WMP]Medical_Crates_Collection/composition.sqe
@@ -48,7 +48,7 @@ class items
 		{
 			position[]={-0.55273438,0,0.18554688};
 		};
-		title="Medical crates, one with and one without field hospital";
+		title="Medical crates, one with and one without field hospital. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Logistics-System,-Starter-Crates-And-Quartermaster";
 		id=7844;
 	};
 };

--- a/WMP_Compositions/[WMP]Object_Scaling_Example/composition.sqe
+++ b/WMP_Compositions/[WMP]Object_Scaling_Example/composition.sqe
@@ -1,0 +1,26 @@
+version=54;
+center[]={0,0,0};
+class items
+{
+	items=2;
+	class Item0
+	{
+		dataType="Object";
+		side="Empty";
+		class PositionInfo {position[]={0,0,0};};
+		class Attributes
+		{
+			name="WMP_ScaledPropSource";
+			init="[this, 1.75, true] call Waldo_fnc_ObjectScale;";
+		};
+		id=1;
+		type="Land_CampingChair_V2_F";
+	};
+	class Item1
+	{
+		dataType="Comment";
+		class PositionInfo {position[]={0,-3,0};};
+		title="Object Scaling: converts this decorative chair to a Simple Object and scales it to 175 percent. The original object reference is replaced. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Optional-Feature-Systems#object-scaling";
+		id=2;
+	};
+};

--- a/WMP_Compositions/[WMP]Object_Scaling_Example/header.sqe
+++ b/WMP_Compositions/[WMP]Object_Scaling_Example/header.sqe
@@ -1,0 +1,5 @@
+version=54;
+name="[WMP] Object Scaling Example";
+author="WaldoTheWarfighter";
+category="Waldos Mission Pack Compositions - Mission Tools";
+requiredAddons[]={"A3_Structures_F_Civ_Camping"};

--- a/WMP_Compositions/[WMP]Radio_Jammer_Example/composition.sqe
+++ b/WMP_Compositions/[WMP]Radio_Jammer_Example/composition.sqe
@@ -20,7 +20,7 @@ class items
 	{
 		dataType="Comment";
 		class PositionInfo {position[]={0,-4,0};};
-		title="Radio Jammer: 300 m omnidirectional field with a standard circuit-bypass Disable Jammer interaction. A successful disable leaves the prop intact and exposes Reactivate Jammer.";
+		title="Radio Jammer: 300 m omnidirectional field with a standard circuit-bypass Disable Jammer interaction. A successful disable leaves the prop intact and exposes Reactivate Jammer. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Radio-Jamming";
 		id=2;
 	};
 };

--- a/WMP_Compositions/[WMP]Starter_Crate_Collection/composition.sqe
+++ b/WMP_Compositions/[WMP]Starter_Crate_Collection/composition.sqe
@@ -346,7 +346,7 @@ class items
 		{
 			position[]={-0.017578125,0,0.19335938};
 		};
-		title="Starter Crate Composition, side setup with arsenal";
+		title="Starter Crate Composition, side setup with arsenal. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Logistics-System,-Starter-Crates-And-Quartermaster";
 		id=7821;
 	};
 };

--- a/WMP_Compositions/[WMP]Supply_Crate_Collection/composition.sqe
+++ b/WMP_Compositions/[WMP]Supply_Crate_Collection/composition.sqe
@@ -17,7 +17,7 @@ class items
 				{
 					position[]={-1.9606018,0.00060272217,-0.05304718};
 				};
-				title="Supply Crate Composition, side setup";
+				title="Supply Crate Composition, side setup. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Logistics-System,-Starter-Crates-And-Quartermaster";
 				id=20;
 				atlOffset=-0.0002822876;
 			};

--- a/WMP_Compositions/[WMP]Tactical_Display_Example/composition.sqe
+++ b/WMP_Compositions/[WMP]Tactical_Display_Example/composition.sqe
@@ -20,7 +20,7 @@ class items
 	{
 		dataType="Comment";
 		class PositionInfo {position[]={0,-3,0};};
-		title="Tactical Display: the board opens the WMP tactical map. sideUnknown follows each viewer; radius is 2000 m; known enemy contacts are enabled.";
+		title="Tactical Display: the board opens the WMP tactical map. sideUnknown follows each viewer; radius is 2000 m; known enemy contacts are enabled. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Optional-Feature-Extensions#tactical-display";
 		id=2;
 	};
 };

--- a/WMP_Compositions/[WMP]Teleport_Script_Example/composition.sqe
+++ b/WMP_Compositions/[WMP]Teleport_Script_Example/composition.sqe
@@ -44,7 +44,7 @@ class items
 		{
 			position[]={-0.36523438,0,0.10546875};
 		};
-		title="Teleport Script";
+		title="Teleport Script. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Teleportation-&-Move-Into-Cargo-Interactions";
 		id=7004;
 	};
 };

--- a/WMP_Compositions/[WMP]Vehicle_Recovery_Workshop_Example/composition.sqe
+++ b/WMP_Compositions/[WMP]Vehicle_Recovery_Workshop_Example/composition.sqe
@@ -46,7 +46,7 @@ class items
 	{
 		dataType="Comment";
 		class PositionInfo {position[]={0,-6,0};};
-		title="Vehicle Recovery: workshop MAIN, recoverable MRAP and AUTO open-deck HEMTT carrier. Its model-space deck offset keeps one package physical and visible; [] would use engine cargo or virtual fallback.";
+		title="Vehicle Recovery: workshop MAIN, recoverable MRAP and AUTO open-deck HEMTT carrier. Its model-space deck offset keeps one package physical and visible; [] would use engine cargo or virtual fallback. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Vehicle-Recovery-And-Squad-Rallies#vehicle-recovery";
 		id=4;
 	};
 };

--- a/WMP_Compositions/[WMP]Virtual_Vehicle_Depot_Spawner_Example/composition.sqe
+++ b/WMP_Compositions/[WMP]Virtual_Vehicle_Depot_Spawner_Example/composition.sqe
@@ -121,7 +121,7 @@ class items
 		{
 			position[]={0.67578125,0,4.6796875};
 		};
-		title="the name of the spawner object will be what appears as the garage name";
+		title="the name of the spawner object will be what appears as the garage name. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Virtual-Vehicle-Depot";
 		id=7819;
 	};
 	class Item2
@@ -131,7 +131,7 @@ class items
 		{
 			position[]={-0.32617188,0,-3.1601563};
 		};
-		title="Laptop is the spawner, everything is available to everyone";
+		title="Laptop is the spawner, everything is available to everyone. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Virtual-Vehicle-Depot";
 		id=7820;
 	};
 };

--- a/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionConfig/releaseAcreConfig.sqf
+++ b/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionConfig/releaseAcreConfig.sqf
@@ -35,6 +35,19 @@
  * frequencies. Shipped PRC-148/152/117F presets share frequencies at matching channel numbers;
  * BF-888S and SEM52SL use separate nets. PRC-77 and SEM70 can share an explicit common frequency.
  *
+ * RADIO COMPATIBILITY - READ BEFORE ADDING OR REUSING A NET:
+ * - ACRE_PRC343 uses [block, channel]. It does not use the named long-range net rows.
+ * - ACRE_PRC148, ACRE_PRC152 and ACRE_PRC117F use numbered channels. Matching channel numbers on
+ *   their official side presets are interoperable, so they may share PLT/AIR/CAS nets.
+ * - ACRE_BF888S is a 16-channel radio in a different band. Give it a BF-only net such as BF_LOCAL.
+ * - ACRE_SEM52SL is a 12-channel radio in a different band. Give it a SEM52-only net.
+ * - ACRE_PRC77 and ACRE_SEM70 use explicit MHz. They may share a net only where that frequency is
+ *   valid for both radios; 34.000 MHz is a valid shared example.
+ * - Unknown and vehicle-rack radios are deliberately preserved and never guessed.
+ * A group may list all these keys together. WMP filters them by class: a PRC-152 cannot consume
+ * BF_LOCAL or LEGACY. A supported carried radio with no compatible tuning is reported by class and
+ * occurrence and left unchanged; WMP does not silently force it onto channel 1.
+ *
  * GROUPS AND OPTIONAL RADIO TEMPLATES
  * A group is [editor group ID, ordered fallback net keys, PRC-343 [block,channel] or [], explicit
  * assignments]. An assignment is [base class, same-type occurrence, target, ear]. Explicit rows are
@@ -240,21 +253,21 @@ createHashMapFromArray [
                     ]
                 ],
                 [
-                    "BF_LOCAL", // internal net key.
+                    "BF_LOCAL", // SPECIAL RADIO ONLY: BF-888S. Not interchangeable with PRC channels.
                     "LOCAL BF", // player-facing name.
                     [
                         ["ACRE_BF888S", 4] // the BF-888S uses its own channel 4; this does not consume PRC channels.
                     ]
                 ],
                 [
-                    "SEM_LOCAL", // internal net key.
+                    "SEM_LOCAL", // SPECIAL RADIO ONLY: SEM52SL. Not interchangeable with BF/PRC channels.
                     "LOCAL SEM", // player-facing name.
                     [
                         ["ACRE_SEM52SL", 4] // the SEM52SL uses its own channel 4.
                     ]
                 ],
                 [
-                    "LEGACY", // internal net key; rename this if a clearer mission name is available.
+                    "LEGACY", // FREQUENCY RADIO ONLY: PRC-77/SEM70; the MHz value must suit each radio.
                     "LEGACY", // player-facing name.
                     [
                         ["ACRE_PRC77", 34.000], // frequency radio: tune PRC-77 to 34.000 MHz.

--- a/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/Logistics/FieldResupply/fieldResupplySetupHubLocal.sqf
+++ b/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/Logistics/FieldResupply/fieldResupplySetupHubLocal.sqf
@@ -18,12 +18,39 @@
  * [_hub] remoteExecCall ["Waldo_fnc_FieldResupplySetupHubLocal", -2, "FieldHub_Main"];
  *
  * Current caller: FieldResupplyRegisterHub through an object-keyed JIP remote call.
+ * Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Optional-Feature-Extensions#field-resupply
  */
 
 params [["_hub", objNull, [objNull]]];
 if !(hasInterface) exitWith {false};
 if (isNull _hub || {_hub getVariable ["Waldo_FieldResupply_LocalSetup", false]}) exitWith {false};
 _hub setVariable ["Waldo_FieldResupply_LocalSetup", true];
+private _inspectHub = {
+    params ["_target"];
+    private _stock = _target getVariable ["Waldo_FieldResupply_Stock", -1];
+    private _side = _target getVariable ["Waldo_FieldResupply_Side", sideUnknown];
+    [
+        "FIELD RESUPPLY HUB",
+        format [
+            "Refills assigned Field Resupply carriers. Stock: %1. Serviced side: %2.",
+            if (_stock < 0) then {"Unlimited"} else {str _stock},
+            if (_side isEqualTo sideUnknown) then {"All sides"} else {str _side}
+        ],
+        "INFO",
+        "FIELD_RESUPPLY_HUB"
+    ] call Waldo_fnc_FeatureNotifyLocal;
+};
+private _infoId = _hub addAction [
+    "<t color='#79C7FF'>Field Resupply Hub</t>",
+    _inspectHub,
+    [],
+    1.6,
+    true,
+    false,
+    "",
+    "_this distance _target <= 4",
+    4
+];
 private _statement = {params ["_target", "_caller"]; [_caller, "REFILL", [_target]] remoteExecCall ["Waldo_fnc_FieldResupplyServerHandle", 2]};
 private _condition = {
     params ["_target", "_caller"];
@@ -39,10 +66,10 @@ if (isClass (configFile >> "CfgPatches" >> "ace_interact_menu")) then {
         ["ACE_MainActions", "Waldo_FieldResupply_Category"],
         ["ACE_MainActions", "Waldo_FieldResupply_Category", "Waldo_FieldResupply_Refill"]
     ]];
-    _hub setVariable ["Waldo_FieldResupply_ActionIds", []];
+    _hub setVariable ["Waldo_FieldResupply_ActionIds", [_infoId]];
 } else {
     private _action = _hub addAction ["Refill Field Resupply Carrier", _statement, [], 1.5, true, true, "", "_this distance _target <= 4 && {_this getVariable ['Waldo_FieldResupply_MaxCrates', 0] > 0} && {backpack _this != ''}", 4];
-    _hub setVariable ["Waldo_FieldResupply_ActionIds", [_action]];
+    _hub setVariable ["Waldo_FieldResupply_ActionIds", [_infoId, _action]];
     _hub setVariable ["Waldo_FieldResupply_ACEActionPaths", []];
 };
 true

--- a/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/MissionFlowAndUi/runDiagnosticsClient.sqf
+++ b/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/MissionFlowAndUi/runDiagnosticsClient.sqf
@@ -15,6 +15,7 @@
  *
  * Example:
  * ["diag_01"] call Waldo_fnc_RunDiagnosticsClient;
+ * Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Diagnostics
  */
 if (!hasInterface) exitWith {false};
 params [["_runId", "", [""]]];
@@ -66,10 +67,37 @@ if (_acreEnabled) then {
     private _groupIndex = _groups findIf {(_x select 0) == _groupKey};
     private _radios = if (isNil "acre_api_fnc_getCurrentRadioList") then {[]} else {[] call acre_api_fnc_getCurrentRadioList};
     private _unique = _radios select {"_ID_" in toUpper _x};
+    private _profiles = [_acreConfig] call Waldo_fnc_ACRE2GetRadioProfiles;
+    private _profileClasses = _profiles apply {toUpperANSI (_x select 0)};
+    private _inventoryRadios = (items player + assignedItems player) select {
+        private _item = toUpperANSI _x;
+        (_profileClasses findIf {_item == _x || {_item find (_x + "_ID_") == 0}}) >= 0
+    };
+    private _acreApiReady = !isNil "acre_api_fnc_isInitialized" && {[] call acre_api_fnc_isInitialized};
+    private _edenRadioSetup = player getVariable ["acre_sys_radio_setup", ""];
     private _last = missionNamespace getVariable ["Waldo_ACRE2_LastApplication", []];
     private _lastOk = count _last > 0 && {_last select 0};
-    private _state = if (!_planValid || {_sideIndex < 0} || {_groupIndex < 0} || {_radios isEqualTo []} || {!_lastOk}) then {"ERROR"} else {"ACTIVE"};
-    ["radio", "acre-player-presetting", _state, format ["rawGroup='%1' normalized=%2 side=%3 planRevision=%4 sideMatch=%5 groupMatch=%6 radios=%7 unique=%8 loadoutGeneration=%9 restoredGeneration=%10 lastApplication=%11", _rawGroup, _groupKey, _sideKey, if (_planValid) then {_plan select 1} else {-1}, _sideIndex >= 0, _groupIndex >= 0, _radios, count _unique, missionNamespace getVariable ["Waldo_ACRE2_LoadoutGeneration", -1], missionNamespace getVariable ["Waldo_ACRE2_RestoredRadioGeneration", -1], _last]] call _add;
+    private _expectsRadios = !(_inventoryRadios isEqualTo []);
+    private _state = if (!_planValid || {_sideIndex < 0} || {_groupIndex < 0} || {_expectsRadios && {(_radios isEqualTo [] || {!_lastOk})}}) then {"ERROR"} else {if (_expectsRadios) then {"ACTIVE"} else {"UNCONFIGURED"}};
+    private _plainFinding = if (!_planValid) then {"The server did not publish a valid ACRE plan."} else {
+        if (_sideIndex < 0) then {format ["No ACRE side block matches %1.", _sideKey]} else {
+            if (_groupIndex < 0) then {format ["Group '%1' is not listed in acreConfig.sqf.", _rawGroup]} else {
+                if (_expectsRadios && {!_acreApiReady}) then {"ACRE has not finished converting the player's carried radios to unique IDs."} else {
+                    if (_expectsRadios && {_radios isEqualTo []}) then {"Supported radio items exist in the inventory, but ACRE returned no current radios."} else {
+                        if (_expectsRadios && {!_lastOk}) then {format ["The radio plan was not applied successfully: %1", _last param [5, []]]} else {
+                            if (_expectsRadios) then {"Carried radios and the configured group plan were applied."} else {"This player carries no supported ACRE radio; no assignment is required."}
+                        }
+                    }
+                }
+            }
+        }
+    };
+    ["radio", "acre-player-presetting", _state, format ["finding=%1 rawGroup='%2' normalized=%3 side=%4 planRevision=%5 sideMatch=%6 groupMatch=%7 inventoryRadios=%8 currentRadios=%9 unique=%10 acreReady=%11 edenRadioSetup=%12 loadoutGeneration=%13 restoredGeneration=%14 lastApplication=%15 readinessFailure=%16", _plainFinding, _rawGroup, _groupKey, _sideKey, if (_planValid) then {_plan select 1} else {-1}, _sideIndex >= 0, _groupIndex >= 0, _inventoryRadios, _radios, count _unique, _acreApiReady, _edenRadioSetup, missionNamespace getVariable ["Waldo_ACRE2_LoadoutGeneration", -1], missionNamespace getVariable ["Waldo_ACRE2_RestoredRadioGeneration", -1], _last, missionNamespace getVariable ["Waldo_ACRE2_LastReadinessFailure", []]]] call _add;
+    if !(_edenRadioSetup isEqualTo "") then {
+        ["radio", "acre-eden-radio-attribute", "ERROR", format ["This unit has an Eden ACRE Radio Setup attribute (%1). It can overwrite acreConfig.sqf during startup. Clear that unit attribute and let WMP own the initial assignment.", _edenRadioSetup]] call _add;
+    } else {
+        ["radio", "acre-eden-radio-attribute", "LOADED", "No conflicting Eden ACRE Radio Setup attribute is present."] call _add;
+    };
 } else {
     ["radio", "acre-player-presetting", if (_acreLoaded) then {"DISABLED"} else {"UNAVAILABLE"}, format ["loaded=%1 configEnabled=%2", _acreLoaded, _acreConfig getOrDefault ["enabled", false]]] call _add;
 };

--- a/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/MissionInit/ACRE2/acre2ApplyPlayerPlan.sqf
+++ b/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/MissionInit/ACRE2/acre2ApplyPlayerPlan.sqf
@@ -18,6 +18,7 @@
  * Example: [true, "RESPAWN"] call Waldo_fnc_ACRE2ApplyPlayerPlan;
  * Result: applicable carried-radio occurrences receive the authored baseline once for this loadout.
  * Current callers: Waldo_fnc_ACRE2SchedulePlayerRefresh and persistence fallback.
+ * Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE-2-Long-Range-Radio-Presetting
  */
 params [["_force", false, [true]], ["_reason", "MANUAL", [""]], ["_retryAllowed", true, [true]]];
 if (!hasInterface || {isNull player} || {!(isClass (configFile >> "CfgPatches" >> "acre_main"))}) exitWith {false};
@@ -60,6 +61,17 @@ private _tuningFor = {
 };
 private _normaliseEar = {params ["_value"]; private _ear = toUpper _value; if (_ear == "BOTH") then {"CENTER"} else {_ear}};
 private _defaultEar = {params ["_profile", "_occurrence"]; private _ears = _profile select 2; _ears select (((_occurrence - 1) min ((count _ears) - 1)) max 0)};
+private _profileClasses = _profiles apply {toUpperANSI (_x select 0)};
+private _inventoryRadios = (items player + assignedItems player) select {
+    private _item = toUpperANSI _x;
+    (_profileClasses findIf {_item == _x || {_item find (_x + "_ID_") == 0}}) >= 0
+};
+if (!(_inventoryRadios isEqualTo []) && {_radios isEqualTo []}) exitWith {
+    private _message = format ["Supported radio items exist in the inventory (%1), but ACRE returned no unique carried radios.", _inventoryRadios];
+    missionNamespace setVariable ["Waldo_ACRE2_LastApplication", [false, _reason, _sideKey, _groupKey, [], [_message], [], []]];
+    diag_log format ["[WMP ACRE] %1", _message];
+    false
+};
 
 // Apply the first matching side-scoped override. MERGE updates assignment identities; REPLACE starts clean.
 {
@@ -117,6 +129,15 @@ private _typeCounts = createHashMap;
         } forEach _netKeys;
         if (count _compatibleNets >= _occurrence) then {
             _resolved pushBack [_radioId, _base, _occurrence, (_compatibleNets select (_occurrence - 1)) select 0, [_profile, _occurrence] call _defaultEar];
+        } else {
+            _success = false;
+            _problems pushBack format [
+                "%1#%2 is carried, but group %3 has only %4 compatible named net(s). Add a tuning for this radio class or an explicit assignment.",
+                _base,
+                _occurrence,
+                _groupKey,
+                count _compatibleNets
+            ];
         };
     };
 } forEach _radios;

--- a/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/MissionInit/ACRE2/acre2SchedulePlayerRefresh.sqf
+++ b/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/MissionInit/ACRE2/acre2SchedulePlayerRefresh.sqf
@@ -15,6 +15,7 @@
  * Example: ["RESPAWN", true] call Waldo_fnc_ACRE2SchedulePlayerRefresh;
  * Result: one bounded local refresh applies Babel/CEOI and, when permitted, the radio baseline.
  * Current callers: ACRE initialisation, respawn, player-unit and group lifecycle handlers.
+ * Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/ACRE-2-Long-Range-Radio-Presetting
  */
 params [["_reason", "MANUAL", [""]], ["_applyPlan", true, [true]]];
 if (!hasInterface || {isNull player}) exitWith {false};
@@ -23,7 +24,10 @@ missionNamespace setVariable ["Waldo_ACRE2_RefreshToken", _token];
 missionNamespace setVariable ["Waldo_ACRE2_RefreshApplyPlan", (missionNamespace getVariable ["Waldo_ACRE2_RefreshApplyPlan", false]) || {_applyPlan}];
 [_token, _reason] spawn {
     params ["_token", "_reason"];
-    private _deadline = diag_tickTime + 30;
+    // ACRE documents isInitialized as the point at which carried base radios have become unique
+    // IDs. Large modsets and Eden-defined radio attributes can legitimately take longer than the
+    // rest of mission init, so this asynchronous waiter allows two minutes without blocking WMP.
+    private _deadline = diag_tickTime + 120;
     waitUntil {
         uiSleep 0.1;
         private _plan = missionNamespace getVariable ["Waldo_ACRE2_Plan", []];
@@ -42,17 +46,45 @@ missionNamespace setVariable ["Waldo_ACRE2_RefreshApplyPlan", (missionNamespace 
     private _plan = missionNamespace getVariable ["Waldo_ACRE2_Plan", []];
     if (diag_tickTime >= _deadline || {count _plan < 4} || {!([] call acre_api_fnc_isInitialized)}) exitWith {
         missionNamespace setVariable ["Waldo_ACRE2_RefreshApplyPlan", false];
-        diag_log format ["[WMP ACRE] %1 refresh timed out; mission startup continues.", _reason];
+        private _acreReady = !isNil "acre_api_fnc_isInitialized" && {[] call acre_api_fnc_isInitialized};
+        private _currentRadios = if (isNil "acre_api_fnc_getCurrentRadioList") then {[]} else {[] call acre_api_fnc_getCurrentRadioList};
+        private _config = missionNamespace getVariable ["Waldo_ACRE2_Config", createHashMap];
+        private _profiles = [_config] call Waldo_fnc_ACRE2GetRadioProfiles;
+        private _profileClasses = _profiles apply {toUpperANSI (_x select 0)};
+        private _inventoryRadios = (items player + assignedItems player) select {
+            private _item = toUpperANSI _x;
+            (_profileClasses findIf {_item == _x || {_item find (_x + "_ID_") == 0}}) >= 0
+        };
+        private _detail = if (!_acreReady && {!(_inventoryRadios isEqualTo [])}) then {
+            format ["ACRE did not finish converting carried radios to unique IDs within 120 seconds. Carried radio classes: %1.", _inventoryRadios]
+        } else {
+            if (count _plan < 4) then {"The server ACRE plan did not arrive."} else {format ["ACRE reported ready but returned no usable carried radios: %1.", _currentRadios]}
+        };
+        missionNamespace setVariable ["Waldo_ACRE2_LastReadinessFailure", [_reason, _acreReady, _inventoryRadios, _currentRadios, _detail]];
+        diag_log format ["[WMP ACRE] %1 refresh timed out: %2 Mission startup continues.", _reason, _detail];
+        if (_config getOrDefault ["notifyAssignmentProblems", true]) then {
+            ["ACRE2 SETUP", _detail + " Run WMP Diagnostics and check the ACRE radio configuration.", "WARNING", "ACRE2_READINESS"] call Waldo_fnc_FeatureNotifyLocal;
+        };
+        // Initial setup owns the baseline and must not be silently abandoned. This asynchronous
+        // retry does not block mission startup and coalesces through the refresh token.
+        if (_reason in ["INITIAL", "INITIAL_LATE"]) then {
+            ["INITIAL_LATE", true] call Waldo_fnc_ACRE2SchedulePlayerRefresh;
+        };
     };
     private _applyPlan = missionNamespace getVariable ["Waldo_ACRE2_RefreshApplyPlan", false];
     missionNamespace setVariable ["Waldo_ACRE2_RefreshApplyPlan", false];
     private _config = missionNamespace getVariable ["Waldo_ACRE2_Config", createHashMap];
     if !(missionNamespace getVariable ["Waldo_ACRE2_PresetNamesReady", false]) then {[_config] call Waldo_fnc_ACRE2ApplyPresetNames};
-    if (_applyPlan) then {[true, _reason] call Waldo_fnc_ACRE2ApplyPlayerPlan};
+    private _planApplied = true;
+    if (_applyPlan) then {_planApplied = [true, _reason] call Waldo_fnc_ACRE2ApplyPlayerPlan};
     [] call Waldo_fnc_ACRE2ApplyBabel;
     [] call Waldo_fnc_ACRE2BuildCEOI;
-    if (_reason in ["INITIAL", "PERSISTENCE_BASELINE", "PERSISTENCE_RESTORE_FALLBACK"]) then {
+    if (_planApplied && {_reason in ["INITIAL", "INITIAL_LATE", "PERSISTENCE_BASELINE", "PERSISTENCE_RESTORE_FALLBACK"]}) then {
         [false] call Waldo_fnc_SaveLoadout;
+    };
+    if (!_planApplied && {_reason in ["INITIAL", "INITIAL_LATE"]}) then {
+        diag_log "[WMP ACRE] Initial radio plan failed; the respawn baseline was not saved.";
+        ["ACRE2 SETUP", "The initial radio plan was not applied, so WMP did not save a channel-1 respawn baseline. Run WMP Diagnostics for the exact radio/net mismatch.", "WARNING", "ACRE2_INITIAL_FAILED"] call Waldo_fnc_FeatureNotifyLocal;
     };
 };
 true

--- a/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/WMPPackSource/MissionConfig/acreConfig.sqf
+++ b/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/WMPPackSource/MissionConfig/acreConfig.sqf
@@ -35,6 +35,19 @@
  * frequencies. Shipped PRC-148/152/117F presets share frequencies at matching channel numbers;
  * BF-888S and SEM52SL use separate nets. PRC-77 and SEM70 can share an explicit common frequency.
  *
+ * RADIO COMPATIBILITY - READ BEFORE ADDING OR REUSING A NET:
+ * - ACRE_PRC343 uses [block, channel]. It does not use the named long-range net rows.
+ * - ACRE_PRC148, ACRE_PRC152 and ACRE_PRC117F use numbered channels. Matching channel numbers on
+ *   their official side presets are interoperable, so they may share PLT/AIR/CAS nets.
+ * - ACRE_BF888S is a 16-channel radio in a different band. Give it a BF-only net such as BF_LOCAL.
+ * - ACRE_SEM52SL is a 12-channel radio in a different band. Give it a SEM52-only net.
+ * - ACRE_PRC77 and ACRE_SEM70 use explicit MHz. They may share a net only where that frequency is
+ *   valid for both radios; 34.000 MHz is a valid shared example.
+ * - Unknown and vehicle-rack radios are deliberately preserved and never guessed.
+ * A group may list all these keys together. WMP filters them by class: a PRC-152 cannot consume
+ * BF_LOCAL or LEGACY. A supported carried radio with no compatible tuning is reported by class and
+ * occurrence and left unchanged; WMP does not silently force it onto channel 1.
+ *
  * GROUPS AND OPTIONAL RADIO TEMPLATES
  * A group is [editor group ID, ordered fallback net keys, PRC-343 [block,channel] or [], explicit
  * assignments]. An assignment is [base class, same-type occurrence, target, ear]. Explicit rows are
@@ -240,21 +253,21 @@ createHashMapFromArray [
                     ]
                 ],
                 [
-                    "BF_LOCAL", // internal net key.
+                    "BF_LOCAL", // SPECIAL RADIO ONLY: BF-888S. Not interchangeable with PRC channels.
                     "LOCAL BF", // player-facing name.
                     [
                         ["ACRE_BF888S", 4] // the BF-888S uses its own channel 4; this does not consume PRC channels.
                     ]
                 ],
                 [
-                    "SEM_LOCAL", // internal net key.
+                    "SEM_LOCAL", // SPECIAL RADIO ONLY: SEM52SL. Not interchangeable with BF/PRC channels.
                     "LOCAL SEM", // player-facing name.
                     [
                         ["ACRE_SEM52SL", 4] // the SEM52SL uses its own channel 4.
                     ]
                 ],
                 [
-                    "LEGACY", // internal net key; rename this if a clearer mission name is available.
+                    "LEGACY", // FREQUENCY RADIO ONLY: PRC-77/SEM70; the MHz value must suit each radio.
                     "LEGACY", // player-facing name.
                     [
                         ["ACRE_PRC77", 34.000], // frequency radio: tune PRC-77 to 34.000 MHz.

--- a/releaseVerificationAndDeployment/test_full_arma_audit.py
+++ b/releaseVerificationAndDeployment/test_full_arma_audit.py
@@ -153,6 +153,12 @@ class FullAuditTests(unittest.TestCase):
             self.assertIsNotNone(category, folder.name)
             self.assertIn(category.group(1), allowed_categories, folder.name)
             self.assertEqual(composition.count("{"), composition.count("}"), folder.name)
+            if 'dataType="Comment"' in composition:
+                self.assertIn(
+                    "https://github.com/AdamWaldie/WaldosMissionPack/wiki/",
+                    composition,
+                    f"{folder.name}: Eden feature comments must link their wiki article",
+                )
             for function_name in set(re.findall(r"Waldo_fnc_[A-Za-z0-9_]+", composition)):
                 short_name = function_name.removeprefix("Waldo_fnc_")
                 self.assertRegex(functions, rf"class\s+{re.escape(short_name)}\b", folder.name)
@@ -170,7 +176,10 @@ class FullAuditTests(unittest.TestCase):
         self.assertIn("Features intentionally without compositions", catalogue)
         self.assertIn("Vehicle Recovery Workshop Example", catalogue)
         self.assertIn("Field Resupply Hub Example", catalogue)
-        self.assertIn("Hazardous Emitter Example", catalogue)
+        self.assertIn("Hazardous Zone Example", catalogue)
+        self.assertIn("Bomb Defusal Example", catalogue)
+        self.assertIn("Electronic Warfare Examples", catalogue)
+        self.assertIn("Custom 3D Marker Example", catalogue)
 
     def test_user_facing_source_uses_current_zeus_and_author_wording(self):
         roots = (
@@ -571,7 +580,9 @@ class FullAuditTests(unittest.TestCase):
         self.assertIn("[] call Waldo_fnc_ACRE2Init;", init_server)
         self.assertIn("[] call Waldo_fnc_ACRE2Init;", init_player)
         self.assertIn("if (isServer &&", acre_init)
-        self.assertIn("private _deadline = diag_tickTime + 30;", acre_refresh)
+        self.assertIn("private _deadline = diag_tickTime + 120;", acre_refresh)
+        self.assertIn('["INITIAL_LATE", true] call Waldo_fnc_ACRE2SchedulePlayerRefresh', acre_refresh)
+        self.assertIn("if (_planApplied", acre_refresh)
         self.assertNotIn("Waldo_ACRE2_PlanReady", acre_init)
         self.assertIn('missionNamespace getVariable ["Waldo_ACRE2_Plan", []]', acre_refresh)
         self.assertIn('if (hasInterface) then {["",""] call Waldo_fnc_InfoText};', init)

--- a/wiki/ACRE-2-Long-Range-Radio-Presetting.md
+++ b/wiki/ACRE-2-Long-Range-Radio-Presetting.md
@@ -45,7 +45,28 @@ compatible net or left unchanged.
 
 A shared net key is meaningful only when its tunings are interoperable. The official PRC-148/152/117F presets use matching frequencies at matching channel numbers. BF-888S and SEM52SL occupy different bands and therefore use separate local nets. PRC-77 and SEM70 can share an explicit common frequency. There is no global net count or smallest-radio capacity limit.
 
-Built-in limits are PRC-148 32 channels, PRC-152/117F 100, BF-888S 16 and SEM52SL 12 ordinary channels. PRC-77 tunes 30–75.95 MHz in 50 kHz steps; SEM70 tunes 30–79.975 MHz in 25 kHz steps. Unknown radios and vehicle racks are preserved.
+### Radio compatibility and special nets
+
+Do not assume that the same channel number means two different radio families can communicate.
+WMP resolves every net against the **base radio class** and ignores incompatible net rows.
+
+| Radio | WMP target | Capacity or range | Safe authoring rule |
+|---|---|---|---|
+| PRC-343 | `[block, channel]` | 16 channels per block; 16 blocks under `FULL_RANGE`, 5 under `SIDE_ISOLATED` | Use the group's PRC-343 field or an explicit PRC-343 assignment. It does not consume LR named-net rows. |
+| PRC-148 | Channel number | Channels 1-32 | May share a named net with PRC-152/117F when official side-preset channel numbers match. |
+| PRC-152 | Channel number | Channels 1-100 | May share numbered-channel PLT/AIR/CAS nets with PRC-148/117F. |
+| PRC-117F | Channel number | Channels 1-100 | May share numbered-channel PLT/AIR/CAS nets with PRC-148/152. |
+| BF-888S | Channel number | Channels 1-16 | Different band: use a BF-888S-specific net such as `BF_LOCAL`. |
+| SEM52SL | Channel number | Channels 1-12 | Different band: use a SEM52SL-specific net such as `SEM_LOCAL`. |
+| PRC-77 | Explicit MHz | 30-75.95 MHz, 50 kHz steps | Use a frequency net. It can share with SEM70 only at a value valid for both, such as 34.000 MHz. |
+| SEM70 | Explicit MHz | 30-79.975 MHz, 25 kHz steps | Use a frequency net; never substitute an ordinary channel number. |
+| Unknown radio or vehicle rack | Unmanaged | Unknown | WMP preserves it. Register a tested carried-radio profile rather than guessing. |
+
+A group may safely list `PLT1`, `BF_LOCAL`, `SEM_LOCAL` and `LEGACY` together. Each carried radio
+selects only compatible tunings: a PRC-152 cannot consume `BF_LOCAL`, and a BF-888S cannot consume
+the PRC-77 frequency. If a supported carried radio has no compatible tuning, WMP records the exact
+class and occurrence as an assignment problem and leaves that radio unchanged; it does not silently
+force channel 1.
 
 ## Groups, duplicate radios and ears
 

--- a/wiki/Eden-Compositions.md
+++ b/wiki/Eden-Compositions.md
@@ -11,6 +11,17 @@ Mission Systems and Mission Tools so Eden does not present one undifferentiated 
 
 ## Newly covered systems
 
+- **Bomb Defusal Example:** an editable electronic device with the standard wire-cutting challenge
+  and explosive failure consequence.
+- **Construction Objects Example:** an ACE construction supply crate using the modern construction
+  audio profile.
+- **Electronic Warfare Examples:** one EMP-immune vehicle and one WEST-tracked vehicle, spaced for
+  immediate testing.
+- **Object Scaling Example:** a decorative object converted to a supported Simple Object at 175%
+  scale. The comment warns that conversion replaces the original object reference.
+- **Custom 3D Marker Example:** a signal relay with labelled marker options written as readable
+  key/value pairs in its init field.
+
 - **Vehicle Recovery Workshop Example:** a safely spaced workshop, recoverable MRAP and generic
   `AUTO` carrier. All share workshop key `MAIN`; the workshop includes optional area and point
   markers.
@@ -18,17 +29,22 @@ Mission Systems and Mission Tools so Eden does not present one undifferentiated 
   with Zeus or `[unit, currentCrates, maximumCrates] call Waldo_fnc_FieldResupplyAssignCarrier`.
 - **Radio Jammer Example:** a 300 m omnidirectional jammer affecting all sides and bands. It starts
   active, is curator-visible, and uses the mission's configured disable/reactivate interaction.
-- **Hazardous Emitter Example:** a 15 m toxic leak with entry/exit notification, staged damage and
+- **Hazardous Zone Example:** a fixed 15 m toxic leak with entry/exit notification, staged damage and
   fatal exposure. Its inline profile is deliberately visible so it can be rewritten for scenario RP.
 - **Tactical Display Example:** a supported map board that opens the client Tactical Display. It
   follows the viewer's side, uses a 2000 m radius and may show known enemy contacts.
 
 ## Locality rule
 
-Composition init fields that register shared state or change global cargo use an `isServer` guard.
-The public function then publishes actions/settings for connected players and JIP. Local-only Eden
-actions, such as teleport boarding points, run on each interface through their repeat-safe setup
-path. Do not remove these boundaries when editing examples.
+Composition init fields call the public feature API directly. Each API routes authority to the
+server and publishes local/JIP setup where required; beginners should not need to add repetitive
+`isServer` wrappers. Local-only Eden actions, such as teleport boarding points, run on each
+interface through their repeat-safe setup path. Do not add a locality guard unless that function's
+wiki article explicitly requires one.
+
+Every WMP Eden comment includes the direct URL of the matching wiki article. Keep that link when
+copying or adapting the example so the next mission maker can recover the parameter and locality
+guidance from inside Eden.
 
 ## Why some features have no composition
 


### PR DESCRIPTION
## What changed

- adds Bomb Defusal, Construction Objects, Electronic Warfare, Object Scaling, and Custom 3D Marker compositions
- adds direct wiki links to WMP composition guidance and documents the expanded catalogue
- fixes the hazardous-area example as a reliable fixed zone with constant exposure, transition feedback, staged injury, and fatal exposure
- replaces obsolete AutoFortify example classnames with current Arma 3 objects
- adds a repeat-safe WMP-blue information action to Field Resupply hubs
- hardens initial ACRE radio presetting around late unique-radio creation and Eden radio attributes
- prevents a failed ACRE plan from saving channel-1 radios as the respawn baseline
- reports group, inventory, unique-radio, plan, compatibility, and Eden-attribute conflicts through WMP diagnostics
- documents which ACRE nets are compatible with the PRC-343, PRC-148/152/117F, BF-888S, SEM52SL, PRC-77, and SEM70

## Why

The current test mission showed a valid `Viking 2-3` plan and group match, but WMP abandoned initial presetting after 30 seconds. ACRE created the unique radios later and then applied Eden-defined channel-1 settings. This was a lifecycle race exposed around the callsign reconciliation work, not a failure to normalize the callsign itself.

The current RPT also showed the hazardous composition registered and the client evaluator running without any spatial transition, plus obsolete object-class warnings in the AutoFortify composition. The static hazard example now uses a network-safe fixed area; moving hazards remain available through the emitter API.

## User impact

- carried ACRE radios are preset only after ACRE has created their unique IDs
- initial respawn state is not contaminated by an unsuccessful channel-1 baseline
- mission makers receive actionable diagnostics instead of silent ACRE failure
- special-frequency nets are explicitly identified so incompatible radios are not accidentally assigned them
- composition users get more feature examples and direct links to setup documentation
- the Field Resupply hub identifies itself consistently with other WMP logistics objects

## Validation

- 166 repository unit tests pass
- 864 SQF files validate with zero errors
- config validation passes
- wiki structure validation passes
- documentation contract validation passes
- `git diff --check` passes

Runtime files were also synchronized into `TestMission.Altis`, and all 31 WMP composition folders were synchronized into the active Eden profile catalogue for the next Arma reload.
