### PR TITLE
Wire paradrop compositions to quick flight setup, fix envelope buffer regression + missing-marker clarity

### DIFF
--- a/.claude/skills/mission-pack-config/references/paradrop.md
+++ b/.claude/skills/mission-pack-config/references/paradrop.md
@@ -66,14 +66,20 @@ plane anywhere.** For that, see the next two sections.
 ## Reliable AI flight — quick setup (`Waldo_fnc_ParadropQuickFlightSetup`)
 
 The simple alternative to the full Dynamic Drop Zone system below, for an
-aircraft the mission maker already placed and crewed in Eden. One call in
-the object's init field:
+aircraft the mission maker already placed and crewed in Eden. Two steps:
+place a named marker as the drop zone, then one call in the object's init
+field:
 
 ```sqf
 [this, "dz1"] call Waldo_fnc_ParadropQuickFlightSetup;
 // [aircraft, target(marker name/position/object), direction(-1=auto), altitude, maxSpeed, options]
 ```
 
+- `target` as a marker name is the beginner-friendly option: place a
+  marker anywhere in Eden, name it, reference that name here — no
+  coordinate math. If the marker was never placed or the name doesn't
+  match exactly, this is reported in-game via `systemChat`, not just the
+  RPT log — the #1 beginner mistake with this function.
 - Builds a reliable standby → green → red → exit AI route (looping by
   default) using the exact same route logic as the Dynamic Drop Zone system
   (`Waldo_fnc_ParadropBuildFlightRoute`) — both stay in sync, fixes to one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,10 @@ drop point, plus the configured jump action — without the full Dynamic Drop Zo
 // [aircraft, target(marker name/position/object), direction(-1 = auto), altitude, maxSpeed, options]
 ```
 
+`target` as a marker name is the beginner-friendly option: place a named marker in Eden and
+reference it here, no coordinate math needed. A marker that was never placed or is misnamed is
+reported in-game via `systemChat`, not just the RPT log.
+
 It clears the aircraft's existing waypoints before adding the generated route — leftover Eden
 waypoints fighting a scripted route is the single most common reason a hand-wired paradrop plane
 was unreliable. If the pilot's group has other units besides this aircraft's crew, the crew is

--- a/MissionScripts/Paradrop/paradropNormalizeJumpEnvelope.sqf
+++ b/MissionScripts/Paradrop/paradropNormalizeJumpEnvelope.sqf
@@ -23,10 +23,13 @@
  * they're offered, and AI flyInHeight/limitSpeed autopilot routinely wanders a few metres/km-h
  * around its nominal route target rather than holding it exactly. A margin sized to the route's
  * commanded value alone would flicker the action on and off with that normal wander; these margins
- * are deliberately generous enough to absorb it:
+ * are deliberately generous enough to absorb it, while staying inside the natural headroom the
+ * pack's own shipped WALDO_STATIC_/WALDO_PARA_ defaults already leave around the route builder's
+ * own default 250 m / 220 km/h - a mission maker's untouched preset values are never widened by
+ * this function, only a genuinely incompatible custom combination is:
  * - staticMinimumAltitude never exceeds route altitude - 50 m (a static-line jumper must be able to
  *   release at least 50 m below the route's cruise altitude).
- * - staticMaximumAltitude never falls below route altitude + 120 m (route altitude must sit well
+ * - staticMaximumAltitude never falls below route altitude + 90 m (route altitude must sit well
  *   inside the static-line window, not near its edge).
  * - staticMaximumSpeed never falls below route speed + 60 km/h (the aircraft's actual cruise speed
  *   must stay comfortably under the jump's speed ceiling, not brush against it).
@@ -50,8 +53,12 @@ params [
 
 // Buffers absorb normal AI flyInHeight/limitSpeed wander around the route's commanded
 // altitude/speed so a brief autopilot dip/spike doesn't flicker the jump hold-action unavailable.
+// Each is sized to stay inside the natural headroom the shipped WALDO_STATIC_/WALDO_PARA_ defaults
+// (180/350/310/1000) already leave around the route builder's own default 250 m / 220 km/h, so an
+// untouched default configuration is never altered by this function - only genuinely incompatible
+// custom altitude/speed/envelope combinations are.
 private _staticMinAltitudeBuffer = 50;
-private _staticMaxAltitudeBuffer = 120;
+private _staticMaxAltitudeBuffer = 90;
 private _staticMaxSpeedBuffer = 60;
 private _haloMinAltitudeBuffer = 50;
 

--- a/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
+++ b/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
@@ -119,8 +119,8 @@ if !(isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropQuickFlightSet
     // rejection rather than folding into the generic "didn't resolve" case below.
     private _missingMarker = typeName _target == "STRING" && {_target != ""} && {markerType _target == ""};
     if (_missingMarker) exitWith {
-        private _message = format ["[WMP PARADROP] %1 has no flight target: place a map marker named ""%2"" (Eden Editor > Markers) for it to fly toward.", typeOf _aircraft, _target];
-        diag_log format ["[WMP PARADROP] Quick flight setup rejected for %1: marker ""%2"" does not exist.", typeOf _aircraft, _target];
+        private _message = format ["[WMP PARADROP] %1 has no flight target: place a map marker named %2 (Eden Editor > Markers) for it to fly toward.", typeOf _aircraft, _target];
+        diag_log format ["[WMP PARADROP] Quick flight setup rejected for %1: marker %2 does not exist.", typeOf _aircraft, _target];
         [_message] remoteExec ["systemChat", 0];
     };
     private _centre = switch (typeName _target) do {

--- a/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
+++ b/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
@@ -121,7 +121,7 @@ if !(isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropQuickFlightSet
     if (_missingMarker) exitWith {
         private _message = format ["[WMP PARADROP] %1 has no flight target: place a map marker named ""%2"" (Eden Editor > Markers) for it to fly toward.", typeOf _aircraft, _target];
         diag_log format ["[WMP PARADROP] Quick flight setup rejected for %1: marker ""%2"" does not exist.", typeOf _aircraft, _target];
-        _message remoteExec ["systemChat", 0];
+        [_message] remoteExec ["systemChat", 0];
     };
     private _centre = switch (typeName _target) do {
         case "STRING": {if (_target == "") then {[]} else {getMarkerPos _target}};

--- a/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
+++ b/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
@@ -119,8 +119,8 @@ if !(isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropQuickFlightSet
     // rejection rather than folding into the generic "didn't resolve" case below.
     private _missingMarker = typeName _target == "STRING" && {_target != ""} && {markerType _target == ""};
     if (_missingMarker) exitWith {
-        private _message = format ["[WMP PARADROP] %1 has no flight target: place a map marker named \"%2\" (Eden Editor > Markers) for it to fly toward.", typeOf _aircraft, _target];
-        diag_log format ["[WMP PARADROP] Quick flight setup rejected for %1: marker \"%2\" does not exist.", typeOf _aircraft, _target];
+        private _message = format ["[WMP PARADROP] %1 has no flight target: place a map marker named ""%2"" (Eden Editor > Markers) for it to fly toward.", typeOf _aircraft, _target];
+        diag_log format ["[WMP PARADROP] Quick flight setup rejected for %1: marker ""%2"" does not exist.", typeOf _aircraft, _target];
         _message remoteExec ["systemChat", 0];
     };
     private _centre = switch (typeName _target) do {

--- a/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
+++ b/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
@@ -33,7 +33,10 @@
  * Arguments:
  * 0: aircraft <OBJECT> - placed, ideally already crewed with a pilot (e.g. via
  *    Waldo_fnc_MoveInCargoPlane in the object's own init field, or an Eden-assigned crew).
- * 1: target <STRING, ARRAY or OBJECT> - drop point: a marker name, a position, or an object.
+ * 1: target <STRING, ARRAY or OBJECT> - drop point: a marker name, a position, or an object. A
+ *    marker name is the beginner-friendly option - place a marker in Eden, name it, put that name
+ *    here. A mistyped or never-placed marker name is reported clearly (see Return Value) rather
+ *    than silently sending the aircraft toward the map's [0,0] corner.
  * 2: direction <NUMBER> - degrees; the aircraft approaches the target along this heading. -1 (the
  *    default) computes a sensible heading automatically from the aircraft's position to the target.
  * 3: altitude <NUMBER> - route altitude AGL in metres (default 250, clamped 100-2000).
@@ -57,7 +60,9 @@
  * Return Value:
  * Boolean - true when accepted (the actual route/actions are applied a moment later on the server
  * once a pilot is confirmed present; check the RPT for "[WMP PARADROP] Quick flight setup" if a
- * plane never starts flying).
+ * plane never starts flying). A target marker name that doesn't exist on the map is also reported
+ * in-game via systemChat, not just the RPT - the single most common beginner setup mistake with
+ * this function is placing the aircraft before placing (or correctly naming) its target marker.
  *
  * Example:
  * [this, "dz1"] call Waldo_fnc_ParadropQuickFlightSetup;
@@ -106,6 +111,18 @@ if !(isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropQuickFlightSet
         diag_log format ["[WMP PARADROP] Quick flight setup abandoned for %1: no pilot became available within 30 seconds. Assign a crew (Eden crew or Waldo_fnc_MoveInCargoPlane) before this call.", typeOf _aircraft];
     };
 
+    // getMarkerPos on a marker name that doesn't exist returns [0,0,0], not an empty array - it
+    // would otherwise silently pass the position check below and send the aircraft toward the
+    // map's [0,0] corner. markerType returning "" is the actual "no such marker" signal, and it's
+    // the single most common beginner mistake with this function (aircraft placed and configured,
+    // target marker forgotten or misspelled), so it gets its own clearly worded, in-game-visible
+    // rejection rather than folding into the generic "didn't resolve" case below.
+    private _missingMarker = typeName _target == "STRING" && {_target != ""} && {markerType _target == ""};
+    if (_missingMarker) exitWith {
+        private _message = format ["[WMP PARADROP] %1 has no flight target: place a map marker named \"%2\" (Eden Editor > Markers) for it to fly toward.", typeOf _aircraft, _target];
+        diag_log format ["[WMP PARADROP] Quick flight setup rejected for %1: marker \"%2\" does not exist.", typeOf _aircraft, _target];
+        _message remoteExec ["systemChat", 0];
+    };
     private _centre = switch (typeName _target) do {
         case "STRING": {if (_target == "") then {[]} else {getMarkerPos _target}};
         case "ARRAY": {_target};

--- a/WMP_Compositions/[WMP]Halo_And_Static_Line_Paradrop_Examples/composition.sqe
+++ b/WMP_Compositions/[WMP]Halo_And_Static_Line_Paradrop_Examples/composition.sqe
@@ -43,7 +43,7 @@ class items
 		side="West";
 		class Entities
 		{
-			items=9;
+			items=2;
 			class Item0
 			{
 				dataType="Object";
@@ -76,90 +76,6 @@ class items
 				id=7665;
 				type="B_Pilot_F";
 				atlOffset=5.9999166;
-			};
-			class Item2
-			{
-				dataType="Waypoint";
-				loiterAltitude=-3.4028235e+038;
-				position[]={564.70313,105.00903,635.41406};
-				class Effects
-				{
-				};
-				showWP="NEVER";
-				id=7706;
-				type="Move";
-			};
-			class Item3
-			{
-				dataType="Waypoint";
-				loiterAltitude=-3.4028235e+038;
-				position[]={-515.36914,98.569023,-2062.5098};
-				class Effects
-				{
-				};
-				showWP="NEVER";
-				id=7701;
-				type="Move";
-			};
-			class Item4
-			{
-				dataType="Waypoint";
-				loiterAltitude=-3.4028235e+038;
-				position[]={-1707.4922,111.73911,-4987.7197};
-				class Effects
-				{
-				};
-				showWP="NEVER";
-				id=7702;
-				type="Move";
-			};
-			class Item5
-			{
-				dataType="Waypoint";
-				loiterAltitude=-3.4028235e+038;
-				position[]={-1702.5059,106.57302,-4751.4072};
-				class Effects
-				{
-				};
-				showWP="NEVER";
-				id=7703;
-				type="Move";
-			};
-			class Item6
-			{
-				dataType="Waypoint";
-				loiterAltitude=-3.4028235e+038;
-				position[]={-596.41406,99.077759,-2023.4658};
-				class Effects
-				{
-				};
-				showWP="NEVER";
-				id=7704;
-				type="Move";
-			};
-			class Item7
-			{
-				dataType="Waypoint";
-				loiterAltitude=-3.4028235e+038;
-				position[]={528.16797,106.35275,652.13281};
-				class Effects
-				{
-				};
-				showWP="NEVER";
-				id=7705;
-				type="Move";
-			};
-			class Item8
-			{
-				dataType="Waypoint";
-				loiterAltitude=-3.4028235e+038;
-				position[]={569.36523,110.82248,686.51758};
-				type="Cycle";
-				class Effects
-				{
-				};
-				showWP="NEVER";
-				id=7707;
 			};
 		};
 		class Attributes
@@ -250,7 +166,7 @@ class items
 		side="West";
 		class Entities
 		{
-			items=9;
+			items=2;
 			class Item0
 			{
 				dataType="Object";
@@ -285,90 +201,6 @@ class items
 				id=7710;
 					type="B_Pilot_F";
 				atlOffset=-37.4589;
-			};
-			class Item2
-			{
-				dataType="Waypoint";
-				loiterAltitude=-3.4028235e+038;
-				position[]={363.80273,4.7227936,2756.2227};
-				class Effects
-				{
-				};
-				showWP="NEVER";
-				id=7711;
-				type="Move";
-			};
-			class Item3
-			{
-				dataType="Waypoint";
-				loiterAltitude=-3.4028235e+038;
-				position[]={-716.26953,133.13348,58.298828};
-				class Effects
-				{
-				};
-				showWP="NEVER";
-				id=7712;
-				type="Move";
-			};
-			class Item4
-			{
-				dataType="Waypoint";
-				loiterAltitude=-3.4028235e+038;
-				position[]={-1908.3926,99.387474,-2866.9111};
-				class Effects
-				{
-				};
-				showWP="NEVER";
-				id=7713;
-				type="Move";
-			};
-			class Item5
-			{
-				dataType="Waypoint";
-				loiterAltitude=-3.4028235e+038;
-				position[]={-1903.4063,134.80023,-2630.5986};
-				class Effects
-				{
-				};
-				showWP="NEVER";
-				id=7714;
-				type="Move";
-			};
-			class Item6
-			{
-				dataType="Waypoint";
-				loiterAltitude=-3.4028235e+038;
-				position[]={-797.31445,121.89677,97.34375};
-				class Effects
-				{
-				};
-				showWP="NEVER";
-				id=7715;
-				type="Move";
-			};
-			class Item7
-			{
-				dataType="Waypoint";
-				loiterAltitude=-3.4028235e+038;
-				position[]={327.26758,0.45301056,2772.9414};
-				class Effects
-				{
-				};
-				showWP="NEVER";
-				id=7716;
-				type="Move";
-			};
-			class Item8
-			{
-				dataType="Waypoint";
-				loiterAltitude=-3.4028235e+038;
-				position[]={368.46484,0,2807.3262};
-				type="Cycle";
-				class Effects
-				{
-				};
-				showWP="NEVER";
-				id=7717;
 			};
 		};
 		class Attributes
@@ -457,7 +289,7 @@ class items
 	{
 		dataType="Comment";
 		class PositionInfo {position[]={0,0,-12};};
-		title="HALO and Static-Line Examples: two vanilla NATO passenger Blackfish aircraft, crews, boarding flags and repeat routes. Static-line uses 300 m and flies toward marker ""dz1""; HALO uses 1200 m and flies toward marker ""dz2"" (both included below - drag them to where you actually want the drop). Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Vehicle-Actions-&-Paradrop";
+		title="HALO and Static-Line Examples: two vanilla NATO passenger Blackfish aircraft, crews and boarding flags, flown by Waldo_fnc_ParadropQuickFlightSetup (no manual waypoints needed - it builds and flies the route itself). Static-line uses 300 m and flies toward marker ""dz1""; HALO uses 1200 m and flies toward marker ""dz2"" (both included below - drag them to where you actually want the drop). The ""dz1""/""dz2"" markers you see now are only the target point you place; once the mission runs, the script automatically adds a full AREA/STANDBY/GREEN/RED/POINT marker corridor around the actual flown route - nothing else to set up. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Vehicle-Actions-&-Paradrop";
 		id=17718;
 	};
 	class Item7

--- a/WMP_Compositions/[WMP]Halo_And_Static_Line_Paradrop_Examples/composition.sqe
+++ b/WMP_Compositions/[WMP]Halo_And_Static_Line_Paradrop_Examples/composition.sqe
@@ -213,7 +213,7 @@ class items
 		flags=2;
 		class Attributes
 		{
-			init="c130Plane call Waldo_fnc_VehicleJumpSetup;c130Plane flyInHeight 300;c130Plane limitSpeed 300";
+			init="[this,""dz1"",-1,300,300] call Waldo_fnc_ParadropQuickFlightSetup;";
 			name="c130Plane";
 			reportOwnPosition=1;
 		};
@@ -422,7 +422,7 @@ class items
 		flags=2;
 		class Attributes
 		{
-			init="c130Plane_1 call Waldo_fnc_VehicleJumpSetup;c130Plane_1 flyInHeight 1200;c130Plane_1 limitSpeed 300";
+			init="[this,""dz2"",-1,1200,250,createHashMapFromArray[[""staticJumpEnabled"",false],[""haloJumpEnabled"",true],[""name"",""HALO Drop Zone""]]] call Waldo_fnc_ParadropQuickFlightSetup;";
 			name="c130Plane_1";
 			reportOwnPosition=1;
 		};

--- a/WMP_Compositions/[WMP]Halo_And_Static_Line_Paradrop_Examples/composition.sqe
+++ b/WMP_Compositions/[WMP]Halo_And_Static_Line_Paradrop_Examples/composition.sqe
@@ -2,7 +2,7 @@ version=54;
 center[]={20742.377,-77.939629,18169.25};
 class items
 {
-	items=7;
+	items=9;
 	class Item0
 	{
 		dataType="Object";
@@ -457,8 +457,36 @@ class items
 	{
 		dataType="Comment";
 		class PositionInfo {position[]={0,0,-12};};
-		title="HALO and Static-Line Examples: two vanilla NATO passenger Blackfish aircraft, crews, boarding flags and repeat routes. Static-line uses 300 m; HALO uses 1200 m. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Vehicle-Actions-&-Paradrop";
+		title="HALO and Static-Line Examples: two vanilla NATO passenger Blackfish aircraft, crews, boarding flags and repeat routes. Static-line uses 300 m and flies toward marker ""dz1""; HALO uses 1200 m and flies toward marker ""dz2"" (both included below - drag them to where you actually want the drop). Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Vehicle-Actions-&-Paradrop";
 		id=17718;
+	};
+	class Item7
+	{
+		dataType="Marker";
+		position[]={-1707.4922,0,-4987.7197};
+		name="dz1";
+		text="Static-Line Drop Zone";
+		type="mil_end";
+		colorName="ColorRed";
+		fillName="Border";
+		a=1;
+		b=1;
+		angle=0;
+		id=7801;
+	};
+	class Item8
+	{
+		dataType="Marker";
+		position[]={-1908.3926,0,-2866.9111};
+		name="dz2";
+		text="HALO Drop Zone";
+		type="mil_end";
+		colorName="ColorRed";
+		fillName="Border";
+		a=1;
+		b=1;
+		angle=0;
+		id=7802;
 	};
 };
 class VehicleInVehicleLinks

--- a/releaseVerificationAndDeployment/test_full_arma_audit.py
+++ b/releaseVerificationAndDeployment/test_full_arma_audit.py
@@ -174,7 +174,10 @@ class FullAuditTests(unittest.TestCase):
             ids = [int(value) for value in re.findall(r"^\s*id=(\d+);", composition, re.MULTILINE)]
             self.assertEqual(len(ids), len(set(ids)), f"{folder.name}: duplicate Eden entity id")
             types = re.findall(r'^\s*type="([^"]+)";', composition, re.MULTILINE)
-            catalogue_types.update(value for value in types if value not in {"Move", "Cycle", "Sync"})
+            # Non-classname uses of type="..." in this format: Waypoint type (Move/Cycle), a Sync
+            # link's CustomData type, and a Marker's CfgMarkers icon type (e.g. mil_end) - none of
+            # these are CfgVehicles classnames and none belong in the catalogue checked below.
+            catalogue_types.update(value for value in types if value not in {"Move", "Cycle", "Sync", "mil_end"})
             addon_block = re.search(r"requiredAddons\[\]\s*=\s*\{([^}]*)\}", header)
             if addon_block:
                 catalogue_addons.update(re.findall(r'"([^"]+)"', addon_block.group(1)))

--- a/wiki/Vehicle-Actions-&-Paradrop.md
+++ b/wiki/Vehicle-Actions-&-Paradrop.md
@@ -155,7 +155,7 @@ another object in the same composition — both init fields can run in any order
 
 **If the plane never takes off toward its target**, the most common cause is step 1 — the marker
 was never placed, or its name doesn't exactly match the `target` string. This case reports itself
-in-game via `systemChat` ("`<aircraft> has no flight target: place a map marker named "..."`"), not
+in-game via `systemChat` ("`<aircraft> has no flight target: place a map marker named <name>...`"), not
 just the RPT log, specifically so this beginner mistake is easy to spot and fix.
 
 The **"[WMP] Halo And Static Line Blackfish Drop Examples"** composition (Eden Editor →

--- a/wiki/Vehicle-Actions-&-Paradrop.md
+++ b/wiki/Vehicle-Actions-&-Paradrop.md
@@ -158,6 +158,12 @@ was never placed, or its name doesn't exactly match the `target` string. This ca
 in-game via `systemChat` ("`<aircraft> has no flight target: place a map marker named "..."`"), not
 just the RPT log, specifically so this beginner mistake is easy to spot and fix.
 
+The **"[WMP] Halo And Static Line Blackfish Drop Examples"** composition (Eden Editor →
+Compositions → Waldos Mission Pack Compositions - Air Operations) demonstrates this end to end: it
+already includes both aircraft wired up as above *and* their `"dz1"`/`"dz2"` target markers, so
+dropping it into a mission and hitting play works immediately with no extra setup — drag the two
+markers to wherever you actually want each drop zone to be.
+
 The aircraft's own existing waypoints are cleared before the generated route is added. This matters:
 a leftover Eden waypoint competing with a scripted route for the AI's attention is the most common
 reason a hand-set-up paradrop plane behaves unpredictably (wandering off the jump run, ignoring

--- a/wiki/Vehicle-Actions-&-Paradrop.md
+++ b/wiki/Vehicle-Actions-&-Paradrop.md
@@ -134,18 +134,29 @@ This is added automatically alongside jump actions. No setup required.
 _Associated Files: `MissionScripts\Paradrop\paradropQuickFlightSetup.sqf`,
 `MissionScripts\Paradrop\paradropBuildFlightRoute.sqf`_
 
-For a plane you've already placed and crewed yourself in Eden, one call in its init field gives it a
-reliable AI-flown paradrop route — no ZEN, no registry, no generated jumpers:
+For a plane you've already placed and crewed yourself in Eden, two steps give it a reliable
+AI-flown paradrop route — no ZEN, no registry, no generated jumpers:
+
+1. Place a marker anywhere on the map and name it (Eden Editor toolbar → Markers) — this is the
+   drop zone the plane will fly toward. Any name works; `"dz1"` is just the example below.
+2. In the aircraft's init field:
 
 ```sqf
 [this, "dz1"] call Waldo_fnc_ParadropQuickFlightSetup;
 ```
 
-Arguments: `[aircraft, target, direction, altitude, maxSpeed, options]`. `target` accepts a marker
-name, a position, or an object; `direction` (`-1` by default) is computed automatically from the
-aircraft's position toward the target if you don't set one. It waits (up to 30 seconds) for a pilot
-to exist before doing anything, so it's safe to place alongside a separate `Waldo_fnc_MoveInCargoPlane`
-call on another object in the same composition — both init fields can run in any order.
+That's it — no marker math, no waypoints to place by hand. Arguments:
+`[aircraft, target, direction, altitude, maxSpeed, options]`. `target` accepts a marker name (the
+beginner-friendly option — reference whatever you named the marker in step 1), a raw position, or
+an object; `direction` (`-1` by default) is computed automatically from the aircraft's position
+toward the target if you don't set one. It waits (up to 30 seconds) for a pilot to exist before
+doing anything, so it's safe to place alongside a separate `Waldo_fnc_MoveInCargoPlane` call on
+another object in the same composition — both init fields can run in any order.
+
+**If the plane never takes off toward its target**, the most common cause is step 1 — the marker
+was never placed, or its name doesn't exactly match the `target` string. This case reports itself
+in-game via `systemChat` ("`<aircraft> has no flight target: place a map marker named "..."`"), not
+just the RPT log, specifically so this beginner mistake is easy to spot and fix.
 
 The aircraft's own existing waypoints are cleared before the generated route is added. This matters:
 a leftover Eden waypoint competing with a scripted route for the AI's attention is the most common


### PR DESCRIPTION
**When merged this pull request will:**

Follow-up to #60 (merged before this commit landed on that branch — carrying it forward here as its own PR rather than leaving it stranded).

**Composition wiring:** wire both aircraft in "[WMP] Halo And Static-Line Paradrop Examples" to `Waldo_fnc_ParadropQuickFlightSetup`, replacing the old `Waldo_fnc_VehicleJumpSetup` + hand-placed Eden waypoints pattern the whole quick-setup feature exists to replace:
- `c130Plane` (Static-Line Aircraft): `[this, "dz1", -1, 300, 300] call Waldo_fnc_ParadropQuickFlightSetup;`
- `c130Plane_1` (HALO Aircraft): `[this, "dz2", -1, 1200, 250, createHashMapFromArray[["staticJumpEnabled",false],["haloJumpEnabled",true],["name","HALO Drop Zone"]]] call Waldo_fnc_ParadropQuickFlightSetup;`

**Ships working `"dz1"`/`"dz2"` markers in the composition itself** so it works immediately with zero extra setup; drag the two markers to wherever the drop should actually happen.

**Removed dead leftover waypoints (latest commit):** both aircraft groups still shipped their original hand-placed `Move`/`Cycle` waypoint chains from before this composition was wired to the new system. `Waldo_fnc_ParadropBuildFlightRoute` clears every waypoint of the group it's given before adding its own generated route, so these did nothing at runtime — they were pure clutter that made the composition look like it was still manually routed when browsing it in Eden. Also reworded the Comment note to explain that `"dz1"`/`"dz2"` are only the drag-to-relocate target point, and that the full AREA/STANDBY/GREEN/RED/POINT marker corridor around the actual flown route is generated automatically by the script once the mission runs — not something the mission maker needs to add themselves.

**Buffer regression fix:** the static-line maximum-altitude buffer (75m → 120m) from #60's buffer-widening commit exceeded the natural headroom the shipped `WALDO_STATIC_MAXALTITUDE` default leaves above the route builder's own default cruise altitude. Reduced to 90m so the shipped defaults normalize to themselves unchanged.

**Missing-marker clarity:** a forgotten/misspelled target marker name now reports itself in-game via `systemChat`, not just the RPT log, instead of silently sending the aircraft toward the map's `[0,0]` corner.

**Note:** both the aircraft wiring and the composition edits are hand-authored `.sqe` changes that can't be verified in Eden Editor from this environment — worth a visual sanity check before treating as final. This branch still needs `Waldo_Paradrop_ManuallyConfigured` from PR #65 to avoid the auto-detect conflict that swaps HALO/static jump settings on these exact aircraft classes — test with both PRs merged, not #64 alone.

All validators pass: `sqf_validator`, `documentation_contract_checker`, `wiki_style_checker`, full `test_full_arma_audit` suite (105 tests).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq

---
_Generated by [Claude Code](https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq)_