### PR TITLE
Fix Field Resupply activation race between broadcast Enable flag and init (locality audit)

### DIFF
--- a/MissionScripts/Logistics/FieldResupply/fieldResupplyInit.sqf
+++ b/MissionScripts/Logistics/FieldResupply/fieldResupplyInit.sqf
@@ -9,7 +9,9 @@
  * again after assignment, runtime activation, JIP or respawn and never publishes authoritative
  * carrier state from the client.
  *
- * Arguments: None.
+ * Arguments:
+ * 0: retries remaining <NUMBER> (default 20) - internal, used only by this function's own
+ *    Waldo_FieldResupply_Enable replication retry below; callers should never pass it.
  *
  * Return Value:
  * Boolean - true when controls already exist or were installed; false when unavailable/disabled.
@@ -20,6 +22,7 @@
  * Current callers: initPlayerLocal.sqf, FieldResupplyAssignCarrier and the local respawn handler.
  */
 
+params [["_retriesRemaining", 20, [0]]];
 if !(hasInterface) exitWith {false};
 if !(missionNamespace getVariable ["Waldo_FeatureRuntimeSnapshotReceived", isServer]) exitWith {
     [] spawn {
@@ -33,7 +36,22 @@ if !(missionNamespace getVariable ["Waldo_FeatureRuntimeSnapshotReceived", isSer
     };
     true
 };
-if !(missionNamespace getVariable ["Waldo_FieldResupply_Enable", false]) exitWith {false};
+// Waldo_FieldResupply_Enable can be turned on mid-mission (a hub registered after players already
+// joined) via a broadcast setVariable [...,true] paired with a directly targeted remoteExecCall to
+// this same function in the same frame. Those two network messages have no ordering guarantee
+// between them, so the direct call can legitimately arrive here before the broadcast replicates -
+// which would otherwise make a perfectly valid activation look disabled and silently skip
+// installing the player's interaction menu with no retry. Give the broadcast a brief, bounded
+// window to catch up before treating it as genuinely disabled.
+if !(missionNamespace getVariable ["Waldo_FieldResupply_Enable", false]) exitWith {
+    if (_retriesRemaining <= 0) exitWith {false};
+    [_retriesRemaining - 1] spawn {
+        params ["_retriesRemaining"];
+        sleep 0.1;
+        [_retriesRemaining] call Waldo_fnc_FieldResupplyInit;
+    };
+    false
+};
 if (player getVariable ["Waldo_FieldResupply_ActionInstalled", false]) exitWith {true};
 
 private _inspect = {


### PR DESCRIPTION
**When merged this pull request will:**

Address the requested locality-issues audit across the pack, as a follow-up to PR #61 (Transport Services / Improved Helicopter Landing).

**Methodology:** searched for the same anti-pattern class already found and fixed in PR #61 — a directly-targeted `remoteExecCall` (going straight to one owner/machine) arriving before a same-frame broadcast `setVariable [..., true]` on the same object/namespace has replicated to that machine. This is a well-known Arma MP synchronization gap: those two message types travel separate network paths with no relative ordering guarantee between them.

Checked systematically:
- Every `if (!isServer) exitWith` guard for missing forward-to-server calls (spot-checked ~15; all either forward correctly or are already only reachable from already-server-side call sites).
- Every function comparing a directly-passed identifier against a `getVariable [..., -1]`-style staleness guard (~25 occurrences) for the same-frame broadcast-vs-remoteExec race shape.
- AI/vehicle waypoint and movement commands issued without an explicit `local` check, to confirm they're safe (they are: in every instance found, the object/group was just `createVehicle`/`createGroup`'d server-side in the same function, which is locally owned by the server at creation until crew/ownership migrates — no locality gap).

**Found and fixed:** Field Resupply's mid-mission activation reachable through two paths — `Waldo_fnc_FieldResupplyRegisterHub` and `Waldo_fnc_FieldResupplyAssignCarrier` — sets `Waldo_FieldResupply_Enable` via a broadcast `setVariable` and, in the same operation, directly dispatches `Waldo_fnc_FieldResupplyInit` to install a player's interaction menu.

Every *other* feature routed through the shared `Waldo_fnc_FeatureRuntimeApply` mechanism (Persistence, Treatment Feedback, Tree Felling, Emergency Dismount, Rally, AI Rebalance, Breaching) consistently reuses the *same* `remoteExec` target parameter for both the ordered settings payload (`Waldo_fnc_FeatureRuntimeReceiveState`) and the following initializer call — which Bohemia's engine does guarantee relative delivery order for, since both come from the same source to the same target. Field Resupply's two registration functions are the exception: the hub-registration path mixes different `remoteExec` target parameters between the two calls (`-2` then `0`), and the carrier-assignment path relies on a plain broadcast variable outside that ordered mechanism entirely. Either path can race — the direct initializer call can arrive before the broadcast `Enable` flag replicates, hitting a **one-shot, non-retrying** bail-out at the top of `Waldo_fnc_FieldResupplyInit`, so a player silently never gets their Field Resupply interaction menu installed for that activation.

**Fix:** `MissionScripts/Logistics/FieldResupply/fieldResupplyInit.sqf` now retries briefly (up to 2 seconds) instead of bailing out immediately when `Enable` reads false — mirroring the same bounded-retry approach already used for Transport Services' request-ID check in PR #61. Fixed at the receiving end so it protects every caller regardless of which one triggers the race, rather than patching each call site separately.

**Audited and confirmed *not* affected** by this race class (so left unchanged): the general `Waldo_fnc_FeatureRuntimeApply`-routed feature toggles listed above; Transport Services' own vehicle action setup and Field Resupply's ACE/vanilla action *conditions* (both re-evaluate their guard variables live every time the interaction menu opens rather than deciding once, so a brief replication delay self-heals instead of failing permanently — only a cosmetic display-name risk was noted there, out of scope); and every AI/vehicle command site checked.

All validators pass: `sqf_validator` (888 files), `config_style_checker`, `zeus_script_parity_checker`, `performance_audit` (no new high-severity recurring patterns), `documentation_contract_checker`, `git diff --check`. As with PR #61, this is a code-level race identified through careful tracing of the network/ordering model, not an in-game repro — static analysis isn't a substitute for an in-editor/dedicated-server test with a live Field Resupply setup.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq

---
_Generated by [Claude Code](https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq)_