### PR TITLE
Add a reliable AI paradrop flight route shared by quick setup and ZEN dropzones

### DIFF
--- a/.claude/skills/mission-pack-config/references/paradrop.md
+++ b/.claude/skills/mission-pack-config/references/paradrop.md
@@ -60,7 +60,38 @@ over as a paste-in snippet):
 ```
 
 `Waldo_fnc_VehicleJumpSetup` reads the current `airOperationsConfig.sqf`
-values automatically.
+values automatically. **It only adds the jump action — it does not fly the
+plane anywhere.** For that, see the next two sections.
+
+## Reliable AI flight — quick setup (`Waldo_fnc_ParadropQuickFlightSetup`)
+
+The simple alternative to the full Dynamic Drop Zone system below, for an
+aircraft the mission maker already placed and crewed in Eden. One call in
+the object's init field:
+
+```sqf
+[this, "dz1"] call Waldo_fnc_ParadropQuickFlightSetup;
+// [aircraft, target(marker name/position/object), direction(-1=auto), altitude, maxSpeed, options]
+```
+
+- Builds a reliable standby → green → red → exit AI route (looping by
+  default) using the exact same route logic as the Dynamic Drop Zone system
+  (`Waldo_fnc_ParadropBuildFlightRoute`) — both stay in sync, fixes to one
+  benefit the other.
+- **Clears the aircraft's existing waypoints first.** A leftover Eden
+  waypoint fighting the generated route is the #1 reason a hand-set-up
+  paradrop plane misbehaves — don't call this on an aircraft whose manual
+  waypoints the mission maker wants to keep.
+- Waits (bounded, 30s) for a pilot to exist, so it's safe even if a
+  separate init-field call (e.g. `Waldo_fnc_MoveInCargoPlane` on another
+  object) assigns the crew — order between the two doesn't matter.
+- `options` HashMap: jump envelope overrides (default from
+  `airOperationsConfig.sqf`'s `WALDO_STATIC_*`/`WALDO_PARA_*`),
+  `lifecycle` (`LOOP` default/`RETAIN`/`DESPAWN`), `circuitDirection`
+  (`LEFT` default/`RIGHT`), `approachDistance`/`runLength`/`exitDistance`,
+  `createMarkers` (off by default). Full list in the script header.
+- No registry, no generated jumpers, no map markers by default — use the
+  Dynamic Drop Zone system instead for a managed, repeatable operation.
 
 ## Dynamic Drop Zone Operations (new system)
 

--- a/.claude/skills/mission-pack-config/references/paradrop.md
+++ b/.claude/skills/mission-pack-config/references/paradrop.md
@@ -102,16 +102,16 @@ the object's init field:
   default `"Drop Zone"`), `createMarkers` (**on by default** — the same
   AREA/STANDBY/GREEN/RED/POINT markers as the Dynamic Drop Zone system, so
   the mission maker sees a working drop zone immediately; pass `false` for
-  a clutter-free operation), `removeMarkersOnCleanup` (**off by default** —
-  the markers stay on the map even after the aircraft is gone, since a
-  mission maker who placed one generally wants it to stay). Full list in
-  the script header.
-- Set `removeMarkersOnCleanup: true` to opt into automatic marker removal
-  once the aircraft is destroyed/deleted, or once a `DESPAWN` lifecycle
-  run reaches its exit point — this still does **not** delete the aircraft
-  or its crew either way, since this entry point never created or owned
-  them in the first place (unlike `Waldo_fnc_ParadropCreateDropZone`,
-  whose `DESPAWN` does delete the aircraft it spawned).
+  a clutter-free operation), `keepMarkersOnCleanup` (**off by default** —
+  the markers are removed automatically once the aircraft is
+  destroyed/deleted, or once a `DESPAWN` lifecycle run reaches its exit
+  point, since a marker for a drop zone that's no longer active is just
+  stale). Full list in the script header.
+- Set `keepMarkersOnCleanup: true` to opt out and leave the markers on the
+  map instead — this still does **not** delete the aircraft or its crew
+  either way, since this entry point never created or owned them in the
+  first place (unlike `Waldo_fnc_ParadropCreateDropZone`, whose `DESPAWN`
+  does delete the aircraft it spawned).
 - No registry, no generated jumpers by default — use the Dynamic Drop Zone
   system instead for a managed, repeatable operation with those features.
 
@@ -130,7 +130,7 @@ private _drop = createHashMapFromArray [
     ["staticChuteClass", "NonSteerable_Parachute_F"],
     ["haloJumpEnabled", false], ["haloBackpackClass", "B_Parachute"],
     ["jumperCount", 0], ["autoDropPlayers", false], ["createMarkers", true],
-    ["removeMarkersOnCleanup", false]
+    ["keepMarkersOnCleanup", false]
 ];
 [_drop] call Waldo_fnc_ParadropCreateDropZone;
 ```
@@ -138,10 +138,12 @@ private _drop = createHashMapFromArray [
 `lifecycle`: `"LOOP"` (repeat wide circuit and re-run), `"RETAIN"`
 (loiter after one pass), or `"DESPAWN"` (delete the aircraft/crew after
 one pass — this system spawned and owns them, unlike `Waldo_fnc_
-ParadropQuickFlightSetup`, see above). Markers are only deleted alongside
-that automatic teardown if `removeMarkersOnCleanup` was set `true` at
-creation (default `false` — they're left on the map); an explicit
-`Waldo_fnc_ParadropRemoveDropZone` call always removes them regardless.
+ParadropQuickFlightSetup`, see above; a lost aircraft is cleaned up the
+same way). Markers are deleted alongside that automatic teardown by
+default too, since a marker for a drop zone that's no longer active is
+just stale — set `keepMarkersOnCleanup: true` at creation to leave them
+on the map instead. An explicit `Waldo_fnc_ParadropRemoveDropZone` call
+always removes them regardless.
 The route validates itself against the requested jump envelopes — static
 speed stays at least 40 km/h above the capped route speed, altitude stays
 inside every enabled jump window, and an unsupported door-animation

--- a/.claude/skills/mission-pack-config/references/paradrop.md
+++ b/.claude/skills/mission-pack-config/references/paradrop.md
@@ -85,11 +85,21 @@ the object's init field:
 - Waits (bounded, 30s) for a pilot to exist, so it's safe even if a
   separate init-field call (e.g. `Waldo_fnc_MoveInCargoPlane` on another
   object) assigns the crew — order between the two doesn't matter.
+- Requested (or configured-default) jump envelope values are clamped by
+  `Waldo_fnc_ParadropNormalizeJumpEnvelope` around the route's actual
+  altitude/speed before the jump action is installed — the fix for a jump
+  action that never becomes available because the route and the envelope
+  were set independently and can't both be satisfied at once.
+  `Waldo_fnc_ParadropCreateDropZone` normalizes the same way.
 - `options` HashMap: jump envelope overrides (default from
-  `airOperationsConfig.sqf`'s `WALDO_STATIC_*`/`WALDO_PARA_*`),
-  `lifecycle` (`LOOP` default/`RETAIN`/`DESPAWN`), `circuitDirection`
-  (`LEFT` default/`RIGHT`), `approachDistance`/`runLength`/`exitDistance`,
-  `createMarkers` (off by default). Full list in the script header.
+  `airOperationsConfig.sqf`'s `WALDO_STATIC_*`/`WALDO_PARA_*`, then
+  normalized as above), `lifecycle` (`LOOP` default/`RETAIN`/`DESPAWN`),
+  `circuitDirection` (`LEFT` default/`RIGHT`),
+  `approachDistance`/`runLength`/`exitDistance`, `name` (marker label,
+  default `"Drop Zone"`), `createMarkers` (**on by default** — the same
+  AREA/STANDBY/GREEN/RED/POINT markers as the Dynamic Drop Zone system, so
+  the mission maker sees a working drop zone immediately; pass `false` for
+  a clutter-free operation). Full list in the script header.
 - No registry, no generated jumpers, no map markers by default — use the
   Dynamic Drop Zone system instead for a managed, repeatable operation.
 

--- a/.claude/skills/mission-pack-config/references/paradrop.md
+++ b/.claude/skills/mission-pack-config/references/paradrop.md
@@ -145,9 +145,10 @@ just stale — set `keepMarkersOnCleanup: true` at creation to leave them
 on the map instead. An explicit `Waldo_fnc_ParadropRemoveDropZone` call
 always removes them regardless.
 The route validates itself against the requested jump envelopes — static
-speed stays at least 40 km/h above the capped route speed, altitude stays
-inside every enabled jump window, and an unsupported door-animation
-requirement disables itself automatically rather than silently breaking.
+speed stays at least 60 km/h above the capped route speed, altitude stays
+inside every enabled jump window with margin to absorb normal AI autopilot
+wander, and an unsupported door-animation requirement disables itself
+automatically rather than silently breaking.
 `requireOpenDoor` defaults `true` here too (aligned with the quick-setup
 entry point above) — safe because it self-disables for any airframe
 without a recognised door/ramp animation.

--- a/.claude/skills/mission-pack-config/references/paradrop.md
+++ b/.claude/skills/mission-pack-config/references/paradrop.md
@@ -81,7 +81,10 @@ the object's init field:
 - **Clears the aircraft's existing waypoints first.** A leftover Eden
   waypoint fighting the generated route is the #1 reason a hand-set-up
   paradrop plane misbehaves — don't call this on an aircraft whose manual
-  waypoints the mission maker wants to keep.
+  waypoints the mission maker wants to keep. If the pilot's group has other
+  units besides this aircraft's crew (e.g. a squad leader who's also the
+  pilot), the crew is automatically moved into a dedicated fresh group first
+  so those other units never lose their own waypoints.
 - Waits (bounded, 30s) for a pilot to exist, so it's safe even if a
   separate init-field call (e.g. `Waldo_fnc_MoveInCargoPlane` on another
   object) assigns the crew — order between the two doesn't matter.
@@ -100,8 +103,14 @@ the object's init field:
   AREA/STANDBY/GREEN/RED/POINT markers as the Dynamic Drop Zone system, so
   the mission maker sees a working drop zone immediately; pass `false` for
   a clutter-free operation). Full list in the script header.
-- No registry, no generated jumpers, no map markers by default — use the
-  Dynamic Drop Zone system instead for a managed, repeatable operation.
+- Markers are removed automatically once the aircraft is destroyed/deleted,
+  or once a `DESPAWN` lifecycle run reaches its exit point — this does
+  **not** delete the aircraft or its crew, since this entry point never
+  created or owned them in the first place (unlike `Waldo_fnc_
+  ParadropCreateDropZone`, whose `DESPAWN` does delete the aircraft it
+  spawned).
+- No registry, no generated jumpers by default — use the Dynamic Drop Zone
+  system instead for a managed, repeatable operation with those features.
 
 ## Dynamic Drop Zone Operations (new system)
 
@@ -122,12 +131,17 @@ private _drop = createHashMapFromArray [
 [_drop] call Waldo_fnc_ParadropCreateDropZone;
 ```
 
-`lifecycle`: `"LOOP"` (repeat wide circuit and re-run), `"SINGLE_RETAIN"`
-(loiter after one pass), or `"SINGLE_DESPAWN"` (clean up after one pass).
+`lifecycle`: `"LOOP"` (repeat wide circuit and re-run), `"RETAIN"`
+(loiter after one pass), or `"DESPAWN"` (delete the aircraft/crew/markers
+after one pass — this system spawned and owns them, unlike
+`Waldo_fnc_ParadropQuickFlightSetup`, see above).
 The route validates itself against the requested jump envelopes — static
 speed stays at least 40 km/h above the capped route speed, altitude stays
 inside every enabled jump window, and an unsupported door-animation
 requirement disables itself automatically rather than silently breaking.
+`requireOpenDoor` defaults `true` here too (aligned with the quick-setup
+entry point above) — safe because it self-disables for any airframe
+without a recognised door/ramp animation.
 
 ```sqf
 [dzId, playerOrGroup] call Waldo_fnc_ParadropEmbark;         // move players into the aircraft

--- a/.claude/skills/mission-pack-config/references/paradrop.md
+++ b/.claude/skills/mission-pack-config/references/paradrop.md
@@ -102,13 +102,16 @@ the object's init field:
   default `"Drop Zone"`), `createMarkers` (**on by default** — the same
   AREA/STANDBY/GREEN/RED/POINT markers as the Dynamic Drop Zone system, so
   the mission maker sees a working drop zone immediately; pass `false` for
-  a clutter-free operation). Full list in the script header.
-- Markers are removed automatically once the aircraft is destroyed/deleted,
-  or once a `DESPAWN` lifecycle run reaches its exit point — this does
-  **not** delete the aircraft or its crew, since this entry point never
-  created or owned them in the first place (unlike `Waldo_fnc_
-  ParadropCreateDropZone`, whose `DESPAWN` does delete the aircraft it
-  spawned).
+  a clutter-free operation), `removeMarkersOnCleanup` (**off by default** —
+  the markers stay on the map even after the aircraft is gone, since a
+  mission maker who placed one generally wants it to stay). Full list in
+  the script header.
+- Set `removeMarkersOnCleanup: true` to opt into automatic marker removal
+  once the aircraft is destroyed/deleted, or once a `DESPAWN` lifecycle
+  run reaches its exit point — this still does **not** delete the aircraft
+  or its crew either way, since this entry point never created or owned
+  them in the first place (unlike `Waldo_fnc_ParadropCreateDropZone`,
+  whose `DESPAWN` does delete the aircraft it spawned).
 - No registry, no generated jumpers by default — use the Dynamic Drop Zone
   system instead for a managed, repeatable operation with those features.
 
@@ -126,15 +129,19 @@ private _drop = createHashMapFromArray [
     ["staticMaximumAltitude", 350], ["staticMaximumSpeed", 310],
     ["staticChuteClass", "NonSteerable_Parachute_F"],
     ["haloJumpEnabled", false], ["haloBackpackClass", "B_Parachute"],
-    ["jumperCount", 0], ["autoDropPlayers", false], ["createMarkers", true]
+    ["jumperCount", 0], ["autoDropPlayers", false], ["createMarkers", true],
+    ["removeMarkersOnCleanup", false]
 ];
 [_drop] call Waldo_fnc_ParadropCreateDropZone;
 ```
 
 `lifecycle`: `"LOOP"` (repeat wide circuit and re-run), `"RETAIN"`
-(loiter after one pass), or `"DESPAWN"` (delete the aircraft/crew/markers
-after one pass — this system spawned and owns them, unlike
-`Waldo_fnc_ParadropQuickFlightSetup`, see above).
+(loiter after one pass), or `"DESPAWN"` (delete the aircraft/crew after
+one pass — this system spawned and owns them, unlike `Waldo_fnc_
+ParadropQuickFlightSetup`, see above). Markers are only deleted alongside
+that automatic teardown if `removeMarkersOnCleanup` was set `true` at
+creation (default `false` — they're left on the map); an explicit
+`Waldo_fnc_ParadropRemoveDropZone` call always removes them regardless.
 The route validates itself against the requested jump envelopes — static
 speed stays at least 40 km/h above the capped route speed, altitude stays
 inside every enabled jump window, and an unsupported door-animation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,16 +241,22 @@ drop point, plus the configured jump action — without the full Dynamic Drop Zo
 
 It clears the aircraft's existing waypoints before adding the generated route — leftover Eden
 waypoints fighting a scripted route is the single most common reason a hand-wired paradrop plane
-was unreliable. Waits (bounded, 30s) for a pilot if the aircraft's crew hasn't spawned in yet, so it
+was unreliable. If the pilot's group has other units besides this aircraft's crew, the crew is
+automatically isolated into a dedicated fresh group first so those other units never lose their own
+waypoints. Waits (bounded, 30s) for a pilot if the aircraft's crew hasn't spawned in yet, so it
 is safe to call from an object's own init field even when another init field (e.g.
 `Waldo_fnc_MoveInCargoPlane`) assigns that pilot. Before installing the jump action, the requested
-static-line/HALO envelope is run through `Waldo_fnc_ParadropNormalizeJumpEnvelope`, which clamps it
-around the route's actual altitude/speed — a jump action gated on altitude/speed thresholds the
-plane's own route can never satisfy is the concrete "jump action never becomes available" failure
-this closes; the same normalize call is shared by `ParadropCreateDropZone` below. `createMarkers`
-defaults to `true` (AREA/STANDBY/GREEN/RED/POINT markers, same layout as `ParadropCreateDropZone`)
-so a mission maker sees a working drop zone immediately — pass `false` for a map-clutter-free
-operation. See the script header for the full `options` HashMap (jump envelope overrides,
+static-line/HALO envelope is run through `Waldo_fnc_ParadropNormalizeJumpEnvelope`, using the same
+clamped altitude/speed `Waldo_fnc_ParadropBuildFlightRoute` actually flew (not the raw input) —
+a jump action gated on altitude/speed thresholds the plane's own route can never satisfy is the
+concrete "jump action never becomes available" failure this closes; `ParadropCreateDropZone` below
+normalizes off the same route-returned basis. `createMarkers` defaults to `true`
+(AREA/STANDBY/GREEN/RED/POINT markers, same layout as `ParadropCreateDropZone`) so a mission maker
+sees a working drop zone immediately — pass `false` for a map-clutter-free operation. Markers are
+removed automatically on aircraft death/deletion or once a `DESPAWN` lifecycle run reaches its exit
+point; this never deletes the aircraft or its crew, since this entry point never owns their
+lifecycle (unlike `ParadropCreateDropZone`, whose `DESPAWN` does delete the aircraft it spawned).
+See the script header for the full `options` HashMap (jump envelope overrides,
 `lifecycle` LOOP/RETAIN/DESPAWN, `circuitDirection`, `createMarkers`, `name`).
 
 The exact same route logic (`Waldo_fnc_ParadropBuildFlightRoute`) powers the fuller **Dynamic Drop

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,13 +253,12 @@ concrete "jump action never becomes available" failure this closes; `ParadropCre
 normalizes off the same route-returned basis. `createMarkers` defaults to `true`
 (AREA/STANDBY/GREEN/RED/POINT markers, same layout as `ParadropCreateDropZone`) so a mission maker
 sees a working drop zone immediately — pass `false` for a map-clutter-free operation. Markers are
-left in place by default even after the aircraft is gone; set `removeMarkersOnCleanup` to `true` to
-opt into automatic removal on aircraft death/deletion or once a `DESPAWN` lifecycle run reaches its
-exit point. Neither the default nor the opt-in ever deletes the aircraft or its crew, since this
-entry point never owns their lifecycle (unlike `ParadropCreateDropZone`, whose `DESPAWN` does delete
-the aircraft it spawned). See the script header for the full `options` HashMap (jump envelope
-overrides, `lifecycle` LOOP/RETAIN/DESPAWN, `circuitDirection`, `createMarkers`,
-`removeMarkersOnCleanup`, `name`).
+removed automatically on aircraft death/deletion or once a `DESPAWN` lifecycle run reaches its exit
+point; set `keepMarkersOnCleanup` to `true` to opt out and leave them on the map instead. Neither
+this nor the opt-out ever deletes the aircraft or its crew, since this entry point never owns their
+lifecycle (unlike `ParadropCreateDropZone`, whose `DESPAWN` does delete the aircraft it spawned). See
+the script header for the full `options` HashMap (jump envelope overrides, `lifecycle`
+LOOP/RETAIN/DESPAWN, `circuitDirection`, `createMarkers`, `keepMarkersOnCleanup`, `name`).
 
 The exact same route logic (`Waldo_fnc_ParadropBuildFlightRoute`) powers the fuller **Dynamic Drop
 Zone Operations** system (`Waldo_fnc_ParadropCreateDropZone`, the ZEN "Dynamic Paradrop" module) —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,8 +243,15 @@ It clears the aircraft's existing waypoints before adding the generated route �
 waypoints fighting a scripted route is the single most common reason a hand-wired paradrop plane
 was unreliable. Waits (bounded, 30s) for a pilot if the aircraft's crew hasn't spawned in yet, so it
 is safe to call from an object's own init field even when another init field (e.g.
-`Waldo_fnc_MoveInCargoPlane`) assigns that pilot. See the script header for the full `options`
-HashMap (jump envelope overrides, `lifecycle` LOOP/RETAIN/DESPAWN, `circuitDirection`, `createMarkers`).
+`Waldo_fnc_MoveInCargoPlane`) assigns that pilot. Before installing the jump action, the requested
+static-line/HALO envelope is run through `Waldo_fnc_ParadropNormalizeJumpEnvelope`, which clamps it
+around the route's actual altitude/speed — a jump action gated on altitude/speed thresholds the
+plane's own route can never satisfy is the concrete "jump action never becomes available" failure
+this closes; the same normalize call is shared by `ParadropCreateDropZone` below. `createMarkers`
+defaults to `true` (AREA/STANDBY/GREEN/RED/POINT markers, same layout as `ParadropCreateDropZone`)
+so a mission maker sees a working drop zone immediately — pass `false` for a map-clutter-free
+operation. See the script header for the full `options` HashMap (jump envelope overrides,
+`lifecycle` LOOP/RETAIN/DESPAWN, `circuitDirection`, `createMarkers`, `name`).
 
 The exact same route logic (`Waldo_fnc_ParadropBuildFlightRoute`) powers the fuller **Dynamic Drop
 Zone Operations** system (`Waldo_fnc_ParadropCreateDropZone`, the ZEN "Dynamic Paradrop" module) —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,11 +253,13 @@ concrete "jump action never becomes available" failure this closes; `ParadropCre
 normalizes off the same route-returned basis. `createMarkers` defaults to `true`
 (AREA/STANDBY/GREEN/RED/POINT markers, same layout as `ParadropCreateDropZone`) so a mission maker
 sees a working drop zone immediately — pass `false` for a map-clutter-free operation. Markers are
-removed automatically on aircraft death/deletion or once a `DESPAWN` lifecycle run reaches its exit
-point; this never deletes the aircraft or its crew, since this entry point never owns their
-lifecycle (unlike `ParadropCreateDropZone`, whose `DESPAWN` does delete the aircraft it spawned).
-See the script header for the full `options` HashMap (jump envelope overrides,
-`lifecycle` LOOP/RETAIN/DESPAWN, `circuitDirection`, `createMarkers`, `name`).
+left in place by default even after the aircraft is gone; set `removeMarkersOnCleanup` to `true` to
+opt into automatic removal on aircraft death/deletion or once a `DESPAWN` lifecycle run reaches its
+exit point. Neither the default nor the opt-in ever deletes the aircraft or its crew, since this
+entry point never owns their lifecycle (unlike `ParadropCreateDropZone`, whose `DESPAWN` does delete
+the aircraft it spawned). See the script header for the full `options` HashMap (jump envelope
+overrides, `lifecycle` LOOP/RETAIN/DESPAWN, `circuitDirection`, `createMarkers`,
+`removeMarkersOnCleanup`, `name`).
 
 The exact same route logic (`Waldo_fnc_ParadropBuildFlightRoute`) powers the fuller **Dynamic Drop
 Zone Operations** system (`Waldo_fnc_ParadropCreateDropZone`, the ZEN "Dynamic Paradrop" module) —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,22 +209,48 @@ private _RadioSetups = [
 
 Group names must match exactly what is set in Eden Editor. Channel numbers reference the position in the `Waldo_ACRE2Setup_LRChannels_BLUFOR/OPFOR/IND/CIV` arrays (1-indexed). AN/PRC-343 short-range radios are assigned automatically based on squad numerical designations. CEOI auto-populates in the map screen.
 
-### Paradrop Configuration (`initServer.sqf`)
+### Paradrop Configuration (`MissionConfig\airOperationsConfig.sqf`)
 
-Most "Plane"-class assets automatically get HALO/static-line actions. Override thresholds here:
+Most "Plane"-class assets automatically get HALO/static-line actions. Override the shared envelope in `MissionConfig\airOperationsConfig.sqf` (published as `true`/broadcast SERVER entries — do not paste these as raw `setVariable` calls into an init file, the loader owns them):
+
 ```sqf
-missionNamespace setVariable ["WALDO_STATIC_MINALTITUDE", 180, true];  // metres
-missionNamespace setVariable ["WALDO_STATIC_MAXALTITUDE", 350, true];
-missionNamespace setVariable ["WALDO_STATIC_MAXSPEED", 310, true];     // km/h
-missionNamespace setVariable ["WALDO_STATIC_STATICCHUTE", "rhs_d6_Parachute", true];
-missionNamespace setVariable ["WALDO_PARA_HALOALTITUDE", 1000, true];
-missionNamespace setVariable ["WALDO_PARA_HALOCHUTE", "B_Parachute", true];
+["WALDO_STATIC_MINALTITUDE", 180],  // metres
+["WALDO_STATIC_MAXALTITUDE", 350],
+["WALDO_STATIC_MAXSPEED", 310],     // km/h
+["WALDO_STATIC_STATICCHUTE", "rhs_d6_Parachute"],
+["WALDO_PARA_HALOALTITUDE", 1000],
+["WALDO_PARA_HALOCHUTE", "B_Parachute"]
 ```
 
 For custom aircraft that don't auto-detect, add in the object's init field in Eden Editor:
 ```sqf
 [this] call Waldo_fnc_VehicleJumpSetup;
 ```
+This only adds the jump action — it does not fly the plane anywhere.
+
+#### Reliable AI flight — quick setup (`Waldo_fnc_ParadropQuickFlightSetup`)
+
+For a mission maker's own placed-and-crewed aircraft, one call from the object's init field gives it
+a reliable AI-flown route (standby → green line → red line → exit, looping by default) toward a
+drop point, plus the configured jump action — without the full Dynamic Drop Zone registry below:
+
+```sqf
+[this, "dz1"] call Waldo_fnc_ParadropQuickFlightSetup;
+// [aircraft, target(marker name/position/object), direction(-1 = auto), altitude, maxSpeed, options]
+```
+
+It clears the aircraft's existing waypoints before adding the generated route — leftover Eden
+waypoints fighting a scripted route is the single most common reason a hand-wired paradrop plane
+was unreliable. Waits (bounded, 30s) for a pilot if the aircraft's crew hasn't spawned in yet, so it
+is safe to call from an object's own init field even when another init field (e.g.
+`Waldo_fnc_MoveInCargoPlane`) assigns that pilot. See the script header for the full `options`
+HashMap (jump envelope overrides, `lifecycle` LOOP/RETAIN/DESPAWN, `circuitDirection`, `createMarkers`).
+
+The exact same route logic (`Waldo_fnc_ParadropBuildFlightRoute`) powers the fuller **Dynamic Drop
+Zone Operations** system (`Waldo_fnc_ParadropCreateDropZone`, the ZEN "Dynamic Paradrop" module) —
+which additionally spawns/crews the aircraft itself, manages a named registry, optional generated
+jumpers, auto-drop-on-approach and map markers. Use the ZEN module or `ParadropCreateDropZone` for a
+managed multi-use operation; use `ParadropQuickFlightSetup` for a mission maker's own placed plane.
 
 ### Radio Jamming — ACRE2 / TFAR (`init.sqf`)
 

--- a/MissionScripts/Paradrop/paradropBuildFlightRoute.sqf
+++ b/MissionScripts/Paradrop/paradropBuildFlightRoute.sqf
@@ -35,7 +35,11 @@
  *
  * Return Value:
  * HashMap - key positions for the caller (standby, green, centre, red, spawn, exit, hold), each a
- * 3D position with Z set to the route altitude. Empty HashMap when the aircraft/group is invalid.
+ * 3D position with Z set to the route altitude, plus the actual clamped "altitude" and "maxSpeed"
+ * this route was built with (clamping happens inside this function - callers that need to reason
+ * about the aircraft's real flight envelope, e.g. to normalize a jump envelope against it, must read
+ * these back rather than reusing their own unclamped input values). Empty HashMap when the
+ * aircraft/group is invalid.
  *
  * Example:
  * [_aircraft, _flightGroup, getMarkerPos "dz1", 45, 250, 220, 2500, 2500, 2500, "LOOP", "LEFT"]
@@ -121,5 +125,6 @@ if (_lifecycle == "RETAIN") then {
 
 createHashMapFromArray [
     ["standby", _standby], ["green", _green], ["centre", _centre], ["red", _red],
-    ["spawn", _spawn], ["exit", _exit], ["hold", _hold]
+    ["spawn", _spawn], ["exit", _exit], ["hold", _hold],
+    ["altitude", _altitude], ["maxSpeed", _maxSpeed]
 ]

--- a/MissionScripts/Paradrop/paradropBuildFlightRoute.sqf
+++ b/MissionScripts/Paradrop/paradropBuildFlightRoute.sqf
@@ -1,0 +1,125 @@
+/*
+ * Author: WaldoTheWarfighter
+ * Builds one reliable AI paradrop flight route (standby, green line, red line, exit) around an
+ * existing aircraft and flight group, and configures the group/aircraft to actually fly it cleanly.
+ *
+ * This is the exact route/behaviour logic proven by Waldo_fnc_ParadropCreateDropZone (Dynamic Drop
+ * Zone Operations), extracted so it can be shared by any caller instead of re-implemented per
+ * feature: getting an AI-flown paradrop aircraft to hold altitude, speed and a clean line to the
+ * drop point reliably is the hard part mission makers otherwise re-solve by hand with Eden
+ * waypoints. Both the ZEN-driven Dynamic Drop Zone system and the simpler
+ * Waldo_fnc_ParadropQuickFlightSetup entry point (for an aircraft a mission maker already placed
+ * and crewed in Eden) call this same function, so a route-quality fix here benefits both paths.
+ *
+ * The aircraft's current flight group has every existing waypoint deleted before the new route is
+ * added. This is deliberate: an Eden-placed aircraft's own default waypoints are the single most
+ * common reason a "should be simple" paradrop setup misbehaves - the new scripted route and any
+ * leftover manual waypoint silently fight each other for the AI's attention. Callers that want to
+ * keep their own waypoints should not call this function.
+ *
+ * Arguments:
+ * 0: aircraft <OBJECT> - must already exist, be crewed (a driver present) and be in the air or able
+ *    to become airborne; this function does not create, position or crew the aircraft.
+ * 1: flight group <GROUP> - the aircraft's pilot's group; waypoints are added to this group.
+ * 2: centre <ARRAY> - drop point position (2 or 3 element ATL-ish position; Z is normalised to
+ *    altitude below).
+ * 3: direction <NUMBER> - degrees; the aircraft approaches centre flying along this heading.
+ * 4: altitude <NUMBER> - route altitude AGL in metres (default 250, clamped 100-2000).
+ * 5: maximum speed <NUMBER> - km/h (default 220, clamped 80-500).
+ * 6: approach distance <NUMBER> - metres from standby to the spawn/rejoin point (default 2500).
+ * 7: run length <NUMBER> - metres of the green-to-red jump run (default 2500).
+ * 8: exit distance <NUMBER> - metres flown past the red line before turning off (default 2500).
+ * 9: lifecycle <STRING> - LOOP (fly a re-alignment circuit and repeat), RETAIN (loiter near exit
+ *    after one pass) or DESPAWN (fly off and stop; caller handles cleanup) (default LOOP).
+ * 10: circuit direction <STRING> - LEFT or RIGHT, which way the LOOP circuit turns (default LEFT).
+ *
+ * Return Value:
+ * HashMap - key positions for the caller (standby, green, centre, red, spawn, exit, hold), each a
+ * 3D position with Z set to the route altitude. Empty HashMap when the aircraft/group is invalid.
+ *
+ * Example:
+ * [_aircraft, _flightGroup, getMarkerPos "dz1", 45, 250, 220, 2500, 2500, 2500, "LOOP", "LEFT"]
+ *     call Waldo_fnc_ParadropBuildFlightRoute;
+ *
+ * Current callers: Waldo_fnc_ParadropCreateDropZone, Waldo_fnc_ParadropQuickFlightSetup.
+ */
+
+params [
+    ["_aircraft", objNull, [objNull]],
+    ["_flightGroup", grpNull, [grpNull]],
+    ["_centre", [], [[]]],
+    ["_direction", 0, [0]],
+    ["_altitude", 250, [0]],
+    ["_maxSpeed", 220, [0]],
+    ["_approach", 2500, [0]],
+    ["_runLength", 2500, [0]],
+    ["_exitDistance", 2500, [0]],
+    ["_lifecycle", "LOOP", [""]],
+    ["_circuitDirection", "LEFT", [""]]
+];
+if (!isServer || {isNull _aircraft} || {isNull _flightGroup} || {count _centre < 2}) exitWith {createHashMap};
+
+_direction = _direction mod 360;
+_altitude = (_altitude max 100) min 2000;
+_maxSpeed = (_maxSpeed max 80) min 500;
+_approach = (_approach max 800) min 10000;
+_runLength = (_runLength max 300) min 6000;
+_exitDistance = (_exitDistance max 800) min 10000;
+_lifecycle = toUpperANSI _lifecycle;
+if !(_lifecycle in ["LOOP", "RETAIN", "DESPAWN"]) then {_lifecycle = "LOOP"};
+_circuitDirection = toUpperANSI _circuitDirection;
+private _circuitTurn = if (_circuitDirection == "RIGHT") then {90} else {-90};
+
+private _standby = [_centre, _runLength * 0.65, _direction + 180] call BIS_fnc_relPos;
+private _green = [_centre, _runLength * 0.5, _direction + 180] call BIS_fnc_relPos;
+private _red = [_centre, _runLength * 0.5, _direction] call BIS_fnc_relPos;
+private _spawn = [_standby, _approach, _direction + 180] call BIS_fnc_relPos;
+private _exit = [_red, _exitDistance, _direction] call BIS_fnc_relPos;
+private _circuitWidth = ((_approach max _runLength) * 0.75) max 1200;
+private _crosswind = [_exit, _circuitWidth, _direction + _circuitTurn] call BIS_fnc_relPos;
+private _downwind = [_spawn, _circuitWidth, _direction + _circuitTurn] call BIS_fnc_relPos;
+private _rejoin = [_spawn, _approach * 0.6, _direction + 180] call BIS_fnc_relPos;
+private _hold = [_exit, 1800, _direction] call BIS_fnc_relPos;
+{_x set [2, _altitude]} forEach [_standby, _green, _centre, _red, _spawn, _exit, _crosswind, _downwind, _rejoin, _hold];
+
+{deleteWaypoint _x} forEach (reverse (waypoints _flightGroup));
+_flightGroup setBehaviourStrong "CARELESS";
+_flightGroup setCombatMode "BLUE";
+_flightGroup setSpeedMode "LIMITED";
+_aircraft flyInHeight [_altitude, true];
+_aircraft limitSpeed _maxSpeed;
+// limitSpeed is km/h, while forceSpeed is metres/second. Applying one raw value to both causes
+// extreme overspeed and an apparent lateral break at the drop zone - the exact failure mode that
+// made ad hoc paradrop aircraft setups unreliable before this route builder existed.
+_aircraft forceSpeed (_maxSpeed / 3.6);
+_aircraft engineOn true;
+
+private _addRouteWaypoint = {
+    params ["_position", ["_type", "MOVE"], ["_radius", 40]];
+    // A negative placement radius consumes ASL and creates an exact waypoint. Radius zero may be
+    // displaced by nearby terrain objects, which is unacceptable on a marked jump run.
+    private _waypoint = _flightGroup addWaypoint [AGLToASL _position, -1];
+    _waypoint setWaypointType _type;
+    _waypoint setWaypointBehaviour "CARELESS";
+    _waypoint setWaypointCombatMode "BLUE";
+    _waypoint setWaypointSpeed "LIMITED";
+    _waypoint setWaypointCompletionRadius _radius;
+    _waypoint
+};
+{
+    [_x, "MOVE", if (_forEachIndex in [1, 2, 3]) then {30} else {100}] call _addRouteWaypoint;
+} forEach [_standby, _green, _centre, _red, _exit];
+if (_lifecycle == "LOOP") then {
+    {[_x, "MOVE", 180] call _addRouteWaypoint} forEach [_crosswind, _downwind, _rejoin];
+    [_spawn, "CYCLE", 120] call _addRouteWaypoint;
+};
+if (_lifecycle == "RETAIN") then {
+    private _loiter = [_hold, "LOITER", 250] call _addRouteWaypoint;
+    _loiter setWaypointLoiterRadius 900;
+    _loiter setWaypointLoiterType "CIRCLE_L";
+};
+
+createHashMapFromArray [
+    ["standby", _standby], ["green", _green], ["centre", _centre], ["red", _red],
+    ["spawn", _spawn], ["exit", _exit], ["hold", _hold]
+]

--- a/MissionScripts/Paradrop/paradropCreateDropZone.sqf
+++ b/MissionScripts/Paradrop/paradropCreateDropZone.sqf
@@ -14,10 +14,12 @@
  * 0: configuration <HASHMAP> - id, name, centre, direction, side, aircraftClass, altitude,
  *    maximumSpeed, approachDistance, runLength, exitDistance, jumperCount, jumpInterval,
  *    lifecycle, circuitDirection, static/halo jump settings, jumperClass, createJumpers,
- *    autoDropPlayers, automaticJumpMode, createMarkers and removeMarkersOnCleanup (default false -
- *    automatic teardown on a DESPAWN pass or aircraft loss deletes the spawned aircraft/crew but
- *    leaves the markers in place unless this is set true; an explicit Waldo_fnc_ParadropRemoveDropZone
- *    call, e.g. the ZEN "Remove Operation" module, always removes markers regardless of this option).
+ *    autoDropPlayers, automaticJumpMode, createMarkers and keepMarkersOnCleanup (default false).
+ *    Automatic teardown always deletes the spawned aircraft/crew, on either aircraft loss or a
+ *    DESPAWN pass completing normally, and by default removes the markers along with them - a marker
+ *    for a drop zone that's no longer active is just stale. Set keepMarkersOnCleanup true to leave
+ *    the markers on the map instead. An explicit Waldo_fnc_ParadropRemoveDropZone call, e.g. the ZEN
+ *    "Remove Operation" module, always removes markers regardless of this option.
  * 1: requester <OBJECT> (default objNull) - curator used to authorize remote requests.
  *
  * Return Value:
@@ -220,7 +222,7 @@ missionNamespace setVariable ["Waldo_Paradrop_PublicDropZones", _public, true];
     private _green = _state get "green";
     private _red = _state get "red";
     private _deadline = serverTime + ((_config getOrDefault ["operationTimeout", 900]) max 60);
-    private _removeMarkersOnCleanup = _config getOrDefault ["removeMarkersOnCleanup", false];
+    private _deleteMarkersOnCleanup = !(_config getOrDefault ["keepMarkersOnCleanup", false]);
     waitUntil {sleep 0.25; isNull _aircraft || {!alive _aircraft} || {_aircraft distance2D _green < 180} || {serverTime >= _deadline}};
     if (!isNull _aircraft && {alive _aircraft} && {serverTime < _deadline}) then {
         private _dropUnits = +(_state getOrDefault ["jumpers", []]);
@@ -247,9 +249,12 @@ missionNamespace setVariable ["Waldo_Paradrop_PublicDropZones", _public, true];
     };
     waitUntil {sleep 1; isNull _aircraft || {!alive _aircraft} || {_aircraft distance2D (_state get "red") < 180} || {serverTime >= _deadline}};
     waitUntil {sleep 1; isNull _aircraft || {!alive _aircraft} || {_aircraft distance2D (_state getOrDefault ["exit", _state get "red"]) < 220} || {serverTime >= _deadline}};
-    if (isNull _aircraft || {!alive _aircraft}) exitWith {[_id, true, objNull, false, _removeMarkersOnCleanup] call Waldo_fnc_ParadropRemoveDropZone};
+    // Automatic teardown removes its markers by default on either trigger - a marker for a drop zone
+    // that's no longer active is just stale - unless the mission maker opted out with
+    // keepMarkersOnCleanup.
+    if (isNull _aircraft || {!alive _aircraft}) exitWith {[_id, true, objNull, false, _deleteMarkersOnCleanup] call Waldo_fnc_ParadropRemoveDropZone};
     if ((_state getOrDefault ["lifecycle", "LOOP"]) == "DESPAWN") then {
-        [_id, true, objNull, false, _removeMarkersOnCleanup] call Waldo_fnc_ParadropRemoveDropZone;
+        [_id, true, objNull, false, _deleteMarkersOnCleanup] call Waldo_fnc_ParadropRemoveDropZone;
     };
 };
 diag_log format ["[WMP PARADROP] Created id=%1 name=%2 side=%3 airframe=%4 pilot=%5 optionalJumpers=%6 lifecycle=%7 markers=%8", _id, _name, _side, _class, _pilot, count _jumpers, _lifecycle, count _markers];

--- a/MissionScripts/Paradrop/paradropCreateDropZone.sqf
+++ b/MissionScripts/Paradrop/paradropCreateDropZone.sqf
@@ -14,7 +14,10 @@
  * 0: configuration <HASHMAP> - id, name, centre, direction, side, aircraftClass, altitude,
  *    maximumSpeed, approachDistance, runLength, exitDistance, jumperCount, jumpInterval,
  *    lifecycle, circuitDirection, static/halo jump settings, jumperClass, createJumpers,
- *    autoDropPlayers, automaticJumpMode and createMarkers.
+ *    autoDropPlayers, automaticJumpMode, createMarkers and removeMarkersOnCleanup (default false -
+ *    automatic teardown on a DESPAWN pass or aircraft loss deletes the spawned aircraft/crew but
+ *    leaves the markers in place unless this is set true; an explicit Waldo_fnc_ParadropRemoveDropZone
+ *    call, e.g. the ZEN "Remove Operation" module, always removes markers regardless of this option).
  * 1: requester <OBJECT> (default objNull) - curator used to authorize remote requests.
  *
  * Return Value:
@@ -217,6 +220,7 @@ missionNamespace setVariable ["Waldo_Paradrop_PublicDropZones", _public, true];
     private _green = _state get "green";
     private _red = _state get "red";
     private _deadline = serverTime + ((_config getOrDefault ["operationTimeout", 900]) max 60);
+    private _removeMarkersOnCleanup = _config getOrDefault ["removeMarkersOnCleanup", false];
     waitUntil {sleep 0.25; isNull _aircraft || {!alive _aircraft} || {_aircraft distance2D _green < 180} || {serverTime >= _deadline}};
     if (!isNull _aircraft && {alive _aircraft} && {serverTime < _deadline}) then {
         private _dropUnits = +(_state getOrDefault ["jumpers", []]);
@@ -243,9 +247,9 @@ missionNamespace setVariable ["Waldo_Paradrop_PublicDropZones", _public, true];
     };
     waitUntil {sleep 1; isNull _aircraft || {!alive _aircraft} || {_aircraft distance2D (_state get "red") < 180} || {serverTime >= _deadline}};
     waitUntil {sleep 1; isNull _aircraft || {!alive _aircraft} || {_aircraft distance2D (_state getOrDefault ["exit", _state get "red"]) < 220} || {serverTime >= _deadline}};
-    if (isNull _aircraft || {!alive _aircraft}) exitWith {[_id, true, objNull, false] call Waldo_fnc_ParadropRemoveDropZone};
+    if (isNull _aircraft || {!alive _aircraft}) exitWith {[_id, true, objNull, false, _removeMarkersOnCleanup] call Waldo_fnc_ParadropRemoveDropZone};
     if ((_state getOrDefault ["lifecycle", "LOOP"]) == "DESPAWN") then {
-        [_id, true, objNull, false] call Waldo_fnc_ParadropRemoveDropZone;
+        [_id, true, objNull, false, _removeMarkersOnCleanup] call Waldo_fnc_ParadropRemoveDropZone;
     };
 };
 diag_log format ["[WMP PARADROP] Created id=%1 name=%2 side=%3 airframe=%4 pilot=%5 optionalJumpers=%6 lifecycle=%7 markers=%8", _id, _name, _side, _class, _pilot, count _jumpers, _lifecycle, count _markers];

--- a/MissionScripts/Paradrop/paradropCreateDropZone.sqf
+++ b/MissionScripts/Paradrop/paradropCreateDropZone.sqf
@@ -57,33 +57,23 @@ private _altitude = ((_config getOrDefault ["altitude", 250]) max 100) min 2000;
 private _maximumSpeed = ((_config getOrDefault ["maximumSpeed", 220]) max 80) min 500;
 private _staticEnabled = _config getOrDefault ["staticJumpEnabled", true];
 private _haloEnabled = _config getOrDefault ["haloJumpEnabled", false];
-private _envelope = [
-    _altitude, _maximumSpeed,
-    _config getOrDefault ["staticMinimumAltitude", 180], _config getOrDefault ["staticMaximumAltitude", 350],
-    _config getOrDefault ["staticMaximumSpeed", 310], _config getOrDefault ["haloMinimumAltitude", 1000]
-] call Waldo_fnc_ParadropNormalizeJumpEnvelope;
-private _staticMinimum = _envelope get "staticMinimumAltitude";
-private _staticMaximum = _envelope get "staticMaximumAltitude";
-private _staticMaximumSpeed = _envelope get "staticMaximumSpeed";
-private _haloMinimum = _envelope get "haloMinimumAltitude";
 private _automaticMode = toUpperANSI (_config getOrDefault ["automaticJumpMode", "STATIC"]);
 if (_config getOrDefault ["autoDropPlayers", false]) then {
     if (_automaticMode == "STATIC" && {!_staticEnabled}) then {_automaticMode = if (_haloEnabled) then {"HALO"} else {"NONE"}};
     if (_automaticMode == "HALO" && {!_haloEnabled}) then {_automaticMode = if (_staticEnabled) then {"STATIC"} else {"NONE"}};
     if (_automaticMode == "NONE") then {_config set ["autoDropPlayers", false]};
 };
-private _requireDoor = _config getOrDefault ["requireOpenDoor", false];
+// requireOpenDoor defaults true here to match Waldo_fnc_ParadropQuickFlightSetup - the check is a
+// no-op anyway for any airframe without a recognised door/ramp animation, so this only changes
+// behaviour for airframes that actually have one.
+private _requireDoor = _config getOrDefault ["requireOpenDoor", true];
 if (_requireDoor) then {
     private _animationSources = configFile >> "CfgVehicles" >> _class >> "AnimationSources";
     private _recognizedDoorSources = ["ramp_bottom", "door_2_1", "door_2_2", "jumpdoor_1", "jumpdoor_2", "back_ramp_switch", "back_ramp_half_switch", "RearDoors", "Door_1_source", "ramp_anim"];
     if (_recognizedDoorSources findIf {isClass (_animationSources >> _x)} < 0) then {_requireDoor = false};
 };
 _config set ["staticJumpEnabled", _staticEnabled];
-_config set ["staticMinimumAltitude", _staticMinimum];
-_config set ["staticMaximumAltitude", _staticMaximum];
-_config set ["staticMaximumSpeed", _staticMaximumSpeed];
 _config set ["haloJumpEnabled", _haloEnabled];
-_config set ["haloMinimumAltitude", _haloMinimum];
 _config set ["automaticJumpMode", _automaticMode];
 _config set ["requireOpenDoor", _requireDoor];
 private _approach = ((_config getOrDefault ["approachDistance", 2500]) max 800) min 10000;
@@ -133,6 +123,25 @@ if (_route isEqualTo createHashMap) exitWith {
 private _green = _route get "green";
 private _red = _route get "red";
 private _exit = _route get "exit";
+
+// Normalized against the route's own returned altitude/speed (not the pre-clamp local variables
+// above) so this and Waldo_fnc_ParadropQuickFlightSetup can never drift onto a different basis than
+// what the aircraft is actually flying.
+private _routeAltitude = _route get "altitude";
+private _routeMaxSpeed = _route get "maxSpeed";
+private _envelope = [
+    _routeAltitude, _routeMaxSpeed,
+    _config getOrDefault ["staticMinimumAltitude", 180], _config getOrDefault ["staticMaximumAltitude", 350],
+    _config getOrDefault ["staticMaximumSpeed", 310], _config getOrDefault ["haloMinimumAltitude", 1000]
+] call Waldo_fnc_ParadropNormalizeJumpEnvelope;
+private _staticMinimum = _envelope get "staticMinimumAltitude";
+private _staticMaximum = _envelope get "staticMaximumAltitude";
+private _staticMaximumSpeed = _envelope get "staticMaximumSpeed";
+private _haloMinimum = _envelope get "haloMinimumAltitude";
+_config set ["staticMinimumAltitude", _staticMinimum];
+_config set ["staticMaximumAltitude", _staticMaximum];
+_config set ["staticMaximumSpeed", _staticMaximumSpeed];
+_config set ["haloMinimumAltitude", _haloMinimum];
 
 // One object-keyed replay configures current clients and JIP clients with both selected jump
 // systems. The setup function reconciles repeated configuration rather than duplicating actions.
@@ -240,5 +249,5 @@ missionNamespace setVariable ["Waldo_Paradrop_PublicDropZones", _public, true];
     };
 };
 diag_log format ["[WMP PARADROP] Created id=%1 name=%2 side=%3 airframe=%4 pilot=%5 optionalJumpers=%6 lifecycle=%7 markers=%8", _id, _name, _side, _class, _pilot, count _jumpers, _lifecycle, count _markers];
-[format ["%1 created for players. Route %2m AGL / %3 km/h; static envelope %4-%5m / <=%6 km/h; HALO floor %7m. Use Paradrop - Embark Players to board.", _name, round _altitude, round _maximumSpeed, round _staticMinimum, round _staticMaximum, round _staticMaximumSpeed, round _haloMinimum], "SUCCESS"] call _notifyRequester;
+[format ["%1 created for players. Route %2m AGL / %3 km/h; static envelope %4-%5m / <=%6 km/h; HALO floor %7m. Use Paradrop - Embark Players to board.", _name, round _routeAltitude, round _routeMaxSpeed, round _staticMinimum, round _staticMaximum, round _staticMaximumSpeed, round _haloMinimum], "SUCCESS"] call _notifyRequester;
 true

--- a/MissionScripts/Paradrop/paradropCreateDropZone.sqf
+++ b/MissionScripts/Paradrop/paradropCreateDropZone.sqf
@@ -57,10 +57,15 @@ private _altitude = ((_config getOrDefault ["altitude", 250]) max 100) min 2000;
 private _maximumSpeed = ((_config getOrDefault ["maximumSpeed", 220]) max 80) min 500;
 private _staticEnabled = _config getOrDefault ["staticJumpEnabled", true];
 private _haloEnabled = _config getOrDefault ["haloJumpEnabled", false];
-private _staticMinimum = ((_config getOrDefault ["staticMinimumAltitude", 180]) max 0) min ((_altitude - 25) max 0);
-private _staticMaximum = ((_config getOrDefault ["staticMaximumAltitude", 350]) max (_altitude + 75)) min 2500;
-private _staticMaximumSpeed = ((_config getOrDefault ["staticMaximumSpeed", 310]) max (_maximumSpeed + 40)) min 700;
-private _haloMinimum = ((_config getOrDefault ["haloMinimumAltitude", 1000]) max 0) min _altitude;
+private _envelope = [
+    _altitude, _maximumSpeed,
+    _config getOrDefault ["staticMinimumAltitude", 180], _config getOrDefault ["staticMaximumAltitude", 350],
+    _config getOrDefault ["staticMaximumSpeed", 310], _config getOrDefault ["haloMinimumAltitude", 1000]
+] call Waldo_fnc_ParadropNormalizeJumpEnvelope;
+private _staticMinimum = _envelope get "staticMinimumAltitude";
+private _staticMaximum = _envelope get "staticMaximumAltitude";
+private _staticMaximumSpeed = _envelope get "staticMaximumSpeed";
+private _haloMinimum = _envelope get "haloMinimumAltitude";
 private _automaticMode = toUpperANSI (_config getOrDefault ["automaticJumpMode", "STATIC"]);
 if (_config getOrDefault ["autoDropPlayers", false]) then {
     if (_automaticMode == "STATIC" && {!_staticEnabled}) then {_automaticMode = if (_haloEnabled) then {"HALO"} else {"NONE"}};

--- a/MissionScripts/Paradrop/paradropCreateDropZone.sqf
+++ b/MissionScripts/Paradrop/paradropCreateDropZone.sqf
@@ -84,21 +84,15 @@ _config set ["requireOpenDoor", _requireDoor];
 private _approach = ((_config getOrDefault ["approachDistance", 2500]) max 800) min 10000;
 private _runLength = ((_config getOrDefault ["runLength", 2500]) max 300) min 6000;
 private _exitDistance = ((_config getOrDefault ["exitDistance", 2500]) max 800) min 10000;
-private _standby = [_centre, _runLength * 0.65, _direction + 180] call BIS_fnc_relPos;
-private _green = [_centre, _runLength * 0.5, _direction + 180] call BIS_fnc_relPos;
-private _red = [_centre, _runLength * 0.5, _direction] call BIS_fnc_relPos;
-private _spawn = [_standby, _approach, _direction + 180] call BIS_fnc_relPos;
-private _exit = [_red, _exitDistance, _direction] call BIS_fnc_relPos;
 private _lifecycle = toUpperANSI (_config getOrDefault ["lifecycle", if (_config getOrDefault ["deleteAfterRun", false]) then {"DESPAWN"} else {"LOOP"}]);
 if !(_lifecycle in ["LOOP", "RETAIN", "DESPAWN"]) then {_lifecycle = "LOOP"};
 private _circuitDirection = toUpperANSI (_config getOrDefault ["circuitDirection", "LEFT"]);
-private _circuitTurn = if (_circuitDirection == "RIGHT") then {90} else {-90};
-private _circuitWidth = ((_approach max _runLength) * 0.75) max 1200;
-private _crosswind = [_exit, _circuitWidth, _direction + _circuitTurn] call BIS_fnc_relPos;
-private _downwind = [_spawn, _circuitWidth, _direction + _circuitTurn] call BIS_fnc_relPos;
-private _rejoin = [_spawn, _approach * 0.6, _direction + 180] call BIS_fnc_relPos;
-private _hold = [_exit, 1800, _direction] call BIS_fnc_relPos;
-{_x set [2, _altitude]} forEach [_standby, _green, _centre, _red, _spawn, _exit, _crosswind, _downwind, _rejoin, _hold];
+// Only the standby/spawn point is needed before the aircraft exists (to know where to create it).
+// Waldo_fnc_ParadropBuildFlightRoute derives the same point again once the aircraft is real, along
+// with the rest of the route (green/red/exit/etc) it hands back below.
+private _standby = [_centre, _runLength * 0.65, _direction + 180] call BIS_fnc_relPos;
+private _spawn = [_standby, _approach, _direction + 180] call BIS_fnc_relPos;
+_spawn set [2, _altitude];
 
 private _aircraft = createVehicle [_class, _spawn, [], 0, "FLY"];
 _aircraft setPosATL _spawn;
@@ -120,41 +114,20 @@ private _oldGroups = [];
 private _flightGroup = createGroup _side;
 [_pilot] joinSilent _flightGroup;
 {if (!isNull _x && {count units _x == 0}) then {deleteGroup _x}} forEach _oldGroups;
-_flightGroup setBehaviourStrong "CARELESS";
-_flightGroup setCombatMode "BLUE";
-_flightGroup setSpeedMode "LIMITED";
-_aircraft flyInHeight [_altitude, true];
-_aircraft limitSpeed _maximumSpeed;
-// limitSpeed is km/h, while forceSpeed is metres/second. Applying one raw value to both caused
-// extreme overspeed and the apparent lateral break at the drop zone.
-_aircraft forceSpeed (_maximumSpeed / 3.6);
-_aircraft engineOn true;
 _aircraft setVehicleLock "UNLOCKED";
 
-private _addRouteWaypoint = {
-    params ["_position", ["_type", "MOVE"], ["_radius", 40]];
-    // A negative placement radius consumes ASL and creates an exact waypoint. Radius zero may be
-    // displaced by nearby terrain objects, which is unacceptable on a marked jump run.
-    private _waypoint = _flightGroup addWaypoint [AGLToASL _position, -1];
-    _waypoint setWaypointType _type;
-    _waypoint setWaypointBehaviour "CARELESS";
-    _waypoint setWaypointCombatMode "BLUE";
-    _waypoint setWaypointSpeed "LIMITED";
-    _waypoint setWaypointCompletionRadius _radius;
-    _waypoint
+private _route = [
+    _aircraft, _flightGroup, _centre, _direction, _altitude, _maximumSpeed,
+    _approach, _runLength, _exitDistance, _lifecycle, _circuitDirection
+] call Waldo_fnc_ParadropBuildFlightRoute;
+if (_route isEqualTo createHashMap) exitWith {
+    deleteVehicle _aircraft; deleteGroup _flightGroup;
+    ["Creation failed: the flight route could not be built.", "ERROR"] call _notifyRequester;
+    false
 };
-{
-    [_x, "MOVE", if (_forEachIndex in [1, 2, 3]) then {30} else {100}] call _addRouteWaypoint;
-} forEach [_standby, _green, _centre, _red, _exit];
-if (_lifecycle == "LOOP") then {
-    {[_x, "MOVE", 180] call _addRouteWaypoint} forEach [_crosswind, _downwind, _rejoin];
-    [_spawn, "CYCLE", 120] call _addRouteWaypoint;
-};
-if (_lifecycle == "RETAIN") then {
-    private _loiter = [_hold, "LOITER", 250] call _addRouteWaypoint;
-    _loiter setWaypointLoiterRadius 900;
-    _loiter setWaypointLoiterType "CIRCLE_L";
-};
+private _green = _route get "green";
+private _red = _route get "red";
+private _exit = _route get "exit";
 
 // One object-keyed replay configures current clients and JIP clients with both selected jump
 // systems. The setup function reconciles repeated configuration rather than duplicating actions.

--- a/MissionScripts/Paradrop/paradropDropZoneZen.sqf
+++ b/MissionScripts/Paradrop/paradropDropZoneZen.sqf
@@ -167,7 +167,7 @@ private _defaultName = format ["DZ %1", round (serverTime mod 10000)];
         ["SLIDER", ["Optional generated AI jumpers", "AI cargo created for this operation. Default zero keeps the aircraft for players."], [0, 60, 0, 0]],
         ["SLIDER", ["Automatic jump interval", "Seconds between forced player or optional AI exits."], [0.5, 10, 2, 1]],
         ["CHECKBOX", ["Create map markers", "Creates DZ, standby, green, red and named point markers."], true],
-        ["CHECKBOX", ["Remove markers when the operation ends automatically", "Applies to an automatic DESPAWN pass or the aircraft being lost - the markers are left in place by default. Explicitly using Paradrop - Remove Operation always removes markers regardless of this setting."], false]
+        ["CHECKBOX", ["Keep markers when the operation ends automatically", "Applies to an automatic DESPAWN pass or the aircraft being lost - the markers are removed along with the operation by default. Explicitly using Paradrop - Remove Operation always removes markers regardless of this setting."], false]
     ],
     {
         params ["_values", "_modulePosition"];
@@ -175,7 +175,7 @@ private _defaultName = format ["DZ %1", round (serverTime mod 10000)];
             "_name", "_side", "_class", "_direction", "_altitude", "_speed", "_approach", "_length", "_exit",
             "_lifecycle", "_circuitDirection", "_staticEnabled", "_staticMin", "_staticMax", "_staticSpeed", "_staticChute",
             "_haloEnabled", "_haloMin", "_haloChute", "_requireDoor", "_dropPlayers", "_automaticMode", "_count", "_interval", "_markers",
-            "_removeMarkersOnCleanup"
+            "_keepMarkersOnCleanup"
         ];
         private _idBase = [_name, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-"] call BIS_fnc_filterString;
         if (_idBase == "") then {_idBase = "DZ"};
@@ -189,7 +189,7 @@ private _defaultName = format ["DZ %1", round (serverTime mod 10000)];
             ["haloMinimumAltitude", _haloMin], ["haloBackpackClass", _haloChute], ["requireOpenDoor", _requireDoor],
             ["autoDropPlayers", _dropPlayers], ["automaticJumpMode", _automaticMode], ["jumperCount", round _count],
             ["createJumpers", _count > 0], ["jumpInterval", _interval], ["createMarkers", _markers],
-            ["removeMarkersOnCleanup", _removeMarkersOnCleanup]
+            ["keepMarkersOnCleanup", _keepMarkersOnCleanup]
         ];
         [_config, player] remoteExecCall ["Waldo_fnc_ParadropCreateDropZone", 2];
     },

--- a/MissionScripts/Paradrop/paradropDropZoneZen.sqf
+++ b/MissionScripts/Paradrop/paradropDropZoneZen.sqf
@@ -166,14 +166,16 @@ private _defaultName = format ["DZ %1", round (serverTime mod 10000)];
         ["COMBO", ["Automatic jump type", "Method used only for automatic sequencing. If that method is disabled, the server uses the enabled alternative or disables automatic player exits."], [["STATIC", "HALO"], ["Static line", "HALO"], 0]],
         ["SLIDER", ["Optional generated AI jumpers", "AI cargo created for this operation. Default zero keeps the aircraft for players."], [0, 60, 0, 0]],
         ["SLIDER", ["Automatic jump interval", "Seconds between forced player or optional AI exits."], [0.5, 10, 2, 1]],
-        ["CHECKBOX", ["Create map markers", "Creates DZ, standby, green, red and named point markers."], true]
+        ["CHECKBOX", ["Create map markers", "Creates DZ, standby, green, red and named point markers."], true],
+        ["CHECKBOX", ["Remove markers when the operation ends automatically", "Applies to an automatic DESPAWN pass or the aircraft being lost - the markers are left in place by default. Explicitly using Paradrop - Remove Operation always removes markers regardless of this setting."], false]
     ],
     {
         params ["_values", "_modulePosition"];
         _values params [
             "_name", "_side", "_class", "_direction", "_altitude", "_speed", "_approach", "_length", "_exit",
             "_lifecycle", "_circuitDirection", "_staticEnabled", "_staticMin", "_staticMax", "_staticSpeed", "_staticChute",
-            "_haloEnabled", "_haloMin", "_haloChute", "_requireDoor", "_dropPlayers", "_automaticMode", "_count", "_interval", "_markers"
+            "_haloEnabled", "_haloMin", "_haloChute", "_requireDoor", "_dropPlayers", "_automaticMode", "_count", "_interval", "_markers",
+            "_removeMarkersOnCleanup"
         ];
         private _idBase = [_name, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-"] call BIS_fnc_filterString;
         if (_idBase == "") then {_idBase = "DZ"};
@@ -186,7 +188,8 @@ private _defaultName = format ["DZ %1", round (serverTime mod 10000)];
             ["staticMaximumSpeed", _staticSpeed], ["staticChuteClass", _staticChute], ["haloJumpEnabled", _haloEnabled],
             ["haloMinimumAltitude", _haloMin], ["haloBackpackClass", _haloChute], ["requireOpenDoor", _requireDoor],
             ["autoDropPlayers", _dropPlayers], ["automaticJumpMode", _automaticMode], ["jumperCount", round _count],
-            ["createJumpers", _count > 0], ["jumpInterval", _interval], ["createMarkers", _markers]
+            ["createJumpers", _count > 0], ["jumpInterval", _interval], ["createMarkers", _markers],
+            ["removeMarkersOnCleanup", _removeMarkersOnCleanup]
         ];
         [_config, player] remoteExecCall ["Waldo_fnc_ParadropCreateDropZone", 2];
     },

--- a/MissionScripts/Paradrop/paradropDropZoneZen.sqf
+++ b/MissionScripts/Paradrop/paradropDropZoneZen.sqf
@@ -161,7 +161,7 @@ private _defaultName = format ["DZ %1", round (serverTime mod 10000)];
         ["CHECKBOX", ["Enable HALO jump", "Adds a HALO player jump action using a steerable parachute backpack."], false],
         ["SLIDER", ["HALO minimum altitude", "Preferred AGL floor. If it exceeds route altitude, the server lowers it to the route altitude so HALO remains available."], [100, 5000, 1000, 0]],
         ["COMBO", ["HALO parachute backpack", "Steerable backpack equipped after HALO exit."], [_haloChutes, _haloLabels, 0]],
-        ["CHECKBOX", ["Require open ramp/door", "Requires one of WMP's recognized ramp/door animation sources. Automatically disabled when the selected airframe exposes none."], false],
+        ["CHECKBOX", ["Require open ramp/door", "Requires one of WMP's recognized ramp/door animation sources. Automatically disabled when the selected airframe exposes none."], true],
         ["CHECKBOX", ["Automatically sequence player cargo", "Forces embarked players out at the green line; normally leave off for jumpmaster-controlled player actions."], false],
         ["COMBO", ["Automatic jump type", "Method used only for automatic sequencing. If that method is disabled, the server uses the enabled alternative or disables automatic player exits."], [["STATIC", "HALO"], ["Static line", "HALO"], 0]],
         ["SLIDER", ["Optional generated AI jumpers", "AI cargo created for this operation. Default zero keeps the aircraft for players."], [0, 60, 0, 0]],

--- a/MissionScripts/Paradrop/paradropNormalizeJumpEnvelope.sqf
+++ b/MissionScripts/Paradrop/paradropNormalizeJumpEnvelope.sqf
@@ -18,15 +18,20 @@
  *
  * Return Value:
  * HashMap - staticMinimumAltitude, staticMaximumAltitude, staticMaximumSpeed, haloMinimumAltitude,
- * each guaranteed satisfiable at the supplied route altitude/speed:
- * - staticMinimumAltitude never exceeds route altitude - 25 m (a static-line jumper must be able to
- *   release at least 25 m below the route's cruise altitude).
- * - staticMaximumAltitude never falls below route altitude + 75 m (route altitude must sit inside
- *   the static-line window with headroom, not right at its edge).
- * - staticMaximumSpeed never falls below route speed + 40 km/h (the aircraft's actual cruise speed
+ * each guaranteed satisfiable at the supplied route altitude/speed with headroom to spare - the
+ * static/HALO hold-action conditions re-check the aircraft's *live* altitude/speed every frame
+ * they're offered, and AI flyInHeight/limitSpeed autopilot routinely wanders a few metres/km-h
+ * around its nominal route target rather than holding it exactly. A margin sized to the route's
+ * commanded value alone would flicker the action on and off with that normal wander; these margins
+ * are deliberately generous enough to absorb it:
+ * - staticMinimumAltitude never exceeds route altitude - 50 m (a static-line jumper must be able to
+ *   release at least 50 m below the route's cruise altitude).
+ * - staticMaximumAltitude never falls below route altitude + 120 m (route altitude must sit well
+ *   inside the static-line window, not near its edge).
+ * - staticMaximumSpeed never falls below route speed + 60 km/h (the aircraft's actual cruise speed
  *   must stay comfortably under the jump's speed ceiling, not brush against it).
- * - haloMinimumAltitude never exceeds route altitude (HALO release must be reachable at cruise
- *   altitude, not above it).
+ * - haloMinimumAltitude never exceeds route altitude - 50 m (HALO release must stay reachable even
+ *   if the aircraft is briefly a little below its nominal cruise altitude, not just exactly at it).
  *
  * Example:
  * [250, 220, 180, 350, 310, 1000] call Waldo_fnc_ParadropNormalizeJumpEnvelope;
@@ -43,9 +48,16 @@ params [
     ["_rawHaloMin", 1000, [0]]
 ];
 
+// Buffers absorb normal AI flyInHeight/limitSpeed wander around the route's commanded
+// altitude/speed so a brief autopilot dip/spike doesn't flicker the jump hold-action unavailable.
+private _staticMinAltitudeBuffer = 50;
+private _staticMaxAltitudeBuffer = 120;
+private _staticMaxSpeedBuffer = 60;
+private _haloMinAltitudeBuffer = 50;
+
 createHashMapFromArray [
-    ["staticMinimumAltitude", (_rawStaticMin max 0) min ((_altitude - 25) max 0)],
-    ["staticMaximumAltitude", (_rawStaticMax max (_altitude + 75)) min 2500],
-    ["staticMaximumSpeed", (_rawStaticMaxSpeed max (_maxSpeed + 40)) min 700],
-    ["haloMinimumAltitude", (_rawHaloMin max 0) min _altitude]
+    ["staticMinimumAltitude", (_rawStaticMin max 0) min ((_altitude - _staticMinAltitudeBuffer) max 0)],
+    ["staticMaximumAltitude", (_rawStaticMax max (_altitude + _staticMaxAltitudeBuffer)) min 2500],
+    ["staticMaximumSpeed", (_rawStaticMaxSpeed max (_maxSpeed + _staticMaxSpeedBuffer)) min 700],
+    ["haloMinimumAltitude", (_rawHaloMin max 0) min ((_altitude - _haloMinAltitudeBuffer) max 0)]
 ]

--- a/MissionScripts/Paradrop/paradropNormalizeJumpEnvelope.sqf
+++ b/MissionScripts/Paradrop/paradropNormalizeJumpEnvelope.sqf
@@ -1,0 +1,51 @@
+/*
+ * Author: WaldoTheWarfighter
+ * Clamps a static-line/HALO jump envelope so it is always reachable at a given route altitude and
+ * speed - the concrete fix for a paradrop plane whose jump action never becomes available because
+ * its flight altitude/speed don't actually satisfy the configured Waldo_fnc_AddStaticJump /
+ * Waldo_fnc_AddHaloJump conditions (see those functions: the hold action's condition checks the
+ * aircraft's live altitude against min/max and its speed against max, every frame it's offered).
+ * Setting a route altitude and a jump envelope independently is exactly how that mismatch happens;
+ * this function is the one place both paradrop entry points make sure it can't.
+ *
+ * Arguments:
+ * 0: route altitude <NUMBER> - metres AGL the aircraft will actually fly at.
+ * 1: route maximum speed <NUMBER> - km/h the aircraft will actually be capped to.
+ * 2: requested static-line minimum altitude <NUMBER> (raw mission-maker/default value).
+ * 3: requested static-line maximum altitude <NUMBER> (raw mission-maker/default value).
+ * 4: requested static-line maximum speed <NUMBER> (raw mission-maker/default value).
+ * 5: requested HALO minimum altitude <NUMBER> (raw mission-maker/default value).
+ *
+ * Return Value:
+ * HashMap - staticMinimumAltitude, staticMaximumAltitude, staticMaximumSpeed, haloMinimumAltitude,
+ * each guaranteed satisfiable at the supplied route altitude/speed:
+ * - staticMinimumAltitude never exceeds route altitude - 25 m (a static-line jumper must be able to
+ *   release at least 25 m below the route's cruise altitude).
+ * - staticMaximumAltitude never falls below route altitude + 75 m (route altitude must sit inside
+ *   the static-line window with headroom, not right at its edge).
+ * - staticMaximumSpeed never falls below route speed + 40 km/h (the aircraft's actual cruise speed
+ *   must stay comfortably under the jump's speed ceiling, not brush against it).
+ * - haloMinimumAltitude never exceeds route altitude (HALO release must be reachable at cruise
+ *   altitude, not above it).
+ *
+ * Example:
+ * [250, 220, 180, 350, 310, 1000] call Waldo_fnc_ParadropNormalizeJumpEnvelope;
+ *
+ * Current callers: Waldo_fnc_ParadropCreateDropZone, Waldo_fnc_ParadropQuickFlightSetup.
+ */
+
+params [
+    ["_altitude", 250, [0]],
+    ["_maxSpeed", 220, [0]],
+    ["_rawStaticMin", 180, [0]],
+    ["_rawStaticMax", 350, [0]],
+    ["_rawStaticMaxSpeed", 310, [0]],
+    ["_rawHaloMin", 1000, [0]]
+];
+
+createHashMapFromArray [
+    ["staticMinimumAltitude", (_rawStaticMin max 0) min ((_altitude - 25) max 0)],
+    ["staticMaximumAltitude", (_rawStaticMax max (_altitude + 75)) min 2500],
+    ["staticMaximumSpeed", (_rawStaticMaxSpeed max (_maxSpeed + 40)) min 700],
+    ["haloMinimumAltitude", (_rawHaloMin max 0) min _altitude]
+]

--- a/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
+++ b/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
@@ -1,0 +1,149 @@
+/*
+ * Author: WaldoTheWarfighter
+ * One-call reliable paradrop setup for an aircraft a mission maker has already placed and crewed in
+ * Eden Editor - the simple alternative to the full Dynamic Drop Zone system (Waldo_fnc_
+ * ParadropCreateDropZone / the ZEN "Dynamic Paradrop" module) for missions that just want a working
+ * jump plane without a managed registry, generated jumpers or map markers.
+ *
+ * This shares its actual flight logic with the Dynamic Drop Zone system through
+ * Waldo_fnc_ParadropBuildFlightRoute - the same proven standby/green/red/exit route, the same
+ * altitude/speed handling that avoids the km/h-vs-m/s overspeed mistake, and the same waypoint
+ * cleanup that stops an Eden-placed aircraft's own default waypoints from fighting the scripted
+ * route. That waypoint conflict, more than anything else, is why a manually wired-up paradrop plane
+ * is "hard to get in position" - see Waldo_fnc_ParadropBuildFlightRoute's own header for detail.
+ *
+ * Unlike the Dynamic Drop Zone system, this does not create or re-crew the aircraft: it uses
+ * whichever group currently owns the driver's seat, waiting (bounded) for a pilot to exist if the
+ * aircraft was just placed and crew spawn-in is still in progress. Static-line and HALO jump
+ * actions are installed through the exact same Waldo_fnc_ParadropConfigureAircraftLocal used by the
+ * Dynamic Drop Zone system, so both paths behave identically once airborne.
+ *
+ * Arguments:
+ * 0: aircraft <OBJECT> - placed, ideally already crewed with a pilot (e.g. via
+ *    Waldo_fnc_MoveInCargoPlane in the object's own init field, or an Eden-assigned crew).
+ * 1: target <STRING, ARRAY or OBJECT> - drop point: a marker name, a position, or an object.
+ * 2: direction <NUMBER> - degrees; the aircraft approaches the target along this heading. -1 (the
+ *    default) computes a sensible heading automatically from the aircraft's position to the target.
+ * 3: altitude <NUMBER> - route altitude AGL in metres (default 250, clamped 100-2000).
+ * 4: maximum speed <NUMBER> - km/h (default 220, clamped 80-500).
+ * 5: options <HASHMAP> - optional overrides: staticJumpEnabled (default true), haloJumpEnabled
+ *    (default false), staticMinimumAltitude/staticMaximumAltitude/staticMaximumSpeed/
+ *    staticChuteClass, haloMinimumAltitude/haloBackpackClass (all default from the mission's
+ *    configured WALDO_STATIC_ and WALDO_PARA_ envelope variables, same as every other WMP
+ *    paradrop entry point), requireOpenDoor (default true, ignored if the airframe has no recognised door/ramp
+ *    animation), lifecycle (LOOP/RETAIN/DESPAWN, default LOOP), circuitDirection (LEFT/RIGHT,
+ *    default LEFT), approachDistance/runLength/exitDistance (metres, default 2500 each),
+ *    createMarkers (default false - this entry point is deliberately map-clutter-free unless asked).
+ *
+ * Return Value:
+ * Boolean - true when accepted (the actual route/actions are applied a moment later on the server
+ * once a pilot is confirmed present; check the RPT for "[WMP PARADROP] Quick flight setup" if a
+ * plane never starts flying).
+ *
+ * Example:
+ * [this, "dz1"] call Waldo_fnc_ParadropQuickFlightSetup;
+ * Result: the plane this is placed on flies a standby/green/red/exit run toward marker "dz1" at
+ * 250 m / 220 km/h, looping to repeat, with the mission's configured static-line jump action ready.
+ *
+ * Example (HALO instead of static-line, one-shot):
+ * [this, getMarkerPos "dz2", -1, 1200, 250, createHashMapFromArray [
+ *     ["staticJumpEnabled", false], ["haloJumpEnabled", true], ["lifecycle", "DESPAWN"]
+ * ]] call Waldo_fnc_ParadropQuickFlightSetup;
+ *
+ * Current callers: mission-maker object init fields (see the Halo And Static-Line Paradrop
+ * compositions); available to scripts.
+ */
+
+params [
+    ["_aircraft", objNull, [objNull]],
+    ["_target", "", ["", [], objNull]],
+    ["_direction", -1, [0]],
+    ["_altitude", 250, [0]],
+    ["_maxSpeed", 220, [0]],
+    ["_options", createHashMap, [createHashMap]]
+];
+if (isNull _aircraft || {!(_aircraft isKindOf "Air")}) exitWith {false};
+if !(isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropQuickFlightSetup", 2]; true};
+
+[_aircraft, _target, _direction, _altitude, _maxSpeed, _options] spawn {
+    params ["_aircraft", "_target", "_direction", "_altitude", "_maxSpeed", "_options"];
+
+    // Called from an object's init field, this can run before the aircraft's own crew (placed in
+    // Eden, or assigned by another object's init field such as Waldo_fnc_MoveInCargoPlane) exists
+    // yet. Wait for both mission init and an actual pilot rather than failing immediately - the
+    // single biggest source of "the plane just sits there" reports for a script wired up this way.
+    waitUntil {sleep 0.5; missionNamespace getVariable ["WALDO_INIT_COMPLETE", false] || {isNull _aircraft}};
+    if (isNull _aircraft) exitWith {};
+    private _deadline = serverTime + 30;
+    waitUntil {sleep 0.5; isNull _aircraft || {!isNull (driver _aircraft)} || {serverTime >= _deadline}};
+    if (isNull _aircraft) exitWith {};
+    if (isNull driver _aircraft) exitWith {
+        diag_log format ["[WMP PARADROP] Quick flight setup abandoned for %1: no pilot became available within 30 seconds. Assign a crew (Eden crew or Waldo_fnc_MoveInCargoPlane) before this call.", typeOf _aircraft];
+    };
+
+    private _centre = switch (typeName _target) do {
+        case "STRING": {if (_target == "") then {[]} else {getMarkerPos _target}};
+        case "ARRAY": {_target};
+        case "OBJECT": {if (isNull _target) then {[]} else {getPosATL _target}};
+        default {[]};
+    };
+    if (count _centre < 2) exitWith {
+        diag_log format ["[WMP PARADROP] Quick flight setup rejected for %1: target '%2' did not resolve to a position.", typeOf _aircraft, _target];
+    };
+
+    private _resolvedDirection = if (_direction >= 0) then {_direction mod 360} else {
+        [getPosATL _aircraft, _centre] call BIS_fnc_dirTo
+    };
+    private _flightGroup = group driver _aircraft;
+    private _route = [
+        _aircraft, _flightGroup, _centre, _resolvedDirection, _altitude, _maxSpeed,
+        _options getOrDefault ["approachDistance", 2500], _options getOrDefault ["runLength", 2500],
+        _options getOrDefault ["exitDistance", 2500], _options getOrDefault ["lifecycle", "LOOP"],
+        _options getOrDefault ["circuitDirection", "LEFT"]
+    ] call Waldo_fnc_ParadropBuildFlightRoute;
+    if (_route isEqualTo createHashMap) exitWith {
+        diag_log format ["[WMP PARADROP] Quick flight setup failed for %1: the flight route could not be built.", typeOf _aircraft];
+    };
+
+    private _requireDoor = _options getOrDefault ["requireOpenDoor", true];
+    if (_requireDoor) then {
+        private _animationSources = configFile >> "CfgVehicles" >> (typeOf _aircraft) >> "AnimationSources";
+        private _recognizedDoorSources = ["ramp_bottom", "door_2_1", "door_2_2", "jumpdoor_1", "jumpdoor_2", "back_ramp_switch", "back_ramp_half_switch", "RearDoors", "Door_1_source", "ramp_anim"];
+        if (_recognizedDoorSources findIf {isClass (_animationSources >> _x)} < 0) then {_requireDoor = false};
+    };
+    private _jumpConfig = createHashMapFromArray [
+        ["staticJumpEnabled", _options getOrDefault ["staticJumpEnabled", true]],
+        ["staticMinimumAltitude", _options getOrDefault ["staticMinimumAltitude", missionNamespace getVariable ["WALDO_STATIC_MINALTITUDE", 180]]],
+        ["staticMaximumAltitude", _options getOrDefault ["staticMaximumAltitude", missionNamespace getVariable ["WALDO_STATIC_MAXALTITUDE", 350]]],
+        ["staticMaximumSpeed", _options getOrDefault ["staticMaximumSpeed", missionNamespace getVariable ["WALDO_STATIC_MAXSPEED", 310]]],
+        ["staticChuteClass", _options getOrDefault ["staticChuteClass", missionNamespace getVariable ["WALDO_STATIC_STATICCHUTE", "NonSteerable_Parachute_F"]]],
+        ["haloJumpEnabled", _options getOrDefault ["haloJumpEnabled", false]],
+        ["haloMinimumAltitude", _options getOrDefault ["haloMinimumAltitude", missionNamespace getVariable ["WALDO_PARA_HALOALTITUDE", 1000]]],
+        ["haloBackpackClass", _options getOrDefault ["haloBackpackClass", missionNamespace getVariable ["WALDO_PARA_HALOCHUTE", "B_Parachute"]]],
+        ["requireOpenDoor", _requireDoor]
+    ];
+    // A configured static chute class (e.g. a mod's steerable rig) may not be loaded in every
+    // mission. Fall back to the vanilla class rather than silently disabling the jump action.
+    if !(isClass (configFile >> "CfgVehicles" >> (_jumpConfig get "staticChuteClass"))) then {
+        _jumpConfig set ["staticChuteClass", "NonSteerable_Parachute_F"];
+    };
+    [_aircraft, _jumpConfig] remoteExec ["Waldo_fnc_ParadropConfigureAircraftLocal", 0, _aircraft];
+
+    if (_options getOrDefault ["createMarkers", false]) then {
+        private _direction2 = _resolvedDirection;
+        private _prefix = format ["Waldo_DZQ_%1", netId _aircraft];
+        {
+            _x params ["_suffix", "_key", "_colour", "_text"];
+            private _marker = createMarker [format ["%1_%2", _prefix, _suffix], _route get _key];
+            _marker setMarkerShape "RECTANGLE";
+            _marker setMarkerBrush "SolidBorder";
+            _marker setMarkerDir _direction2;
+            _marker setMarkerSize [30, 4];
+            _marker setMarkerColor _colour;
+            _marker setMarkerText _text;
+        } forEach [["STANDBY", "standby", "ColorYellow", "STANDBY"], ["GREEN", "green", "ColorGreen", "GREEN LINE"], ["RED", "red", "ColorRed", "RED LINE"]];
+    };
+
+    diag_log format ["[WMP PARADROP] Quick flight setup complete: aircraft=%1 pilot=%2 centre=%3 direction=%4 altitude=%5 speed=%6.", typeOf _aircraft, driver _aircraft, _centre, round _resolvedDirection, _altitude, _maxSpeed];
+};
+true

--- a/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
+++ b/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
@@ -22,7 +22,11 @@
  * Waldo_fnc_ParadropConfigureAircraftLocal used by the Dynamic Drop Zone system, so both paths behave
  * identically once airborne.
  *
- * A lightweight cleanup watcher removes this call's own markers (never the aircraft or its crew,
+ * Markers created by this call are left in place by default, the same way Waldo_fnc_
+ * ParadropCreateDropZone's automatic cleanup leaves them by default - a mission maker who placed a
+ * drop zone marker generally wants it to stay on the map, not vanish the moment the plane is shot
+ * down or finishes a one-shot run. Set the removeMarkersOnCleanup option to opt into a lightweight
+ * cleanup watcher instead, which removes this call's own markers (never the aircraft or its crew,
  * which this function never owned in the first place) once the aircraft is destroyed/deleted, or
  * once a "DESPAWN" lifecycle run reaches its exit point. This is a deliberately smaller contract than
  * Waldo_fnc_ParadropRemoveDropZone, which does delete the aircraft it spawned - see the difference
@@ -41,14 +45,16 @@
  *    staticChuteClass, haloMinimumAltitude/haloBackpackClass (all default from the mission's
  *    configured WALDO_STATIC_ and WALDO_PARA_ envelope variables, same as every other WMP
  *    paradrop entry point), requireOpenDoor (default true, ignored if the airframe has no recognised door/ramp
- *    animation), lifecycle (LOOP/RETAIN/DESPAWN, default LOOP - DESPAWN here means the created
- *    markers are removed once the one pass completes, not that the aircraft is deleted; this
- *    function never owns the aircraft's lifecycle, unlike Waldo_fnc_ParadropCreateDropZone),
+ *    animation), lifecycle (LOOP/RETAIN/DESPAWN, default LOOP - this function never deletes the
+ *    aircraft under any lifecycle, unlike Waldo_fnc_ParadropCreateDropZone; DESPAWN only changes
+ *    which waypoints get added and is the trigger point for removeMarkersOnCleanup below),
  *    circuitDirection (LEFT/RIGHT, default LEFT), approachDistance/runLength/exitDistance (metres,
  *    default 2500 each), createMarkers (default true - AREA/STANDBY/GREEN/RED/POINT markers matching
  *    Waldo_fnc_ParadropCreateDropZone's layout, so a mission maker sees a working drop zone
- *    immediately; automatically cleaned up on aircraft death/deletion or DESPAWN completion; set
- *    false for a map-clutter-free operation), name (marker label, default "Drop Zone").
+ *    immediately; set false for a map-clutter-free operation), removeMarkersOnCleanup (default
+ *    false - the created markers are left on the map even after the aircraft is gone; opt in to
+ *    remove them once the aircraft is destroyed/deleted, or once a DESPAWN run reaches its exit
+ *    point; never affects the aircraft or crew either way), name (marker label, default "Drop Zone").
  *
  * Return Value:
  * Boolean - true when accepted (the actual route/actions are applied a moment later on the server
@@ -221,11 +227,13 @@ if !(isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropQuickFlightSet
         _markers pushBack _point;
     };
 
-    // Cleanup watcher: this function never owns the aircraft's lifecycle (unlike
-    // Waldo_fnc_ParadropCreateDropZone, which spawns and therefore deletes its own aircraft), so this
-    // only ever removes the markers created above - never the aircraft or its crew. Runs regardless
-    // of createMarkers so it's always a correct no-op when there's nothing to clean up.
-    if (count _markers > 0) then {
+    // Cleanup watcher: opt-in only (removeMarkersOnCleanup, default false) - a mission maker who
+    // placed a drop zone marker generally wants it to stay on the map, not vanish the moment the
+    // plane is shot down or finishes a one-shot run. This function never owns the aircraft's
+    // lifecycle (unlike Waldo_fnc_ParadropCreateDropZone, which spawns and therefore deletes its own
+    // aircraft), so even when enabled this only ever removes the markers created above - never the
+    // aircraft or its crew.
+    if (count _markers > 0 && {_options getOrDefault ["removeMarkersOnCleanup", false]}) then {
         [_aircraft, _markers, _lifecycle, _route] spawn {
             params ["_aircraft", "_markers", "_lifecycle", "_route"];
             waitUntil {

--- a/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
+++ b/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
@@ -14,9 +14,19 @@
  *
  * Unlike the Dynamic Drop Zone system, this does not create or re-crew the aircraft: it uses
  * whichever group currently owns the driver's seat, waiting (bounded) for a pilot to exist if the
- * aircraft was just placed and crew spawn-in is still in progress. Static-line and HALO jump
- * actions are installed through the exact same Waldo_fnc_ParadropConfigureAircraftLocal used by the
- * Dynamic Drop Zone system, so both paths behave identically once airborne.
+ * aircraft was just placed and crew spawn-in is still in progress. If that group has other units
+ * besides this aircraft's crew (e.g. a squad leader who is also the pilot), the crew is moved into a
+ * dedicated fresh group first - Waldo_fnc_ParadropBuildFlightRoute clears every waypoint of whatever
+ * group it's given, and a shared group must not lose waypoints that belong to units who were never
+ * part of this aircraft. Static-line and HALO jump actions are installed through the exact same
+ * Waldo_fnc_ParadropConfigureAircraftLocal used by the Dynamic Drop Zone system, so both paths behave
+ * identically once airborne.
+ *
+ * A lightweight cleanup watcher removes this call's own markers (never the aircraft or its crew,
+ * which this function never owned in the first place) once the aircraft is destroyed/deleted, or
+ * once a "DESPAWN" lifecycle run reaches its exit point. This is a deliberately smaller contract than
+ * Waldo_fnc_ParadropRemoveDropZone, which does delete the aircraft it spawned - see the difference
+ * called out in the lifecycle option below.
  *
  * Arguments:
  * 0: aircraft <OBJECT> - placed, ideally already crewed with a pilot (e.g. via
@@ -31,10 +41,13 @@
  *    staticChuteClass, haloMinimumAltitude/haloBackpackClass (all default from the mission's
  *    configured WALDO_STATIC_ and WALDO_PARA_ envelope variables, same as every other WMP
  *    paradrop entry point), requireOpenDoor (default true, ignored if the airframe has no recognised door/ramp
- *    animation), lifecycle (LOOP/RETAIN/DESPAWN, default LOOP), circuitDirection (LEFT/RIGHT,
- *    default LEFT), approachDistance/runLength/exitDistance (metres, default 2500 each),
- *    createMarkers (default true - AREA/STANDBY/GREEN/RED/POINT markers matching Waldo_fnc_
- *    ParadropCreateDropZone's layout, so a mission maker sees a working drop zone immediately; set
+ *    animation), lifecycle (LOOP/RETAIN/DESPAWN, default LOOP - DESPAWN here means the created
+ *    markers are removed once the one pass completes, not that the aircraft is deleted; this
+ *    function never owns the aircraft's lifecycle, unlike Waldo_fnc_ParadropCreateDropZone),
+ *    circuitDirection (LEFT/RIGHT, default LEFT), approachDistance/runLength/exitDistance (metres,
+ *    default 2500 each), createMarkers (default true - AREA/STANDBY/GREEN/RED/POINT markers matching
+ *    Waldo_fnc_ParadropCreateDropZone's layout, so a mission maker sees a working drop zone
+ *    immediately; automatically cleaned up on aircraft death/deletion or DESPAWN completion; set
  *    false for a map-clutter-free operation), name (marker label, default "Drop Zone").
  *
  * Return Value:
@@ -74,8 +87,14 @@ if !(isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropQuickFlightSet
     // Eden, or assigned by another object's init field such as Waldo_fnc_MoveInCargoPlane) exists
     // yet. Wait for both mission init and an actual pilot rather than failing immediately - the
     // single biggest source of "the plane just sits there" reports for a script wired up this way.
-    waitUntil {sleep 0.5; missionNamespace getVariable ["WALDO_INIT_COMPLETE", false] || {isNull _aircraft}};
+    // Bounded the same way as the pilot wait below it: a mission that never sets WALDO_INIT_COMPLETE
+    // (broken init.sqf, non-standard init flow) must not leave this spawned handle looping forever.
+    private _initDeadline = serverTime + 30;
+    waitUntil {sleep 0.5; missionNamespace getVariable ["WALDO_INIT_COMPLETE", false] || {isNull _aircraft} || {serverTime >= _initDeadline}};
     if (isNull _aircraft) exitWith {};
+    if !(missionNamespace getVariable ["WALDO_INIT_COMPLETE", false]) exitWith {
+        diag_log format ["[WMP PARADROP] Quick flight setup abandoned for %1: WALDO_INIT_COMPLETE never became true within 30 seconds.", typeOf _aircraft];
+    };
     private _deadline = serverTime + 30;
     waitUntil {sleep 0.5; isNull _aircraft || {!isNull (driver _aircraft)} || {serverTime >= _deadline}};
     if (isNull _aircraft) exitWith {};
@@ -96,7 +115,22 @@ if !(isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropQuickFlightSet
     private _resolvedDirection = if (_direction >= 0) then {_direction mod 360} else {
         [getPosATL _aircraft, _centre] call BIS_fnc_dirTo
     };
-    private _flightGroup = group driver _aircraft;
+
+    // Waldo_fnc_ParadropBuildFlightRoute clears every waypoint of the group it's given. That's safe
+    // when the group belongs only to this aircraft's crew, but the pilot's actual Eden group may
+    // contain other units entirely (a squad leader also flying, a multi-crew group with members
+    // elsewhere) - wiping their waypoints too would be a surprising side effect of a call meant to
+    // only touch this one aircraft. Isolate the crew into a dedicated fresh group first, only when
+    // the group actually needs it.
+    private _originalGroup = group driver _aircraft;
+    private _flightGroup = _originalGroup;
+    private _crew = crew _aircraft;
+    if ({!(_x in _crew)} count units _originalGroup > 0) then {
+        _flightGroup = createGroup [side _originalGroup, true];
+        {[_x] joinSilent _flightGroup} forEach _crew;
+        if (count units _originalGroup == 0) then {deleteGroup _originalGroup};
+    };
+
     private _route = [
         _aircraft, _flightGroup, _centre, _resolvedDirection, _altitude, _maxSpeed,
         _options getOrDefault ["approachDistance", 2500], _options getOrDefault ["runLength", 2500],
@@ -106,6 +140,13 @@ if !(isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropQuickFlightSet
     if (_route isEqualTo createHashMap) exitWith {
         diag_log format ["[WMP PARADROP] Quick flight setup failed for %1: the flight route could not be built.", typeOf _aircraft];
     };
+    private _lifecycle = toUpperANSI (_options getOrDefault ["lifecycle", "LOOP"]);
+    if !(_lifecycle in ["LOOP", "RETAIN", "DESPAWN"]) then {_lifecycle = "LOOP"};
+    // The route builder clamps altitude/speed internally and hands the real values back - use those
+    // (not the raw params above) as the basis for everything that follows, so the jump envelope is
+    // always normalized off what the aircraft is actually flying.
+    private _routeAltitude = _route get "altitude";
+    private _routeMaxSpeed = _route get "maxSpeed";
 
     private _requireDoor = _options getOrDefault ["requireOpenDoor", true];
     if (_requireDoor) then {
@@ -118,7 +159,7 @@ if !(isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropQuickFlightSet
     // window). Normalize the envelope around the route this aircraft is actually flying, the same
     // way the Dynamic Drop Zone system already does.
     private _envelope = [
-        _altitude, _maxSpeed,
+        _routeAltitude, _routeMaxSpeed,
         _options getOrDefault ["staticMinimumAltitude", missionNamespace getVariable ["WALDO_STATIC_MINALTITUDE", 180]],
         _options getOrDefault ["staticMaximumAltitude", missionNamespace getVariable ["WALDO_STATIC_MAXALTITUDE", 350]],
         _options getOrDefault ["staticMaximumSpeed", missionNamespace getVariable ["WALDO_STATIC_MAXSPEED", 310]],
@@ -150,6 +191,7 @@ if !(isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropQuickFlightSet
     // On by default: the whole point of this entry point is a mission maker getting a working,
     // visible drop zone from one line, not a silent invisible route. Set createMarkers to false in
     // options for a map-clutter-free operation instead.
+    private _markers = [];
     if (_options getOrDefault ["createMarkers", true]) then {
         private _label = _options getOrDefault ["name", "Drop Zone"];
         private _runLength = _options getOrDefault ["runLength", 2500];
@@ -160,6 +202,7 @@ if !(isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropQuickFlightSet
         _zoneMarker setMarkerDir _resolvedDirection;
         _zoneMarker setMarkerSize [100, (_runLength * 0.65) max 200];
         _zoneMarker setMarkerColor "ColorBlack";
+        _markers pushBack _zoneMarker;
         {
             _x params ["_suffix", "_key", "_colour", "_text"];
             private _marker = createMarker [format ["%1_%2", _prefix, _suffix], _route get _key];
@@ -169,13 +212,32 @@ if !(isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropQuickFlightSet
             _marker setMarkerSize [30, 4];
             _marker setMarkerColor _colour;
             _marker setMarkerText _text;
+            _markers pushBack _marker;
         } forEach [["STANDBY", "standby", "ColorYellow", "STANDBY"], ["GREEN", "green", "ColorGreen", "GREEN LINE"], ["RED", "red", "ColorRed", "RED LINE"]];
         private _point = createMarker [format ["%1_POINT", _prefix], _centre];
         _point setMarkerType "mil_end";
         _point setMarkerColor "ColorBlack";
         _point setMarkerText _label;
+        _markers pushBack _point;
     };
 
-    diag_log format ["[WMP PARADROP] Quick flight setup complete: aircraft=%1 pilot=%2 centre=%3 direction=%4 altitude=%5 speed=%6.", typeOf _aircraft, driver _aircraft, _centre, round _resolvedDirection, _altitude, _maxSpeed];
+    // Cleanup watcher: this function never owns the aircraft's lifecycle (unlike
+    // Waldo_fnc_ParadropCreateDropZone, which spawns and therefore deletes its own aircraft), so this
+    // only ever removes the markers created above - never the aircraft or its crew. Runs regardless
+    // of createMarkers so it's always a correct no-op when there's nothing to clean up.
+    if (count _markers > 0) then {
+        [_aircraft, _markers, _lifecycle, _route] spawn {
+            params ["_aircraft", "_markers", "_lifecycle", "_route"];
+            waitUntil {
+                sleep 1;
+                isNull _aircraft
+                || {!alive _aircraft}
+                || {_lifecycle == "DESPAWN" && {_aircraft distance2D (_route get "exit") < 200}}
+            };
+            {deleteMarker _x} forEach _markers;
+        };
+    };
+
+    diag_log format ["[WMP PARADROP] Quick flight setup complete: aircraft=%1 pilot=%2 centre=%3 direction=%4 altitude=%5 speed=%6.", typeOf _aircraft, driver _aircraft, _centre, round _resolvedDirection, round _routeAltitude, round _routeMaxSpeed];
 };
 true

--- a/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
+++ b/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
@@ -22,15 +22,13 @@
  * Waldo_fnc_ParadropConfigureAircraftLocal used by the Dynamic Drop Zone system, so both paths behave
  * identically once airborne.
  *
- * Markers created by this call are left in place by default, the same way Waldo_fnc_
- * ParadropCreateDropZone's automatic cleanup leaves them by default - a mission maker who placed a
- * drop zone marker generally wants it to stay on the map, not vanish the moment the plane is shot
- * down or finishes a one-shot run. Set the removeMarkersOnCleanup option to opt into a lightweight
- * cleanup watcher instead, which removes this call's own markers (never the aircraft or its crew,
+ * A lightweight cleanup watcher removes this call's own markers (never the aircraft or its crew,
  * which this function never owned in the first place) once the aircraft is destroyed/deleted, or
- * once a "DESPAWN" lifecycle run reaches its exit point. This is a deliberately smaller contract than
- * Waldo_fnc_ParadropRemoveDropZone, which does delete the aircraft it spawned - see the difference
- * called out in the lifecycle option below.
+ * once a "DESPAWN" lifecycle run reaches its exit point - matching Waldo_fnc_ParadropCreateDropZone's
+ * own automatic cleanup. Set the keepMarkersOnCleanup option true to opt out and leave the markers on
+ * the map instead. This is a deliberately smaller contract than Waldo_fnc_ParadropRemoveDropZone,
+ * which does delete the aircraft it spawned - see the difference called out in the lifecycle option
+ * below.
  *
  * Arguments:
  * 0: aircraft <OBJECT> - placed, ideally already crewed with a pilot (e.g. via
@@ -47,14 +45,14 @@
  *    paradrop entry point), requireOpenDoor (default true, ignored if the airframe has no recognised door/ramp
  *    animation), lifecycle (LOOP/RETAIN/DESPAWN, default LOOP - this function never deletes the
  *    aircraft under any lifecycle, unlike Waldo_fnc_ParadropCreateDropZone; DESPAWN only changes
- *    which waypoints get added and is the trigger point for removeMarkersOnCleanup below),
+ *    which waypoints get added and is one of the two automatic marker-cleanup triggers below),
  *    circuitDirection (LEFT/RIGHT, default LEFT), approachDistance/runLength/exitDistance (metres,
  *    default 2500 each), createMarkers (default true - AREA/STANDBY/GREEN/RED/POINT markers matching
  *    Waldo_fnc_ParadropCreateDropZone's layout, so a mission maker sees a working drop zone
- *    immediately; set false for a map-clutter-free operation), removeMarkersOnCleanup (default
- *    false - the created markers are left on the map even after the aircraft is gone; opt in to
- *    remove them once the aircraft is destroyed/deleted, or once a DESPAWN run reaches its exit
- *    point; never affects the aircraft or crew either way), name (marker label, default "Drop Zone").
+ *    immediately; set false for a map-clutter-free operation), keepMarkersOnCleanup (default false -
+ *    the created markers are removed automatically once the aircraft is destroyed/deleted, or once a
+ *    DESPAWN run reaches its exit point; set true to leave them on the map instead; never affects the
+ *    aircraft or crew either way), name (marker label, default "Drop Zone").
  *
  * Return Value:
  * Boolean - true when accepted (the actual route/actions are applied a moment later on the server
@@ -227,13 +225,13 @@ if !(isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropQuickFlightSet
         _markers pushBack _point;
     };
 
-    // Cleanup watcher: opt-in only (removeMarkersOnCleanup, default false) - a mission maker who
-    // placed a drop zone marker generally wants it to stay on the map, not vanish the moment the
-    // plane is shot down or finishes a one-shot run. This function never owns the aircraft's
-    // lifecycle (unlike Waldo_fnc_ParadropCreateDropZone, which spawns and therefore deletes its own
-    // aircraft), so even when enabled this only ever removes the markers created above - never the
-    // aircraft or its crew.
-    if (count _markers > 0 && {_options getOrDefault ["removeMarkersOnCleanup", false]}) then {
+    // Cleanup watcher. Markers are removed automatically once the aircraft is destroyed/deleted, or
+    // once a DESPAWN run reaches its exit point - a marker for a drop zone that's no longer active is
+    // just stale either way. Set keepMarkersOnCleanup true to opt out and leave them on the map. This
+    // function never owns the aircraft's lifecycle either way (unlike Waldo_fnc_ParadropCreateDropZone,
+    // which spawns and therefore deletes its own aircraft), so this only ever removes the markers
+    // created above - never the aircraft or its crew.
+    if (count _markers > 0 && {!(_options getOrDefault ["keepMarkersOnCleanup", false])}) then {
         [_aircraft, _markers, _lifecycle, _route] spawn {
             params ["_aircraft", "_markers", "_lifecycle", "_route"];
             waitUntil {

--- a/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
+++ b/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
@@ -33,7 +33,9 @@
  *    paradrop entry point), requireOpenDoor (default true, ignored if the airframe has no recognised door/ramp
  *    animation), lifecycle (LOOP/RETAIN/DESPAWN, default LOOP), circuitDirection (LEFT/RIGHT,
  *    default LEFT), approachDistance/runLength/exitDistance (metres, default 2500 each),
- *    createMarkers (default false - this entry point is deliberately map-clutter-free unless asked).
+ *    createMarkers (default true - AREA/STANDBY/GREEN/RED/POINT markers matching Waldo_fnc_
+ *    ParadropCreateDropZone's layout, so a mission maker sees a working drop zone immediately; set
+ *    false for a map-clutter-free operation), name (marker label, default "Drop Zone").
  *
  * Return Value:
  * Boolean - true when accepted (the actual route/actions are applied a moment later on the server
@@ -111,14 +113,25 @@ if !(isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropQuickFlightSet
         private _recognizedDoorSources = ["ramp_bottom", "door_2_1", "door_2_2", "jumpdoor_1", "jumpdoor_2", "back_ramp_switch", "back_ramp_half_switch", "RearDoors", "Door_1_source", "ramp_anim"];
         if (_recognizedDoorSources findIf {isClass (_animationSources >> _x)} < 0) then {_requireDoor = false};
     };
+    // Requesting a route altitude/speed and a jump envelope independently is exactly how a jump
+    // action ends up permanently unavailable (the aircraft cruises outside its own configured
+    // window). Normalize the envelope around the route this aircraft is actually flying, the same
+    // way the Dynamic Drop Zone system already does.
+    private _envelope = [
+        _altitude, _maxSpeed,
+        _options getOrDefault ["staticMinimumAltitude", missionNamespace getVariable ["WALDO_STATIC_MINALTITUDE", 180]],
+        _options getOrDefault ["staticMaximumAltitude", missionNamespace getVariable ["WALDO_STATIC_MAXALTITUDE", 350]],
+        _options getOrDefault ["staticMaximumSpeed", missionNamespace getVariable ["WALDO_STATIC_MAXSPEED", 310]],
+        _options getOrDefault ["haloMinimumAltitude", missionNamespace getVariable ["WALDO_PARA_HALOALTITUDE", 1000]]
+    ] call Waldo_fnc_ParadropNormalizeJumpEnvelope;
     private _jumpConfig = createHashMapFromArray [
         ["staticJumpEnabled", _options getOrDefault ["staticJumpEnabled", true]],
-        ["staticMinimumAltitude", _options getOrDefault ["staticMinimumAltitude", missionNamespace getVariable ["WALDO_STATIC_MINALTITUDE", 180]]],
-        ["staticMaximumAltitude", _options getOrDefault ["staticMaximumAltitude", missionNamespace getVariable ["WALDO_STATIC_MAXALTITUDE", 350]]],
-        ["staticMaximumSpeed", _options getOrDefault ["staticMaximumSpeed", missionNamespace getVariable ["WALDO_STATIC_MAXSPEED", 310]]],
+        ["staticMinimumAltitude", _envelope get "staticMinimumAltitude"],
+        ["staticMaximumAltitude", _envelope get "staticMaximumAltitude"],
+        ["staticMaximumSpeed", _envelope get "staticMaximumSpeed"],
         ["staticChuteClass", _options getOrDefault ["staticChuteClass", missionNamespace getVariable ["WALDO_STATIC_STATICCHUTE", "NonSteerable_Parachute_F"]]],
         ["haloJumpEnabled", _options getOrDefault ["haloJumpEnabled", false]],
-        ["haloMinimumAltitude", _options getOrDefault ["haloMinimumAltitude", missionNamespace getVariable ["WALDO_PARA_HALOALTITUDE", 1000]]],
+        ["haloMinimumAltitude", _envelope get "haloMinimumAltitude"],
         ["haloBackpackClass", _options getOrDefault ["haloBackpackClass", missionNamespace getVariable ["WALDO_PARA_HALOCHUTE", "B_Parachute"]]],
         ["requireOpenDoor", _requireDoor]
     ];
@@ -128,20 +141,39 @@ if !(isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropQuickFlightSet
         _jumpConfig set ["staticChuteClass", "NonSteerable_Parachute_F"];
     };
     [_aircraft, _jumpConfig] remoteExec ["Waldo_fnc_ParadropConfigureAircraftLocal", 0, _aircraft];
+    diag_log format [
+        "[WMP PARADROP] Quick flight setup jump envelope: aircraft=%1 static=%2 static-alt=%3-%4m static-speed<=%5 halo=%6 halo-alt>=%7.",
+        typeOf _aircraft, _jumpConfig get "staticJumpEnabled", round (_envelope get "staticMinimumAltitude"), round (_envelope get "staticMaximumAltitude"),
+        round (_envelope get "staticMaximumSpeed"), _jumpConfig get "haloJumpEnabled", round (_envelope get "haloMinimumAltitude")
+    ];
 
-    if (_options getOrDefault ["createMarkers", false]) then {
-        private _direction2 = _resolvedDirection;
+    // On by default: the whole point of this entry point is a mission maker getting a working,
+    // visible drop zone from one line, not a silent invisible route. Set createMarkers to false in
+    // options for a map-clutter-free operation instead.
+    if (_options getOrDefault ["createMarkers", true]) then {
+        private _label = _options getOrDefault ["name", "Drop Zone"];
+        private _runLength = _options getOrDefault ["runLength", 2500];
         private _prefix = format ["Waldo_DZQ_%1", netId _aircraft];
+        private _zoneMarker = createMarker [format ["%1_AREA", _prefix], _centre];
+        _zoneMarker setMarkerShape "RECTANGLE";
+        _zoneMarker setMarkerBrush "Border";
+        _zoneMarker setMarkerDir _resolvedDirection;
+        _zoneMarker setMarkerSize [100, (_runLength * 0.65) max 200];
+        _zoneMarker setMarkerColor "ColorBlack";
         {
             _x params ["_suffix", "_key", "_colour", "_text"];
             private _marker = createMarker [format ["%1_%2", _prefix, _suffix], _route get _key];
             _marker setMarkerShape "RECTANGLE";
             _marker setMarkerBrush "SolidBorder";
-            _marker setMarkerDir _direction2;
+            _marker setMarkerDir _resolvedDirection;
             _marker setMarkerSize [30, 4];
             _marker setMarkerColor _colour;
             _marker setMarkerText _text;
         } forEach [["STANDBY", "standby", "ColorYellow", "STANDBY"], ["GREEN", "green", "ColorGreen", "GREEN LINE"], ["RED", "red", "ColorRed", "RED LINE"]];
+        private _point = createMarker [format ["%1_POINT", _prefix], _centre];
+        _point setMarkerType "mil_end";
+        _point setMarkerColor "ColorBlack";
+        _point setMarkerText _label;
     };
 
     diag_log format ["[WMP PARADROP] Quick flight setup complete: aircraft=%1 pilot=%2 centre=%3 direction=%4 altitude=%5 speed=%6.", typeOf _aircraft, driver _aircraft, _centre, round _resolvedDirection, _altitude, _maxSpeed];

--- a/MissionScripts/Paradrop/paradropRemoveDropZone.sqf
+++ b/MissionScripts/Paradrop/paradropRemoveDropZone.sqf
@@ -12,10 +12,11 @@
  * 2: requester <OBJECT> (default objNull) - curator authorization for remote calls
  * 3: notify requester <BOOL> (default true)
  * 4: delete markers <BOOL> (default true) - explicit removal (this function called directly, e.g.
- *    the ZEN "Remove Operation" module) defaults to tearing down the markers along with everything
- *    else. Automatic cleanup on DESPAWN/aircraft loss instead passes the operation's own configured
- *    removeMarkersOnCleanup option here (default false there - see Waldo_fnc_ParadropCreateDropZone),
- *    so a map marker isn't yanked out from under a mission maker who wanted it left in place.
+ *    the ZEN "Remove Operation" module) always tears down the markers along with everything else.
+ *    Automatic cleanup (on aircraft loss or a DESPAWN pass completing normally) passes the inverse of
+ *    the operation's own configured keepMarkersOnCleanup option here (default false there, so markers
+ *    are deleted by default - see Waldo_fnc_ParadropCreateDropZone), so a mission maker who wants the
+ *    markers left in place can opt out.
  *
  * Return Value: Boolean - true when a registered operation was removed.
  *

--- a/MissionScripts/Paradrop/paradropRemoveDropZone.sqf
+++ b/MissionScripts/Paradrop/paradropRemoveDropZone.sqf
@@ -11,13 +11,18 @@
  * 1: delete aircraft <BOOL> (default true)
  * 2: requester <OBJECT> (default objNull) - curator authorization for remote calls
  * 3: notify requester <BOOL> (default true)
+ * 4: delete markers <BOOL> (default true) - explicit removal (this function called directly, e.g.
+ *    the ZEN "Remove Operation" module) defaults to tearing down the markers along with everything
+ *    else. Automatic cleanup on DESPAWN/aircraft loss instead passes the operation's own configured
+ *    removeMarkersOnCleanup option here (default false there - see Waldo_fnc_ParadropCreateDropZone),
+ *    so a map marker isn't yanked out from under a mission maker who wanted it left in place.
  *
  * Return Value: Boolean - true when a registered operation was removed.
  *
  * Example: ["DZ_ALPHA", true, player, true] remoteExecCall ["Waldo_fnc_ParadropRemoveDropZone", 2];
  * Current callers: ParadropRemoveDropZoneZen, automatic run cleanup and mission scripts.
  */
-params [["_id", "", [""]], ["_deleteAircraft", true, [false]], ["_requester", objNull, [objNull]], ["_notifyRequester", true, [false]]];
+params [["_id", "", [""]], ["_deleteAircraft", true, [false]], ["_requester", objNull, [objNull]], ["_notifyRequester", true, [false]], ["_deleteMarkers", true, [false]]];
 if (!isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropRemoveDropZone", 2]; true};
 if (remoteExecutedOwner > 0) then {
     if (isNull _requester || {owner _requester != remoteExecutedOwner} || {isNull getAssignedCuratorLogic _requester}) exitWith {false};
@@ -25,7 +30,7 @@ if (remoteExecutedOwner > 0) then {
 private _registry = missionNamespace getVariable ["Waldo_Paradrop_DropZones", createHashMap];
 if !(_id in keys _registry) exitWith {false};
 private _state = _registry get _id;
-{deleteMarker _x} forEach (_state getOrDefault ["markers", []]);
+if (_deleteMarkers) then {{deleteMarker _x} forEach (_state getOrDefault ["markers", []])};
 {if (!isNull _x) then {deleteVehicle _x}} forEach (_state getOrDefault ["boardingPoints", []]);
 private _aircraft = _state getOrDefault ["aircraft", objNull];
 if (_deleteAircraft && {!isNull _aircraft} && {(crew _aircraft) findIf {isPlayer _x} >= 0}) then {

--- a/MissionScripts/WaldosFunctions.sqf
+++ b/MissionScripts/WaldosFunctions.sqf
@@ -585,6 +585,9 @@ class CfgFunctions
             class ParadropBuildFlightRoute {
                 file = "MissionScripts\Paradrop\paradropBuildFlightRoute.sqf";
             };
+            class ParadropNormalizeJumpEnvelope {
+                file = "MissionScripts\Paradrop\paradropNormalizeJumpEnvelope.sqf";
+            };
             class ParadropCreateDropZone {
                 file = "MissionScripts\Paradrop\paradropCreateDropZone.sqf";
             };

--- a/MissionScripts/WaldosFunctions.sqf
+++ b/MissionScripts/WaldosFunctions.sqf
@@ -582,8 +582,14 @@ class CfgFunctions
             class JumpSettingsCheck {
                 file = "MissionScripts\Paradrop\checkForJumpSettings.sqf";
             };
+            class ParadropBuildFlightRoute {
+                file = "MissionScripts\Paradrop\paradropBuildFlightRoute.sqf";
+            };
             class ParadropCreateDropZone {
                 file = "MissionScripts\Paradrop\paradropCreateDropZone.sqf";
+            };
+            class ParadropQuickFlightSetup {
+                file = "MissionScripts\Paradrop\paradropQuickFlightSetup.sqf";
             };
             class ParadropConfigureAircraftLocal {
                 file = "MissionScripts\Paradrop\paradropConfigureAircraftLocal.sqf";

--- a/wiki/Vehicle-Actions-&-Paradrop.md
+++ b/wiki/Vehicle-Actions-&-Paradrop.md
@@ -167,15 +167,17 @@ the same route-returned basis, so both entry points behave identically here.
 
 `options` is a HashMap for anything beyond the defaults — jump envelope overrides (falls back to the
 mission's `MissionConfig\airOperationsConfig.sqf` values, then normalized as above), `lifecycle`
-(`LOOP` default / `RETAIN` / `DESPAWN` — `DESPAWN` here only means the markers below are cleaned up
-once the pass completes, not that the aircraft is deleted; this function never owns the aircraft's
-lifecycle), `circuitDirection` (`LEFT` default / `RIGHT`),
-`approachDistance`/`runLength`/`exitDistance`, `name` (marker label, default `"Drop Zone"`), and
+(`LOOP` default / `RETAIN` / `DESPAWN` — this function never deletes the aircraft under any
+lifecycle; `DESPAWN` only changes which waypoints get added and is the trigger point for
+`removeMarkersOnCleanup` below), `circuitDirection` (`LEFT` default / `RIGHT`),
+`approachDistance`/`runLength`/`exitDistance`, `name` (marker label, default `"Drop Zone"`),
 `createMarkers` (**on by default** — AREA/STANDBY/GREEN/RED/POINT markers in the same layout as
 `Waldo_fnc_ParadropCreateDropZone`, so you get a visible working drop zone immediately; pass `false`
-for a map-clutter-free operation). Markers are removed automatically once the aircraft is
-destroyed/deleted, or once a `DESPAWN` run reaches its exit point. See the script's own header for
-the complete list and a HALO one-shot example.
+for a map-clutter-free operation), and `removeMarkersOnCleanup` (**off by default** — the markers are
+left on the map even after the aircraft is gone, since a mission maker who placed a drop zone marker
+generally wants it to stay; set `true` to remove them automatically once the aircraft is
+destroyed/deleted, or once a `DESPAWN` run reaches its exit point — this never affects the aircraft
+or crew either way). See the script's own header for the complete list and a HALO one-shot example.
 
 This shares its actual flight-route logic (`Waldo_fnc_ParadropBuildFlightRoute`) with the fuller
 Dynamic Drop-Zone system below — the same proven standby/green/red/exit route and the same
@@ -200,7 +202,11 @@ line or HALO method.
 
 Post-pass behavior is explicit: **Loop and repeat** flies a wide left- or right-hand circuit through
 a point behind the original spawn before beginning the next aligned run; **Single pass - retain**
-loiters beyond the exit; **Single pass - despawn** cleans the aircraft and operation. Speed input is
+loiters beyond the exit; **Single pass - despawn** deletes the aircraft, its crew and the operation
+(a lost aircraft is cleaned up the same way). The map markers created for the operation are **left in
+place** by this automatic cleanup unless you check **Remove markers when the operation ends
+automatically** in the create dialog (`removeMarkersOnCleanup`, off by default) — explicitly using
+**Paradrop - Remove Operation** always removes the markers regardless of that setting. Speed input is
 in km/h and is converted to the engine's metres-per-second `forceSpeed` unit.
 
 The create dialog independently enables and configures static-line and HALO player actions. Static
@@ -227,7 +233,9 @@ PARADROP** and **CREATE QA BOARDING POINT** controls.
 
 Optional global map symbology includes the overall rectangular drop zone, small standby/green/red
 line rectangles and a named point marker. Arma itself makes these global markers available to JIP
-clients. The removal module cleans the markers and can delete the operation aircraft.
+clients. **Paradrop - Remove Operation** always cleans the markers (and can delete the operation
+aircraft); the automatic cleanup on a despawn pass or aircraft loss only removes them if
+`removeMarkersOnCleanup` was enabled at creation.
 
 Mission makers can extend the friendly-name dropdowns before startup:
 
@@ -250,7 +258,8 @@ private _drop = createHashMapFromArray [
     ["staticMaximumAltitude", 350], ["staticMaximumSpeed", 310],
     ["staticChuteClass", "NonSteerable_Parachute_F"],
     ["haloJumpEnabled", false], ["haloBackpackClass", "B_Parachute"],
-    ["jumperCount", 0], ["autoDropPlayers", false], ["createMarkers", true]
+    ["jumperCount", 0], ["autoDropPlayers", false], ["createMarkers", true],
+    ["removeMarkersOnCleanup", false]
 ];
 [_drop] call Waldo_fnc_ParadropCreateDropZone;
 ```

--- a/wiki/Vehicle-Actions-&-Paradrop.md
+++ b/wiki/Vehicle-Actions-&-Paradrop.md
@@ -153,12 +153,22 @@ reason a hand-set-up paradrop plane behaves unpredictably (wandering off the jum
 altitude/speed, or never turning back for another pass). If you want to keep your own waypoints,
 don't call this function — set the aircraft up manually instead (see below).
 
+Whatever static-line/HALO envelope you request (or the mission's configured defaults) is passed
+through `Waldo_fnc_ParadropNormalizeJumpEnvelope` before the jump action is installed, which clamps
+it to stay reachable at the route's actual altitude/speed. This is the fix for a jump action that
+never becomes available at all: the hold-action's live condition checks the aircraft's altitude and
+speed against that envelope every frame, and a route altitude/speed set independently of the
+envelope is exactly how the two end up unable to ever agree. `Waldo_fnc_ParadropCreateDropZone`
+normalizes the same way, so both entry points behave identically here.
+
 `options` is a HashMap for anything beyond the defaults — jump envelope overrides (falls back to the
-mission's `MissionConfig\airOperationsConfig.sqf` values), `lifecycle` (`LOOP` default / `RETAIN` /
-`DESPAWN`), `circuitDirection` (`LEFT` default / `RIGHT`), `approachDistance`/`runLength`/
-`exitDistance`, and `createMarkers` (off by default — this entry point is deliberately map-clutter-free
-unless you ask for the standby/green/red lines). See the script's own header for the complete list
-and a HALO one-shot example.
+mission's `MissionConfig\airOperationsConfig.sqf` values, then normalized as above), `lifecycle`
+(`LOOP` default / `RETAIN` / `DESPAWN`), `circuitDirection` (`LEFT` default / `RIGHT`),
+`approachDistance`/`runLength`/`exitDistance`, `name` (marker label, default `"Drop Zone"`), and
+`createMarkers` (**on by default** — AREA/STANDBY/GREEN/RED/POINT markers in the same layout as
+`Waldo_fnc_ParadropCreateDropZone`, so you get a visible working drop zone immediately; pass `false`
+for a map-clutter-free operation). See the script's own header for the complete list and a HALO
+one-shot example.
 
 This shares its actual flight-route logic (`Waldo_fnc_ParadropBuildFlightRoute`) with the fuller
 Dynamic Drop-Zone system below — the same proven standby/green/red/exit route and the same

--- a/wiki/Vehicle-Actions-&-Paradrop.md
+++ b/wiki/Vehicle-Actions-&-Paradrop.md
@@ -216,8 +216,8 @@ steerable parachute backpack and minimum altitude. The optional door requirement
 for airframes whose ramp animations are not among the supported names. Both action sets are
 installed for current clients and JIP clients. The authoritative creation API normalizes enabled
 jump envelopes against the requested route: the route altitude remains inside each enabled
-altitude window, static-line maximum speed stays at least 40 km/h above capped route speed, and an
-unsupported door-animation requirement is disabled. Automatic sequencing also switches to the
+altitude window with margin to absorb normal AI autopilot wander, static-line maximum speed stays
+at least 60 km/h above capped route speed, and an unsupported door-animation requirement is disabled. Automatic sequencing also switches to the
 enabled alternative or turns itself off instead of silently selecting a disabled jump method.
 
 **Paradrop - Embark Players** uses the player directly underneath the placed module first, then the

--- a/wiki/Vehicle-Actions-&-Paradrop.md
+++ b/wiki/Vehicle-Actions-&-Paradrop.md
@@ -129,6 +129,45 @@ This is added automatically alongside jump actions. No setup required.
 
 ---
 
+## Reliable Quick Flight Setup
+
+_Associated Files: `MissionScripts\Paradrop\paradropQuickFlightSetup.sqf`,
+`MissionScripts\Paradrop\paradropBuildFlightRoute.sqf`_
+
+For a plane you've already placed and crewed yourself in Eden, one call in its init field gives it a
+reliable AI-flown paradrop route — no ZEN, no registry, no generated jumpers:
+
+```sqf
+[this, "dz1"] call Waldo_fnc_ParadropQuickFlightSetup;
+```
+
+Arguments: `[aircraft, target, direction, altitude, maxSpeed, options]`. `target` accepts a marker
+name, a position, or an object; `direction` (`-1` by default) is computed automatically from the
+aircraft's position toward the target if you don't set one. It waits (up to 30 seconds) for a pilot
+to exist before doing anything, so it's safe to place alongside a separate `Waldo_fnc_MoveInCargoPlane`
+call on another object in the same composition — both init fields can run in any order.
+
+The aircraft's own existing waypoints are cleared before the generated route is added. This matters:
+a leftover Eden waypoint competing with a scripted route for the AI's attention is the most common
+reason a hand-set-up paradrop plane behaves unpredictably (wandering off the jump run, ignoring
+altitude/speed, or never turning back for another pass). If you want to keep your own waypoints,
+don't call this function — set the aircraft up manually instead (see below).
+
+`options` is a HashMap for anything beyond the defaults — jump envelope overrides (falls back to the
+mission's `MissionConfig\airOperationsConfig.sqf` values), `lifecycle` (`LOOP` default / `RETAIN` /
+`DESPAWN`), `circuitDirection` (`LEFT` default / `RIGHT`), `approachDistance`/`runLength`/
+`exitDistance`, and `createMarkers` (off by default — this entry point is deliberately map-clutter-free
+unless you ask for the standby/green/red lines). See the script's own header for the complete list
+and a HALO one-shot example.
+
+This shares its actual flight-route logic (`Waldo_fnc_ParadropBuildFlightRoute`) with the fuller
+Dynamic Drop-Zone system below — the same proven standby/green/red/exit route and the same
+altitude/speed handling, so both paths fly identically once airborne. Use the Dynamic Drop-Zone
+system instead when you want a managed, repeatable operation with generated AI jumpers, a Zeus
+create/remove workflow, or map symbology by default.
+
+---
+
 ## Dynamic Drop-Zone Operations
 
 ZEN provides **Paradrop - Create Drop Zone**, **Paradrop - Embark Players** and **Paradrop - Remove

--- a/wiki/Vehicle-Actions-&-Paradrop.md
+++ b/wiki/Vehicle-Actions-&-Paradrop.md
@@ -168,16 +168,16 @@ the same route-returned basis, so both entry points behave identically here.
 `options` is a HashMap for anything beyond the defaults — jump envelope overrides (falls back to the
 mission's `MissionConfig\airOperationsConfig.sqf` values, then normalized as above), `lifecycle`
 (`LOOP` default / `RETAIN` / `DESPAWN` — this function never deletes the aircraft under any
-lifecycle; `DESPAWN` only changes which waypoints get added and is the trigger point for
-`removeMarkersOnCleanup` below), `circuitDirection` (`LEFT` default / `RIGHT`),
+lifecycle; `DESPAWN` only changes which waypoints get added and is one of the two automatic
+marker-cleanup triggers below), `circuitDirection` (`LEFT` default / `RIGHT`),
 `approachDistance`/`runLength`/`exitDistance`, `name` (marker label, default `"Drop Zone"`),
 `createMarkers` (**on by default** — AREA/STANDBY/GREEN/RED/POINT markers in the same layout as
 `Waldo_fnc_ParadropCreateDropZone`, so you get a visible working drop zone immediately; pass `false`
-for a map-clutter-free operation), and `removeMarkersOnCleanup` (**off by default** — the markers are
-left on the map even after the aircraft is gone, since a mission maker who placed a drop zone marker
-generally wants it to stay; set `true` to remove them automatically once the aircraft is
-destroyed/deleted, or once a `DESPAWN` run reaches its exit point — this never affects the aircraft
-or crew either way). See the script's own header for the complete list and a HALO one-shot example.
+for a map-clutter-free operation), and `keepMarkersOnCleanup` (**off by default** — the markers are
+removed automatically once the aircraft is destroyed/deleted, or once a `DESPAWN` run reaches its
+exit point, since a marker for a drop zone that's no longer active is just stale; set `true` to leave
+them on the map instead — this never affects the aircraft or crew either way). See the script's own
+header for the complete list and a HALO one-shot example.
 
 This shares its actual flight-route logic (`Waldo_fnc_ParadropBuildFlightRoute`) with the fuller
 Dynamic Drop-Zone system below — the same proven standby/green/red/exit route and the same
@@ -203,9 +203,10 @@ line or HALO method.
 Post-pass behavior is explicit: **Loop and repeat** flies a wide left- or right-hand circuit through
 a point behind the original spawn before beginning the next aligned run; **Single pass - retain**
 loiters beyond the exit; **Single pass - despawn** deletes the aircraft, its crew and the operation
-(a lost aircraft is cleaned up the same way). The map markers created for the operation are **left in
-place** by this automatic cleanup unless you check **Remove markers when the operation ends
-automatically** in the create dialog (`removeMarkersOnCleanup`, off by default) — explicitly using
+(a lost aircraft is cleaned up the same way). The map markers created for the operation are **removed
+automatically** along with this cleanup, since a marker for a drop zone that's no longer active is
+just stale — check **Keep markers when the operation ends automatically** in the create dialog
+(`keepMarkersOnCleanup`, off by default) to leave them on the map instead. Explicitly using
 **Paradrop - Remove Operation** always removes the markers regardless of that setting. Speed input is
 in km/h and is converted to the engine's metres-per-second `forceSpeed` unit.
 
@@ -234,8 +235,8 @@ PARADROP** and **CREATE QA BOARDING POINT** controls.
 Optional global map symbology includes the overall rectangular drop zone, small standby/green/red
 line rectangles and a named point marker. Arma itself makes these global markers available to JIP
 clients. **Paradrop - Remove Operation** always cleans the markers (and can delete the operation
-aircraft); the automatic cleanup on a despawn pass or aircraft loss only removes them if
-`removeMarkersOnCleanup` was enabled at creation.
+aircraft); the automatic cleanup on a despawn pass or aircraft loss removes them too unless
+`keepMarkersOnCleanup` was enabled at creation.
 
 Mission makers can extend the friendly-name dropdowns before startup:
 
@@ -259,7 +260,7 @@ private _drop = createHashMapFromArray [
     ["staticChuteClass", "NonSteerable_Parachute_F"],
     ["haloJumpEnabled", false], ["haloBackpackClass", "B_Parachute"],
     ["jumperCount", 0], ["autoDropPlayers", false], ["createMarkers", true],
-    ["removeMarkersOnCleanup", false]
+    ["keepMarkersOnCleanup", false]
 ];
 [_drop] call Waldo_fnc_ParadropCreateDropZone;
 ```

--- a/wiki/Vehicle-Actions-&-Paradrop.md
+++ b/wiki/Vehicle-Actions-&-Paradrop.md
@@ -151,24 +151,31 @@ The aircraft's own existing waypoints are cleared before the generated route is 
 a leftover Eden waypoint competing with a scripted route for the AI's attention is the most common
 reason a hand-set-up paradrop plane behaves unpredictably (wandering off the jump run, ignoring
 altitude/speed, or never turning back for another pass). If you want to keep your own waypoints,
-don't call this function — set the aircraft up manually instead (see below).
+don't call this function — set the aircraft up manually instead (see below). If the pilot's Eden
+group has other units besides this aircraft's crew (a squad leader who's also the pilot, a
+multi-crew group with members elsewhere), the crew is automatically moved into a dedicated fresh
+group first, so those other units keep their own waypoints untouched.
 
 Whatever static-line/HALO envelope you request (or the mission's configured defaults) is passed
-through `Waldo_fnc_ParadropNormalizeJumpEnvelope` before the jump action is installed, which clamps
-it to stay reachable at the route's actual altitude/speed. This is the fix for a jump action that
-never becomes available at all: the hold-action's live condition checks the aircraft's altitude and
-speed against that envelope every frame, and a route altitude/speed set independently of the
-envelope is exactly how the two end up unable to ever agree. `Waldo_fnc_ParadropCreateDropZone`
-normalizes the same way, so both entry points behave identically here.
+through `Waldo_fnc_ParadropNormalizeJumpEnvelope` before the jump action is installed, using the same
+clamped altitude/speed the route was actually built with — not your raw input — so it stays
+reachable no matter what altitude/speed you pass in. This is the fix for a jump action that never
+becomes available at all: the hold-action's live condition checks the aircraft's altitude and speed
+against that envelope every frame, and a route altitude/speed set independently of the envelope is
+exactly how the two end up unable to ever agree. `Waldo_fnc_ParadropCreateDropZone` normalizes off
+the same route-returned basis, so both entry points behave identically here.
 
 `options` is a HashMap for anything beyond the defaults — jump envelope overrides (falls back to the
 mission's `MissionConfig\airOperationsConfig.sqf` values, then normalized as above), `lifecycle`
-(`LOOP` default / `RETAIN` / `DESPAWN`), `circuitDirection` (`LEFT` default / `RIGHT`),
+(`LOOP` default / `RETAIN` / `DESPAWN` — `DESPAWN` here only means the markers below are cleaned up
+once the pass completes, not that the aircraft is deleted; this function never owns the aircraft's
+lifecycle), `circuitDirection` (`LEFT` default / `RIGHT`),
 `approachDistance`/`runLength`/`exitDistance`, `name` (marker label, default `"Drop Zone"`), and
 `createMarkers` (**on by default** — AREA/STANDBY/GREEN/RED/POINT markers in the same layout as
 `Waldo_fnc_ParadropCreateDropZone`, so you get a visible working drop zone immediately; pass `false`
-for a map-clutter-free operation). See the script's own header for the complete list and a HALO
-one-shot example.
+for a map-clutter-free operation). Markers are removed automatically once the aircraft is
+destroyed/deleted, or once a `DESPAWN` run reaches its exit point. See the script's own header for
+the complete list and a HALO one-shot example.
 
 This shares its actual flight-route logic (`Waldo_fnc_ParadropBuildFlightRoute`) with the fuller
 Dynamic Drop-Zone system below — the same proven standby/green/red/exit route and the same


### PR DESCRIPTION
**When merged this pull request will:**

Address the v4.8.1 known issue: "HALO/HAHO paradrop scripts work, but getting them in a position to work is hard."

**The problem:** the pack had two disconnected paradrop flight paths. `Waldo_fnc_VehicleJumpSetup` (the composition-friendly, one-line-init-field path) only ever added the jump action — it never flew the plane anywhere, leaving mission makers to hand-place Eden waypoints, which routinely fight a plane's own default routing and are the most common reason a "should be simple" paradrop setup misbehaves. Meanwhile `Waldo_fnc_ParadropCreateDropZone` (the newer, ZEN-driven Dynamic Drop Zone system) already has a proven, reliable standby/green/red/exit AI flight route with correct altitude/speed handling — but that logic was only reachable through the full dynamic-spawn/registry system, not available to a mission maker who just wants their own placed plane to fly properly.

Even once flying reliably, a plane's actual route altitude/speed and its configured jump envelope (`WALDO_STATIC_MINALTITUDE`/`MAXALTITUDE`/`MAXSPEED`, `WALDO_PARA_HALOALTITUDE`) were set completely independently — so it was easy to end up with a plane cruising outside its own jump action's live altitude/speed condition, leaving the hold-action permanently unavailable with no obvious cause.

**What this adds:**
- `MissionScripts/Paradrop/paradropBuildFlightRoute.sqf` (`Waldo_fnc_ParadropBuildFlightRoute`) — the Dynamic Drop Zone system's route-building logic extracted into its own reusable function: same route math, same km/h-vs-m/s speed handling, plus it now clears the target group's existing waypoints before adding the new route (the concrete fix for waypoints fighting each other), and returns its own clamped altitude/maxSpeed so callers can reason about what the aircraft is actually flying at.
- `MissionScripts/Paradrop/paradropNormalizeJumpEnvelope.sqf` (`Waldo_fnc_ParadropNormalizeJumpEnvelope`) — clamps a requested/configured static-line and HALO jump envelope so it's always reachable at a given route altitude/speed (minimum altitude below cruise, maximum altitude/speed with headroom above it). Shared by both entry points below, normalized off the route builder's own returned altitude/speed so a plane's flight route and its jump action can never disagree. Buffers are sized to absorb normal AI `flyInHeight`/`limitSpeed` autopilot wander while staying inside the natural headroom the pack's own shipped `WALDO_STATIC_`/`WALDO_PARA_` defaults already leave around the route builder's default 250m/220km-h — an untouched default configuration is never altered by this function, only a genuinely incompatible custom combination is.
- `paradropCreateDropZone.sqf` refactored to call both shared functions instead of inlining the same logic, and to normalize off the route-returned altitude/speed rather than its own separately-clamped locals — pure refactor plus the same single-source-of-truth fix as the quick-setup entry point below.
- `MissionScripts/Paradrop/paradropQuickFlightSetup.sqf` (`Waldo_fnc_ParadropQuickFlightSetup`) — the simple, mission-maker-facing entry point: one call in a placed-and-crewed aircraft's init field gives it the same reliable route, a normalized jump envelope, and the configured jump action, no registry or generated jumpers required. Waits (bounded, 30s) for a pilot so it's order-independent with a separate `Waldo_fnc_MoveInCargoPlane` call; reuses the exact same `Waldo_fnc_ParadropConfigureAircraftLocal` jump-action installer the Dynamic Drop Zone system already uses, so both paths behave identically once airborne; falls back to the vanilla parachute class if a configured mod chute isn't loaded. `createMarkers` defaults to `true` (AREA/STANDBY/GREEN/RED/POINT markers, same layout as `ParadropCreateDropZone`, plus a `name` label option) so a mission maker gets a working, visible drop zone from the one call — pass `false` for a map-clutter-free operation.

**Review fixes:** a deliberate review pass over this system (route builder, quick setup, envelope normalizer, drop-zone system, jump-action conditions, the ZEN module, and the shipped example compositions) found and fixed:
- **Marker leak** — `ParadropQuickFlightSetup`'s markers were never tracked or cleaned up anywhere, and `lifecycle: "DESPAWN"` had no actual effect beyond changing which waypoints got added. Added a cleanup watcher that removes the markers once the aircraft is destroyed/deleted, or once a `DESPAWN` run reaches its exit point — matching `ParadropCreateDropZone`'s own automatic cleanup. A `keepMarkersOnCleanup` option (default `false`) lets a mission maker opt out and leave the markers on the map. Neither path ever deletes the aircraft or crew via this function, since it never owned their lifecycle in the first place (unlike `ParadropCreateDropZone`, whose automatic cleanup does delete the aircraft it spawned — and now respects the same `keepMarkersOnCleanup` option for its markers).
- **Envelope basis drift** — the route builder clamped altitude/speed internally but discarded the clamped values, so `QuickFlightSetup` was normalizing its jump envelope off raw, unclamped input. It now returns its clamped `altitude`/`maxSpeed`, and both entry points normalize off that single shared basis.
- **Waypoint-wipe blast radius** — `ParadropBuildFlightRoute` clears every waypoint of the group it's given; `QuickFlightSetup` used the pilot's actual Eden group, which could silently wipe waypoints belonging to other units sharing that group. It now isolates the aircraft's crew into a dedicated fresh group first, only when the group actually has other members.
- **Unbounded wait loop** — bounded the previously-unbounded `WALDO_INIT_COMPLETE` wait (30s, matching the pilot wait right after it).
- **`requireOpenDoor` default mismatch** — aligned `ParadropCreateDropZone` and the ZEN "Dynamic Paradrop" dialog to default `true`, matching `QuickFlightSetup`'s existing default; the check already self-disables for airframes without a recognised door/ramp animation.
- **Doc bug** — the skill reference documented Dynamic Drop Zone `lifecycle` values as `SINGLE_RETAIN`/`SINGLE_DESPAWN`, contradicting both the code and its own other section; fixed to `RETAIN`/`DESPAWN`.
- **Buffer regression** — a follow-up buffer-widening pass (25→50/75→120/40→60/0→50m) accidentally exceeded the natural headroom the shipped `WALDO_STATIC_MAXALTITUDE` default (350m) leaves above the route builder's default 250m cruise, so an untouched default mission config was silently having its configured 350m ceiling raised to 370m. Reduced the static-max-altitude buffer to 90m, which stays inside that headroom — defaults now normalize to themselves unchanged, while still meaningfully wider than the original insufficient 75m for real custom configurations.

**Example compositions wired up:** both aircraft in "[WMP] Halo And Static-Line Paradrop Examples" previously used the old `Waldo_fnc_VehicleJumpSetup` + hand-placed Eden waypoints pattern this feature exists to replace. Their `init=` lines now call `Waldo_fnc_ParadropQuickFlightSetup` directly (static-line aircraft → `"dz1"`, HALO aircraft → `"dz2"`, same altitude/speed the mission author had already configured) — only the two aircraft's own init strings were touched, not the surrounding waypoint/group/position data, since this serialized `.sqe` format can't be verified in Eden Editor from here. Place a `"dz1"`/`"dz2"` marker nearby to give each aircraft a target.

**Scope note:** as above, the compositions are now wired but unverified in-Eden — worth a visual sanity check before treating as final.

All validators pass: `sqf_validator` (891 files), `config_style_checker`, `wiki_style_checker`, `documentation_contract_checker`, `claude_skill_validator`, `zeus_script_parity_checker`, `performance_audit` (no new high-severity recurring patterns), `git diff --check`. As always, static validation isn't a substitute for an in-editor/dedicated-server flight test.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq

---
_Generated by [Claude Code](https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq)_