### PR TITLE
Fix Vehicle Recovery crash from malformed custom-variable pairs

### DIFF
--- a/MissionScripts/Logistics/VehicleRecovery/recoveryRequestServer.sqf
+++ b/MissionScripts/Logistics/VehicleRecovery/recoveryRequestServer.sqf
@@ -60,7 +60,16 @@ if (_operation == "PACK") exitWith {
     private _cargo = if (_preserveCargo) then {[getWeaponCargo _target, getMagazineCargo _target, getItemCargo _target, getBackpackCargo _target]} else {[]};
     private _customVariableNames = +(missionNamespace getVariable ["Waldo_Recovery_DefaultCustomVariables", []]);
     {_customVariableNames pushBackUnique _x} forEach (_target getVariable ["Waldo_Recovery_CustomVariables", []]);
-    private _customVariables = _customVariableNames apply {[_x, _target getVariable _x]};
+    // getVariable with no default returns nil for a variable name the target never had set (the
+    // normal case for most vehicles and the built-in "Waldo_TransportService_Registration" entry),
+    // and an SQF array literal silently drops a nil element - [_x, nil] becomes the 1-element
+    // array [_x], not a [name, value] pair. Build the list imperatively and skip unset names so
+    // recoveryRestoreServer.sqf's "_x params ["_name", "_value"]" always gets a real pair.
+    private _customVariables = [];
+    {
+        private _value = _target getVariable [_x, nil];
+        if !(isNil "_value") then {_customVariables pushBack [_x, _value]};
+    } forEach _customVariableNames;
     private _bounds = boundingBoxReal _target;
     private _minimum = _bounds param [0, [-1, -1, -1]];
     private _maximum = _bounds param [1, [1, 1, 1]];

--- a/MissionScripts/Logistics/VehicleRecovery/recoveryRestoreServer.sqf
+++ b/MissionScripts/Logistics/VehicleRecovery/recoveryRestoreServer.sqf
@@ -62,7 +62,9 @@ if (_wasAlive && {!isNull _retained}) then {
         _vehicle setVehicleVarName _variableName;
         missionNamespace setVariable [_variableName, _vehicle, true];
     };
-    {_x params ["_name", "_value"]; _vehicle setVariable [_name, _value, true]} forEach _customVariables;
+    // Guard against a malformed (non-pair) entry rather than throwing "Undefined variable" mid-restore
+    // - see recoveryRequestServer.sqf's PACK branch for why an entry could otherwise be short.
+    {if (count _x == 2) then {_x params ["_name", "_value"]; _vehicle setVariable [_name, _value, true]}} forEach _customVariables;
 };
 
 deleteVehicle _package;

--- a/MissionScripts/Persistence/persistenceLoadObject.sqf
+++ b/MissionScripts/Persistence/persistenceLoadObject.sqf
@@ -78,8 +78,10 @@ if (_loadPosition && {count _position >= 2}) then {
 };
 private _allowedCustom = _options param [5, missionNamespace getVariable ["Waldo_Persistence_DefaultCustomVariables", []]];
 {
-    _x params ["_name", "_value"];
-    if (_name in _allowedCustom) then {_object setVariable [_name, _value, true]};
+    if (count _x == 2) then {
+        _x params ["_name", "_value"];
+        if (_name in _allowedCustom) then {_object setVariable [_name, _value, true]};
+    };
 } forEach _custom;
 if ("Waldo_ObjectScale" in _allowedCustom) then {
     _object setObjectScale (_object getVariable ["Waldo_ObjectScale", 1]);


### PR DESCRIPTION
**When merged this pull request will:**

Fix the reported error:
```
Error Undefined variable in expression: _value
.../MissionScripts/Logistics/VehicleRecovery/recoveryRestoreServer.sqf, line 65
```

- Fix the root cause in `recoveryRequestServer.sqf`'s `PACK` branch: `_customVariableNames apply {[_x, _target getVariable _x]}` used `getVariable`'s no-default form, which returns `nil` for any listed variable name the target never actually had set. An SQF array literal silently drops a `nil` element, so `[_x, nil]` collapsed to the 1-element array `[_x]` instead of a real `[name, value]` pair. That's the normal case for the built-in `"Waldo_TransportService_Registration"` entry in `Waldo_Recovery_DefaultCustomVariables` on any vehicle that was never registered as a transport service — i.e. most ordinary recovered vehicles — so packaging/restoring practically any vehicle could hit this.
- Rebuild the list imperatively, only pushing a pair when the variable is actually set — matching the pattern `persistenceSaveObject.sqf` already uses correctly for the equivalent Persistence custom-variable list.
- Harden both consumers (`recoveryRestoreServer.sqf` and `persistenceLoadObject.sqf`, which shares the same `_x params ["_name", "_value"]` pattern) to skip a malformed entry via a `count _x == 2` guard instead of throwing mid-restore — defense in depth against this bug's prior output or any future producer bug.

`sqf_validator.py` (888 files, 0 errors) and `git diff --check` both pass.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq

---
_Generated by [Claude Code](https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq)_