### PR TITLE
Fix Hazardous Environments registration race with init.sqf's SHARED config

### DIFF
--- a/MissionScripts/EnvironmentalSystems/HazardousEnvironments/hazardRegisterEmitter.sqf
+++ b/MissionScripts/EnvironmentalSystems/HazardousEnvironments/hazardRegisterEmitter.sqf
@@ -26,4 +26,16 @@
 params ["_key", ["_emitter", objNull, [objNull]], ["_radius", 3, [0]], ["_profile", createHashMap, [createHashMap]]];
 if (isNull _emitter) exitWith {false};
 _profile set ["emitterRadius", _radius max 0.5];
-[_key, _emitter, _profile] call Waldo_fnc_HazardRegisterZone
+private _registered = [_key, _emitter, _profile] call Waldo_fnc_HazardRegisterZone;
+// A moving emitter can be destroyed/deleted mid-mission (wreck cleanup, a scripted deleteVehicle)
+// without anything unregistering its zone, leaving a permanently inert entry in the registry that
+// every client keeps evaluating every tick. Auto-unregister the zone once, the same lifecycle
+// Waldo_Jamming_Destructible already applies to jammer emitters.
+if (_registered) then {
+    _emitter addEventHandler ["Deleted", {
+        params ["_entity"];
+        [_entity getVariable ["Waldo_Hazard_EmitterKey", ""]] call Waldo_fnc_HazardUnregisterZone;
+    }];
+    _emitter setVariable ["Waldo_Hazard_EmitterKey", _key];
+};
+_registered

--- a/MissionScripts/EnvironmentalSystems/HazardousEnvironments/hazardRegisterPresetZone.sqf
+++ b/MissionScripts/EnvironmentalSystems/HazardousEnvironments/hazardRegisterPresetZone.sqf
@@ -20,13 +20,32 @@
  * Example:
  * ["reactor", reactorTrigger, "SEVERE_RADIATION", createHashMapFromArray [["notifyTransitions", true]]] call Waldo_fnc_HazardRegisterPresetZone;
  * Result: Registers `reactor` with a copied severe-radiation profile plus the supplied override.
- * Current callers: server mission scripts and the full-pack audit function station.
+ * Current callers: server mission scripts, the shipped Radiation Hazard composition's object init
+ * field, and the full-pack audit function station.
  */
 
 params ["_key", "_area", ["_presetKey", "LOW_RADIATION", [""]], ["_overrides", createHashMap, [createHashMap]]];
+// Waldo_Hazard_Presets is SHARED-scope config, loaded by init.sqf's "SHARED" LoadFeatureConfigs
+// call. Object init fields (this is exactly how the shipped Radiation Hazard composition triggers
+// registration) are not guaranteed to run after init.sqf - a preset lookup here can silently and
+// permanently miss on that race, registering nothing with no error. Defer once instead of failing:
+// re-parses the same original arguments after init.sqf's Waldo_SharedFeatureConfigReady flag is
+// set, then falls through to the normal synchronous path unchanged for every other caller (server
+// mission scripts, ZEN) that already runs after full startup.
+if !(missionNamespace getVariable ["Waldo_SharedFeatureConfigReady", false]) exitWith {
+    [_this] spawn {
+        params ["_args"];
+        waitUntil {missionNamespace getVariable ["Waldo_SharedFeatureConfigReady", false]};
+        _args call Waldo_fnc_HazardRegisterPresetZone;
+    };
+    true
+};
 private _presets = missionNamespace getVariable ["Waldo_Hazard_Presets", createHashMap];
 _presetKey = toUpperANSI _presetKey;
-if !(_presetKey in (keys _presets)) exitWith {false};
+if !(_presetKey in (keys _presets)) exitWith {
+    diag_log format ["[WMP HAZARD] Preset zone '%1' rejected: unknown preset '%2'.", _key, _presetKey];
+    false
+};
 private _profile = createHashMap;
 private _preset = _presets get _presetKey;
 {_profile set [_x, _preset get _x]} forEach keys _preset;

--- a/MissionScripts/EnvironmentalSystems/HazardousEnvironments/hazardTick.sqf
+++ b/MissionScripts/EnvironmentalSystems/HazardousEnvironments/hazardTick.sqf
@@ -53,7 +53,16 @@ private _zoneDiagnostics = [];
             _intensity = 1 - ((player distance2D getMarkerPos _area) / _radius);
         };
     };
-    if (_area isEqualType objNull) then {
+    if (_area isEqualType objNull && {isNull _area}) then {
+        // A moving-emitter anchor (Waldo_fnc_HazardRegisterEmitter) can be deleted mid-mission
+        // (vehicle wreck cleanup, a scripted deleteVehicle) without the zone being unregistered.
+        // distance2D's behaviour against objNull isn't something to rely on for a damage gate -
+        // treat a null anchor as "not inside" rather than risk every player reading as inside a
+        // hazard that no longer has a real position.
+        _inside = false;
+        _intensity = 0;
+    };
+    if (_area isEqualType objNull && {!isNull _area}) then {
         if (_area isKindOf "EmptyDetector") then {
             _inside = player inArea _area;
             if (_inside) then {


### PR DESCRIPTION
**When merged this pull request will:**

**Fix 1 — registration race with init.sqf's SHARED config.** `Waldo_Hazard_Presets` is SHARED-scope config, populated by `init.sqf`'s `["SHARED"] call Waldo_fnc_LoadFeatureConfigs;`. Both shipped hazard compositions (**Radiation Hazard Example**, **Hazardous Emitter Example**) register their zone directly from the placed object's init field via `Waldo_fnc_HazardRegisterPresetZone`. Arma gives no ordering guarantee between an object's init field and `init.sqf` — object inits frequently run first — so the preset lookup could run before `Waldo_Hazard_Presets` was populated, silently registering nothing (no error, no log). `hazardRegisterPresetZone.sqf` now defers once (`spawn` + `waitUntil {Waldo_SharedFeatureConfigReady}`) instead of failing outright when called too early; every other caller is unaffected. Also added a `diag_log` on a genuinely unknown preset name.

**Fix 2 — deleted emitter object left a stuck zone (found on a second pass).** `Waldo_fnc_HazardRegisterEmitter` (moving-object hazard zones) had no cleanup when its anchor object was later deleted — the zone stayed registered indefinitely, evaluated every tick on every client against a null object with no null guard before the distance-based damage gate. Fixed:
- `hazardRegisterEmitter.sqf` now installs a `"Deleted"` event handler that auto-unregisters the zone (matching the existing `Waldo_Jamming_Destructible` lifecycle pattern for jammer emitters).
- `hazardTick.sqf` now explicitly treats a null OBJECT-type area as "not inside" before any distance calculation, as its own guarded branch.

**Scope note:** traced the rest of the Hazardous Environments system (protection factor, awareness, HUD, audio feedback, treatment interactions, ZEN `HAZARD_SET`/`HAZARD_REMOVE` wiring) across two passes now and didn't find further correctness bugs. Static/marker-anchored zones (the two shipped compositions) were never affected by the emitter-specific gap.

`sqf_validator.py` (888 files, 0 errors) and `git diff --check` both pass.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq