### PR TITLE
Add a visible indicator to field hospital medical crates

### DIFF
--- a/MissionScripts/Logistics/Crates/doMedicalCrate.sqf
+++ b/MissionScripts/Logistics/Crates/doMedicalCrate.sqf
@@ -1,5 +1,7 @@
 /*
 This function populates an advanced medical crate, with the option to enable the box as a field hospital if desired.
+When enabled with ACE medical present, a "FIELD HOSPITAL" 3D marker is attached to the crate so players can see
+which crate grants the locational treatment boost without opening its inventory or reading the mission briefing.
 
 Params:
 _crate - object to populate (Passed from module where thee classname of the box is defined)
@@ -34,11 +36,23 @@ clearbackpackcargoGlobal _crate;
 //Verify ACE Medical Activation, then perform due dilligence
 if (isClass(configFile >> "CfgPatches" >> "ace_medical")) then {
     //Check if option selected for medical locational boost
+    private _markerId = format ["WMP_FieldHospital_%1", netId _crate];
     if (_isFacility) then {
         _crate setVariable ["ace_medical_isMedicalFacility", true, true];
-        // ACE medical already exposes the facility state. A decorative addAction here used to
-        // pollute the vanilla action menu even when ACE was the active interaction surface.
+        // ACE medical already exposes the facility state to treatment logic, but that gives
+        // players no visible reason to bring casualties to this specific crate over any other
+        // one - a persistent 3D marker is the non-intrusive indicator (no addAction, so it
+        // never pollutes the vanilla/ACE interaction menu the way a prior decorative action did).
+        [_markerId, _crate, createHashMapFromArray [
+            ["text", "FIELD HOSPITAL"],
+            ["icon", "\z\ACE\addons\medical_gui\ui\cross.paa"],
+            ["colour", [0.35, 0.85, 0.45, 0.95]],
+            ["offset", [0, 0, 1.2]],
+            ["distance", 40]
+        ]] call Waldo_fnc_Create3DMarker;
         diag_log format ["[WMP LOGISTICS] ACE medical facility enabled crate=%1", netId _crate];
+    } else {
+        [_markerId] call Waldo_fnc_Remove3DMarker;
     };
     //Add ACE Medical supplies   
    //Common Items


### PR DESCRIPTION
**When merged this pull request will:**

Address the v4.8.1 known issue: "Field hospital upgraded medical boxes have no indicator that they are field hospitals."

- ACE already reads `ace_medical_isMedicalFacility` off the crate to grant its treatment bonus, but nothing told players which crate actually carries that flag. A decorative `addAction` used to do this but was deliberately removed because it polluted the vanilla/ACE interaction menu even when ACE was the active interaction surface (per the file's own existing comment).
- `doMedicalCrate.sqf` now attaches a **"FIELD HOSPITAL"** 3D marker (`Waldo_fnc_Create3DMarker`, the pack's existing broadcast/JIP-safe world-marker API) to the crate instead — visible at a glance, no action-menu clutter.
- Keyed off the crate's `netId`, so re-populating the same crate updates rather than duplicates the marker, and it's removed via `Waldo_fnc_Remove3DMarker` if a mission maker re-runs the populate call with the facility option turned off.
- Uses ACE's own medical-cross icon (`\z\ACE\addons\medical_gui\ui\cross.paa`, already referenced elsewhere in the pack for a Zeus module icon) and a short 40m visibility distance so it doesn't clutter the map from range.

Only applies when ACE medical is loaded and the facility option is enabled — vanilla-medical crates are unaffected. `sqf_validator.py` (888 files, 0 errors) and `git diff --check` both pass.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq

---
_Generated by [Claude Code](https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq)_