### PR TITLE
Fix claude.ai skill upload: Windows backslash arcnames

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,6 +29,9 @@ jobs:
     - name: Test the Claude Mission Config Skill validator
       working-directory: releaseVerificationAndDeployment
       run: python3 -m unittest -v test_claude_skill_validator.py
+    - name: Test the claude.ai skill upload packager
+      working-directory: releaseVerificationAndDeployment
+      run: python3 -m unittest -v test_package_claude_skill_upload.py
     - name: Test interaction equipment UI checker
       working-directory: releaseVerificationAndDeployment
       run: python3 -m unittest -v test_interaction_ui_checker.py

--- a/releaseVerificationAndDeployment/package_claude_skill_upload.py
+++ b/releaseVerificationAndDeployment/package_claude_skill_upload.py
@@ -94,7 +94,20 @@ def package(skill_dir: Path, output_path: Path):
             rel_path = file_path.relative_to(skill_dir.parent)
             if _should_exclude(rel_path):
                 continue
-            zf.write(file_path, rel_path)
+            # The ZIP format requires forward slashes as directory separators
+            # regardless of host OS. On Windows, rel_path is a WindowsPath,
+            # and passing it (or str(rel_path)) straight to ZipFile.write
+            # writes arcnames with backslashes instead - the zip has no real
+            # subdirectories at all, just filenames containing a literal "\"
+            # character. Every real folder structure in the archive (the
+            # skill's own "<name>/SKILL.md" root, "<name>/references/...")
+            # silently collapses, which is exactly what a strict reader like
+            # claude.ai's uploader rejects ("skill not at root" even though
+            # every file is technically present). as_posix() forces forward
+            # slashes on every platform, matching what this script already
+            # verified correctly on Linux/macOS by coincidence of using the
+            # native separator there.
+            zf.write(file_path, rel_path.as_posix())
 
     print(f"Wrote claude.ai-upload-ready skill package: {output_path}")
 

--- a/releaseVerificationAndDeployment/package_claude_skill_upload.py
+++ b/releaseVerificationAndDeployment/package_claude_skill_upload.py
@@ -15,17 +15,8 @@ fails validation ("must contain a SKILL.md file").
 This script produces that second, upload-ready shape as its own artifact.
 Both are shipped: the release zip for dropping into a mission project /
 Claude Code, this one for claude.ai's/the Skills API's direct upload path.
-
-This package also deliberately contains LESS than the release zip: only
-what a Claude skill itself actually is (SKILL.md plus its references/*
-bundled resources, per Anthropic's own skill anatomy —
-name+description frontmatter, instructions, reference files). ChatGPT's
-Custom GPT entry point (chatgpt/INSTRUCTIONS.md) is a different product's
-config, not part of the skill Claude loads or executes — including it here
-would just be dead weight/clutter in something meant to be exactly "what
-you'd want to take in as a skill." It still ships in the mission-project
-release zip, where a mission maker reasonably wants both entry points
-side by side.
+Both packages ship the exact same content — SKILL.md, references/* and
+chatgpt/INSTRUCTIONS.md — only the archive's root layout differs.
 
 Usage:
     python3 releaseVerificationAndDeployment/package_claude_skill_upload.py [version_tag] [output_dir]
@@ -42,24 +33,15 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SKILL_DIR = REPO_ROOT / ".claude" / "skills" / "mission-pack-config"
 
 # Mirror package_skill.py's exclusions so this stays consistent with the
-# general Anthropic skill-packaging convention (no build artifacts, no
-# evals-only content shipped to end users).
+# general Anthropic skill-packaging convention (no build artifacts shipped
+# to end users). Everything else under the skill folder - including
+# chatgpt/INSTRUCTIONS.md - ships as part of the skill build.
 EXCLUDE_DIRS = {"__pycache__", "node_modules"}
 EXCLUDE_FILES = {".DS_Store"}
-# Excluded only at the skill root (not if a reference file elsewhere happens
-# to sit under a same-named directory) — mirrors package_skill.py's handling
-# of "evals". "chatgpt" is Custom GPT instructions for an entirely different
-# product; it isn't part of what Claude loads as this skill.
-ROOT_EXCLUDE_DIRS = {"chatgpt"}
 
 
 def _should_exclude(rel_path: Path) -> bool:
-    # rel_path is relative to skill_dir.parent, so parts[0] is the skill
-    # folder name and parts[1] (if present) is the first subdir under it.
-    parts = rel_path.parts
-    if any(part in EXCLUDE_DIRS for part in parts):
-        return True
-    if len(parts) > 1 and parts[1] in ROOT_EXCLUDE_DIRS:
+    if any(part in EXCLUDE_DIRS for part in rel_path.parts):
         return True
     return rel_path.name in EXCLUDE_FILES
 

--- a/releaseVerificationAndDeployment/package_claude_skill_upload.py
+++ b/releaseVerificationAndDeployment/package_claude_skill_upload.py
@@ -16,6 +16,17 @@ This script produces that second, upload-ready shape as its own artifact.
 Both are shipped: the release zip for dropping into a mission project /
 Claude Code, this one for claude.ai's/the Skills API's direct upload path.
 
+This package also deliberately contains LESS than the release zip: only
+what a Claude skill itself actually is (SKILL.md plus its references/*
+bundled resources, per Anthropic's own skill anatomy —
+name+description frontmatter, instructions, reference files). ChatGPT's
+Custom GPT entry point (chatgpt/INSTRUCTIONS.md) is a different product's
+config, not part of the skill Claude loads or executes — including it here
+would just be dead weight/clutter in something meant to be exactly "what
+you'd want to take in as a skill." It still ships in the mission-project
+release zip, where a mission maker reasonably wants both entry points
+side by side.
+
 Usage:
     python3 releaseVerificationAndDeployment/package_claude_skill_upload.py [version_tag] [output_dir]
 
@@ -35,10 +46,20 @@ SKILL_DIR = REPO_ROOT / ".claude" / "skills" / "mission-pack-config"
 # evals-only content shipped to end users).
 EXCLUDE_DIRS = {"__pycache__", "node_modules"}
 EXCLUDE_FILES = {".DS_Store"}
+# Excluded only at the skill root (not if a reference file elsewhere happens
+# to sit under a same-named directory) — mirrors package_skill.py's handling
+# of "evals". "chatgpt" is Custom GPT instructions for an entirely different
+# product; it isn't part of what Claude loads as this skill.
+ROOT_EXCLUDE_DIRS = {"chatgpt"}
 
 
 def _should_exclude(rel_path: Path) -> bool:
-    if any(part in EXCLUDE_DIRS for part in rel_path.parts):
+    # rel_path is relative to skill_dir.parent, so parts[0] is the skill
+    # folder name and parts[1] (if present) is the first subdir under it.
+    parts = rel_path.parts
+    if any(part in EXCLUDE_DIRS for part in parts):
+        return True
+    if len(parts) > 1 and parts[1] in ROOT_EXCLUDE_DIRS:
         return True
     return rel_path.name in EXCLUDE_FILES
 

--- a/releaseVerificationAndDeployment/test_package_claude_skill_upload.py
+++ b/releaseVerificationAndDeployment/test_package_claude_skill_upload.py
@@ -75,6 +75,36 @@ class PackageClaudeSkillUploadTests(unittest.TestCase):
             packager.package(self.skill_dir, self.output_path)
         self.assertFalse(self.output_path.exists())
 
+    def test_nested_reference_subdirectories_use_forward_slashes(self):
+        # Regression test: every arcname must use '/' regardless of host OS,
+        # and real nested folders (e.g. references/mods/*.md in the actual
+        # skill) must appear as genuine subdirectory entries, not collapse.
+        _write_skill(self.skill_dir)
+        nested_dir = self.skill_dir / "references" / "nested"
+        nested_dir.mkdir()
+        (nested_dir / "deep.md").write_text("# Nested\n", encoding="utf-8")
+
+        packager.package(self.skill_dir, self.output_path)
+        entries = self._zip_entries()
+        self.assertIn("example-skill/references/nested/deep.md", entries)
+        self.assertFalse(any("\\" in name for name in entries))
+
+    def test_windows_style_relative_path_normalizes_to_forward_slashes(self):
+        # Regression test for the actual reported bug: on Windows, a
+        # relative Path's native string form uses backslashes. Passing that
+        # straight to ZipFile.write embeds the backslash literally in the
+        # arcname instead of producing a real subdirectory separator (the
+        # ZIP format requires '/'), which collapses every folder in the
+        # archive - exactly what made claude.ai's uploader reject the
+        # skill as "not at root" even though every file was present. This
+        # doesn't require running on Windows to verify: PureWindowsPath
+        # reproduces the exact platform string semantics package() relies
+        # on .as_posix() to normalize away.
+        from pathlib import PureWindowsPath
+        windows_style = PureWindowsPath("mission-pack-config", "references", "nested", "deep.md")
+        self.assertIn("\\", str(windows_style))
+        self.assertEqual(windows_style.as_posix(), "mission-pack-config/references/nested/deep.md")
+
     def test_real_repo_skill_packages_to_correct_shape(self):
         # End-to-end guard against the real shipped skill.
         packager.package(packager.SKILL_DIR, self.output_path)

--- a/releaseVerificationAndDeployment/test_package_claude_skill_upload.py
+++ b/releaseVerificationAndDeployment/test_package_claude_skill_upload.py
@@ -42,10 +42,10 @@ class PackageClaudeSkillUploadTests(unittest.TestCase):
         tops = {name.split("/", 1)[0] for name in entries}
         self.assertEqual(tops, {"example-skill"})
 
-    def test_chatgpt_directory_is_excluded(self):
-        # Regression test: a Claude skill upload should contain only what
-        # Claude's skill system actually loads (SKILL.md + references/) —
-        # not a different product's Custom GPT instructions.
+    def test_chatgpt_directory_is_included(self):
+        # The claude.ai upload package ships the same content as the
+        # mission-project release zip — chatgpt/INSTRUCTIONS.md included —
+        # only the archive's root layout differs between the two.
         _write_skill(self.skill_dir)
         chatgpt_dir = self.skill_dir / "chatgpt"
         chatgpt_dir.mkdir()
@@ -53,7 +53,7 @@ class PackageClaudeSkillUploadTests(unittest.TestCase):
 
         packager.package(self.skill_dir, self.output_path)
         entries = self._zip_entries()
-        self.assertFalse(any("chatgpt" in name for name in entries))
+        self.assertIn("example-skill/chatgpt/INSTRUCTIONS.md", entries)
         self.assertIn("example-skill/SKILL.md", entries)
         self.assertIn("example-skill/references/example.md", entries)
 
@@ -110,7 +110,7 @@ class PackageClaudeSkillUploadTests(unittest.TestCase):
         packager.package(packager.SKILL_DIR, self.output_path)
         entries = self._zip_entries()
         self.assertIn("mission-pack-config/SKILL.md", entries)
-        self.assertFalse(any("chatgpt" in name for name in entries))
+        self.assertIn("mission-pack-config/chatgpt/INSTRUCTIONS.md", entries)
         tops = {name.split("/", 1)[0] for name in entries}
         self.assertEqual(tops, {"mission-pack-config"})
 

--- a/releaseVerificationAndDeployment/test_package_claude_skill_upload.py
+++ b/releaseVerificationAndDeployment/test_package_claude_skill_upload.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Unit tests for package_claude_skill_upload.py.
+
+Run from this directory: python3 -m unittest -v test_package_claude_skill_upload.py
+"""
+
+import shutil
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+import package_claude_skill_upload as packager
+
+
+def _write_skill(root: Path, description="A short, valid description under the length cap."):
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "SKILL.md").write_text(
+        f"---\nname: {root.name}\ndescription: {description}\n---\n\n# Body\n", encoding="utf-8"
+    )
+    (root / "references").mkdir(exist_ok=True)
+    (root / "references" / "example.md").write_text("# Example reference\n", encoding="utf-8")
+
+
+class PackageClaudeSkillUploadTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = Path(tempfile.mkdtemp(prefix="wmp_skill_package_test_"))
+        self.addCleanup(shutil.rmtree, self.tmp_dir, ignore_errors=True)
+        self.skill_dir = self.tmp_dir / "example-skill"
+        self.output_path = self.tmp_dir / "out" / "example-skill.zip"
+
+    def _zip_entries(self):
+        with zipfile.ZipFile(self.output_path) as zf:
+            return zf.namelist()
+
+    def test_skill_folder_is_the_single_top_level_directory(self):
+        _write_skill(self.skill_dir)
+        packager.package(self.skill_dir, self.output_path)
+        entries = self._zip_entries()
+        self.assertIn("example-skill/SKILL.md", entries)
+        tops = {name.split("/", 1)[0] for name in entries}
+        self.assertEqual(tops, {"example-skill"})
+
+    def test_chatgpt_directory_is_excluded(self):
+        # Regression test: a Claude skill upload should contain only what
+        # Claude's skill system actually loads (SKILL.md + references/) —
+        # not a different product's Custom GPT instructions.
+        _write_skill(self.skill_dir)
+        chatgpt_dir = self.skill_dir / "chatgpt"
+        chatgpt_dir.mkdir()
+        (chatgpt_dir / "INSTRUCTIONS.md").write_text("ChatGPT-only instructions.\n", encoding="utf-8")
+
+        packager.package(self.skill_dir, self.output_path)
+        entries = self._zip_entries()
+        self.assertFalse(any("chatgpt" in name for name in entries))
+        self.assertIn("example-skill/SKILL.md", entries)
+        self.assertIn("example-skill/references/example.md", entries)
+
+    def test_build_artifacts_are_excluded(self):
+        _write_skill(self.skill_dir)
+        pycache_dir = self.skill_dir / "references" / "__pycache__"
+        pycache_dir.mkdir()
+        (pycache_dir / "stale.pyc").write_bytes(b"\x00")
+        (self.skill_dir / ".DS_Store").write_bytes(b"\x00")
+
+        packager.package(self.skill_dir, self.output_path)
+        entries = self._zip_entries()
+        self.assertFalse(any("__pycache__" in name for name in entries))
+        self.assertFalse(any(name.endswith(".DS_Store") for name in entries))
+
+    def test_invalid_skill_refuses_to_package(self):
+        _write_skill(self.skill_dir, description="x" * 1025)
+        with self.assertRaises(SystemExit):
+            packager.package(self.skill_dir, self.output_path)
+        self.assertFalse(self.output_path.exists())
+
+    def test_real_repo_skill_packages_to_correct_shape(self):
+        # End-to-end guard against the real shipped skill.
+        packager.package(packager.SKILL_DIR, self.output_path)
+        entries = self._zip_entries()
+        self.assertIn("mission-pack-config/SKILL.md", entries)
+        self.assertFalse(any("chatgpt" in name for name in entries))
+        tops = {name.split("/", 1)[0] for name in entries}
+        self.assertEqual(tops, {"mission-pack-config"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**When merged this pull request will:**

**The real fix:** `package_claude_skill_upload.py` computed each zip entry's arcname as a plain `pathlib.Path` and passed it straight to `ZipFile.write`. On Linux/macOS that path's string form already uses forward slashes, so this looked correct in every test and manual check performed here. On **Windows**, the same `Path` is a `WindowsPath` whose native string form uses **backslashes** (e.g. `mission-pack-config\SKILL.md`) — the ZIP format requires forward slashes as directory separators, so those entries have no real subdirectory structure at all, just filenames containing a literal `\` character. Every folder in the archive collapses, which is exactly what claude.ai's uploader rejects ("skill not at root," references not packed) even though every file is technically present in the zip. Fixed with `rel_path.as_posix()` before writing, forcing forward slashes on every platform.

Added two regression tests: an integration check that nested reference subdirectories produce real `/`-separated entries with no backslash anywhere in the archive, and a focused unit test using `PureWindowsPath` that reproduces the exact platform string semantics without needing to run on Windows (CI only runs on `ubuntu-latest`, which could not otherwise have caught this).

**Reverted from this PR's original scope:** this PR initially also excluded `chatgpt/INSTRUCTIONS.md` from the claude.ai-upload package. Per explicit follow-up feedback, that instructions file should be part of the skill build, not stripped out — reverted, so both release packages (the mission-project drop-in zip and the claude.ai-upload zip) now ship identical content (`SKILL.md`, `references/*`, `chatgpt/INSTRUCTIONS.md`); only the archive's root layout differs between them.

Verified end-to-end against the real shipped skill: 57 entries, `chatgpt/INSTRUCTIONS.md` present, all 55 references present, no backslashes anywhere. All existing validators and `git diff --check` still pass.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq