### PR TITLE
Replace field hospital 3D marker with a simple info interaction; harden hazard grace-clock pruning

### DIFF
--- a/.claude/skills/mission-pack-config/references/paradrop.md
+++ b/.claude/skills/mission-pack-config/references/paradrop.md
@@ -91,9 +91,11 @@ field:
   units besides this aircraft's crew (e.g. a squad leader who's also the
   pilot), the crew is automatically moved into a dedicated fresh group first
   so those other units never lose their own waypoints.
-- Waits (bounded, 30s) for a pilot to exist, so it's safe even if a
-  separate init-field call (e.g. `Waldo_fnc_MoveInCargoPlane` on another
-  object) assigns the crew — order between the two doesn't matter.
+- Waits (bounded, 180s - generous since this is a one-time setup cost and a
+  heavy multi-feature mission can legitimately still be finishing init.sqf)
+  for a pilot to exist, so it's safe even if a separate init-field call
+  (e.g. `Waldo_fnc_MoveInCargoPlane` on another object) assigns the crew —
+  order between the two doesn't matter.
 - Requested (or configured-default) jump envelope values are clamped by
   `Waldo_fnc_ParadropNormalizeJumpEnvelope` around the route's actual
   altitude/speed before the jump action is installed — the fix for a jump

--- a/MissionScripts/EnvironmentalSystems/HazardousEnvironments/hazardTick.sqf
+++ b/MissionScripts/EnvironmentalSystems/HazardousEnvironments/hazardTick.sqf
@@ -228,10 +228,15 @@ private _graceSeconds = missionNamespace getVariable ["Waldo_Hazard_StatusGraceS
 } forEach (keys _typeAggregates);
 
 // Drop grace-clock entries long past their window so this hashmap doesn't grow forever across a
-// mission with many transient hazard types (moving emitters, ZEN-placed/removed zones, etc).
+// mission with many transient hazard types (moving emitters, ZEN-placed/removed zones, etc). Build
+// a fresh replacement rather than deleteAt-while-iterating its own keys.
+private _prunedTypeLastInside = createHashMap;
 {
-    if ((diag_tickTime - (_typeLastInside get _x)) > (_graceSeconds * 20)) then {_typeLastInside deleteAt _x};
-} forEach (keys _typeLastInside);
+    if ((diag_tickTime - (_typeLastInside get _x)) <= (_graceSeconds * 20)) then {
+        _prunedTypeLastInside set [_x, _typeLastInside get _x];
+    };
+} forEach (+(keys _typeLastInside));
+_typeLastInside = _prunedTypeLastInside;
 
 // Diagnostics must prove that spatial evaluation is actually advancing. Merely having a loop
 // handle and a zone registry previously allowed a permanently inert evaluator to report ACTIVE.

--- a/MissionScripts/Logistics/Crates/doMedicalCrate.sqf
+++ b/MissionScripts/Logistics/Crates/doMedicalCrate.sqf
@@ -1,7 +1,8 @@
 /*
 This function populates an advanced medical crate, with the option to enable the box as a field hospital if desired.
-When enabled with ACE medical present, a "FIELD HOSPITAL" 3D marker is attached to the crate so players can see
-which crate grants the locational treatment boost without opening its inventory or reading the mission briefing.
+When enabled with ACE medical present, a simple "Field Hospital Info" interaction (ACE Interact plus a linked
+vanilla addAction) is installed on the crate so players can see which crate grants the locational treatment
+boost without opening its inventory or reading the mission briefing - no persistent 3D marker in the world.
 
 Params:
 _crate - object to populate (Passed from module where thee classname of the box is defined)
@@ -36,23 +37,16 @@ clearbackpackcargoGlobal _crate;
 //Verify ACE Medical Activation, then perform due dilligence
 if (isClass(configFile >> "CfgPatches" >> "ace_medical")) then {
     //Check if option selected for medical locational boost
-    private _markerId = format ["WMP_FieldHospital_%1", netId _crate];
     if (_isFacility) then {
         _crate setVariable ["ace_medical_isMedicalFacility", true, true];
         // ACE medical already exposes the facility state to treatment logic, but that gives
         // players no visible reason to bring casualties to this specific crate over any other
-        // one - a persistent 3D marker is the non-intrusive indicator (no addAction, so it
-        // never pollutes the vanilla/ACE interaction menu the way a prior decorative action did).
-        [_markerId, _crate, createHashMapFromArray [
-            ["text", "FIELD HOSPITAL"],
-            ["icon", "\z\ACE\addons\medical_gui\ui\cross.paa"],
-            ["colour", [0.35, 0.85, 0.45, 0.95]],
-            ["offset", [0, 0, 1.2]],
-            ["distance", 40]
-        ]] call Waldo_fnc_Create3DMarker;
+        // one - a simple informational interaction on the crate itself is the indicator, not a
+        // persistent 3D marker floating in the world.
+        [_crate, true] remoteExec ["Waldo_fnc_MedicalCrateFacilityActionLocal", 0, _crate];
         diag_log format ["[WMP LOGISTICS] ACE medical facility enabled crate=%1", netId _crate];
     } else {
-        [_markerId] call Waldo_fnc_Remove3DMarker;
+        [_crate, false] remoteExec ["Waldo_fnc_MedicalCrateFacilityActionLocal", 0, _crate];
     };
     //Add ACE Medical supplies   
    //Common Items

--- a/MissionScripts/Logistics/Crates/medicalCrateFacilityActionLocal.sqf
+++ b/MissionScripts/Logistics/Crates/medicalCrateFacilityActionLocal.sqf
@@ -1,0 +1,83 @@
+/*
+ * Author: WaldoTheWarfighter
+ * Installs (or removes) a simple informational interaction on a field hospital-enabled medical
+ * crate. ACE Interact ("Field Hospital Info") is used when available; a vanilla addAction is
+ * installed alongside it (or instead of it, on a mission without ACE) so the same information -
+ * that this crate grants ACE medical's locational treatment boost - is always reachable without a
+ * persistent 3D marker cluttering the world. Repeated calls reconcile a stale action instead of
+ * duplicating one.
+ *
+ * Arguments:
+ * 0: crate <OBJECT>
+ * 1: enabled <BOOL> (default true) - false removes any previously installed action.
+ *
+ * Return Value:
+ * Boolean - true once this client has processed the request.
+ *
+ * Example:
+ * [_crate, true] remoteExec ["Waldo_fnc_MedicalCrateFacilityActionLocal", 0, _crate];
+ *
+ * Current callers: Waldo_fnc_MedicalCratePopulate.
+ */
+
+params [["_crate", objNull, [objNull]], ["_enabled", true]];
+if (!hasInterface || {isNull _crate}) exitWith {false};
+
+private _oldAcePath = _crate getVariable ["Waldo_FieldHospital_AceActionPath", []];
+if (count _oldAcePath > 0 && {!(isNil "ace_interact_menu_fnc_removeActionFromObject")}) then {
+    [_crate, 0, _oldAcePath] call ace_interact_menu_fnc_removeActionFromObject;
+};
+_crate setVariable ["Waldo_FieldHospital_AceActionPath", []];
+
+private _oldVanillaId = _crate getVariable ["Waldo_FieldHospital_VanillaActionId", -1];
+if (_oldVanillaId != -1) then {_crate removeAction _oldVanillaId;};
+_crate setVariable ["Waldo_FieldHospital_VanillaActionId", -1];
+
+if !(_enabled) exitWith {true};
+
+// The ACE/vanilla callbacks below are stored and invoked later (when the player actually triggers
+// the action) rather than called immediately - SQF's dynamic scoping means a private variable from
+// this script's frame is not visible to them by then, so the message text is inlined into each
+// callback rather than referenced from a local here.
+private _icon = "\z\ACE\addons\medical_gui\ui\cross.paa";
+private _infoTitle = "Field Hospital Info";
+
+if (isClass (configFile >> "CfgPatches" >> "ace_interact_menu")) then {
+    private _action = [
+        "Waldo_FieldHospital_Info", _infoTitle, _icon,
+        {
+            params ["_target"];
+            [
+                "FIELD HOSPITAL",
+                "This crate grants ACE medical's locational treatment boost to casualties treated nearby.",
+                "INFO",
+                format ["FIELD_HOSPITAL_INFO_%1", netId _target],
+                6
+            ] call Waldo_fnc_FeatureNotifyLocal;
+        },
+        {true}
+    ] call ace_interact_menu_fnc_createAction;
+    private _actionPath = [_crate, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
+    _crate setVariable ["Waldo_FieldHospital_AceActionPath", _actionPath];
+};
+
+// Installed alongside ACE (not only as a fallback) - the same dual-surface policy used elsewhere
+// in the pack (loadout-save points, party tables): the vanilla entry is also a useful
+// discoverability cue for players who haven't opened the ACE interact menu on this crate yet.
+private _vanillaId = _crate addAction [
+    _infoTitle,
+    {
+        params ["_target"];
+        [
+            "FIELD HOSPITAL",
+            "This crate grants ACE medical's locational treatment boost to casualties treated nearby.",
+            "INFO",
+            format ["FIELD_HOSPITAL_INFO_%1", netId _target],
+            6
+        ] call Waldo_fnc_FeatureNotifyLocal;
+    },
+    [], 1.5, false, true, "",
+    "alive _this", 6
+];
+_crate setVariable ["Waldo_FieldHospital_VanillaActionId", _vanillaId];
+true

--- a/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
+++ b/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
@@ -106,17 +106,22 @@ if !(isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropQuickFlightSet
     // single biggest source of "the plane just sits there" reports for a script wired up this way.
     // Bounded the same way as the pilot wait below it: a mission that never sets WALDO_INIT_COMPLETE
     // (broken init.sqf, non-standard init flow) must not leave this spawned handle looping forever.
-    private _initDeadline = serverTime + 30;
+    // 180s, not 30s - this is a one-time setup cost, and a heavy multi-feature mission (many
+    // compositions, ACRE/ACE/Zeus registration, background Steam Workshop lookups, first-load asset
+    // streaming) can legitimately still be mid-init.sqf at 30s without anything actually being
+    // broken; a real "give up" deadline still exists, it just isn't tight enough to fire on a slow
+    // but healthy mission load.
+    private _initDeadline = serverTime + 180;
     waitUntil {sleep 0.5; missionNamespace getVariable ["WALDO_INIT_COMPLETE", false] || {isNull _aircraft} || {serverTime >= _initDeadline}};
     if (isNull _aircraft) exitWith {};
     if !(missionNamespace getVariable ["WALDO_INIT_COMPLETE", false]) exitWith {
-        diag_log format ["[WMP PARADROP] Quick flight setup abandoned for %1: WALDO_INIT_COMPLETE never became true within 30 seconds.", typeOf _aircraft];
+        diag_log format ["[WMP PARADROP] Quick flight setup abandoned for %1: WALDO_INIT_COMPLETE never became true within 180 seconds.", typeOf _aircraft];
     };
-    private _deadline = serverTime + 30;
+    private _deadline = serverTime + 180;
     waitUntil {sleep 0.5; isNull _aircraft || {!isNull (driver _aircraft)} || {serverTime >= _deadline}};
     if (isNull _aircraft) exitWith {};
     if (isNull driver _aircraft) exitWith {
-        diag_log format ["[WMP PARADROP] Quick flight setup abandoned for %1: no pilot became available within 30 seconds. Assign a crew (Eden crew or Waldo_fnc_MoveInCargoPlane) before this call.", typeOf _aircraft];
+        diag_log format ["[WMP PARADROP] Quick flight setup abandoned for %1: no pilot became available within 180 seconds. Assign a crew (Eden crew or Waldo_fnc_MoveInCargoPlane) before this call.", typeOf _aircraft];
     };
 
     // getMarkerPos on a marker name that doesn't exist returns [0,0,0], not an empty array - it

--- a/MissionScripts/WaldosFunctions.sqf
+++ b/MissionScripts/WaldosFunctions.sqf
@@ -380,6 +380,9 @@ class CfgFunctions
             class MedicalCratePopulate {
                 file = "MissionScripts\Logistics\Crates\doMedicalCrate.sqf";
             };
+            class MedicalCrateFacilityActionLocal {
+                file = "MissionScripts\Logistics\Crates\medicalCrateFacilityActionLocal.sqf";
+            };
             class SupplyCratePopulate {
                 file = "MissionScripts\Logistics\Crates\doSupplyCrate.sqf";
             };

--- a/wiki/Vehicle-Actions-&-Paradrop.md
+++ b/wiki/Vehicle-Actions-&-Paradrop.md
@@ -149,9 +149,10 @@ That's it — no marker math, no waypoints to place by hand. Arguments:
 `[aircraft, target, direction, altitude, maxSpeed, options]`. `target` accepts a marker name (the
 beginner-friendly option — reference whatever you named the marker in step 1), a raw position, or
 an object; `direction` (`-1` by default) is computed automatically from the aircraft's position
-toward the target if you don't set one. It waits (up to 30 seconds) for a pilot to exist before
-doing anything, so it's safe to place alongside a separate `Waldo_fnc_MoveInCargoPlane` call on
-another object in the same composition — both init fields can run in any order.
+toward the target if you don't set one. It waits (up to 180 seconds - a heavy multi-feature mission
+can legitimately still be finishing init.sqf, and this is a one-time setup cost) for a pilot to
+exist before doing anything, so it's safe to place alongside a separate `Waldo_fnc_MoveInCargoPlane`
+call on another object in the same composition — both init fields can run in any order.
 
 **If the plane never takes off toward its target**, the most common cause is step 1 — the marker
 was never placed, or its name doesn't exactly match the `target` string. This case reports itself


### PR DESCRIPTION
**When merged this pull request will:**

**Field Hospital marker → simple interaction.** Field Hospital crates were showing a persistent, badly-offset "FIELD HOSPITAL" 3D marker floating in the sky over the crate (`Waldo_fnc_Create3DMarker`) — not the desired UX. Replaced it with a "Field Hospital Info" interaction on the crate itself: ACE Interact when available plus a linked vanilla `addAction` (the pack's existing dual-surface policy for player-facing actions), reporting the crate's ACE medical locational treatment boost on demand instead of a persistent world marker. New `Waldo_fnc_MedicalCrateFacilityActionLocal` installs/removes it; `Waldo_fnc_MedicalCratePopulate` now dispatches to it instead of `Create3DMarker`/`Remove3DMarker`.

**Hardened hazard grace-clock pruning.** `Waldo_fnc_HazardTick`'s grace-clock pruning loop previously called `deleteAt` on `Waldo_Hazard_LocalTypeLastInside` while iterating `keys` of that same HashMap. Likely safe in practice (`keys` returns a snapshot array), but given a reported full client freeze on entering a hazard zone, this eliminates any doubt cheaply — the loop now builds a fresh replacement HashMap instead of mutating the live one mid-iteration.

**Fixed a real "paradrop does nothing at all" report (RPT-diagnosed).** `Waldo_fnc_ParadropQuickFlightSetup`'s own diagnostic logging pinpointed the cause exactly: `"WALDO_INIT_COMPLETE never became true within 30 seconds"`, fired on a heavy multi-feature test mission that was also hitting repeated `Unable to retrieve steam ugc detail` engine stalls (656 occurrences across the session — a background Steam Workshop lookup issue, unrelated to WMP). The RPT shows init.sqf demonstrably kept progressing normally after the 30s mark (ACRE/transport/jamming all completed within the next few seconds) — the deadline was just too tight for that combination, so the one-time paradrop setup gave up right as everything else was about to succeed. Widened both the init-complete wait and the pilot wait from 30s to 180s — a one-time mission-start cost has no real downside to a more generous bound, and 180s still guarantees the spawned handle can't loop forever on a genuinely broken init flow.

**Note on the freeze:** I could not find a definitive *code* cause for the reported freeze through static review — the RPT strongly suggests it's the same Steam UGC stall issue above (an engine-level, non-WMP problem), not a WMP script hang. The HashMap hardening above is defensive, not a confirmed root-cause fix.

All validators pass: `sqf_validator`, `documentation_contract_checker`, `wiki_style_checker`, `claude_skill_validator`, full `test_full_arma_audit` suite (105 tests).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq

---
_Generated by [Claude Code](https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq)_