### PR TITLE
Fix overlapping paradrop drop-zone markers; explicit composition options

### DIFF
--- a/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
+++ b/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
@@ -50,9 +50,11 @@
  *    aircraft under any lifecycle, unlike Waldo_fnc_ParadropCreateDropZone; DESPAWN only changes
  *    which waypoints get added and is one of the two automatic marker-cleanup triggers below),
  *    circuitDirection (LEFT/RIGHT, default LEFT), approachDistance/runLength/exitDistance (metres,
- *    default 2500 each), createMarkers (default true - AREA/STANDBY/GREEN/RED/POINT markers matching
+ *    default 2500 each), createMarkers (default true - AREA/STANDBY/GREEN/RED markers matching
  *    Waldo_fnc_ParadropCreateDropZone's layout, so a mission maker sees a working drop zone
- *    immediately; set false for a map-clutter-free operation), keepMarkersOnCleanup (default false -
+ *    immediately, plus a POINT marker at the target - but only when target was not itself a marker
+ *    name, since that marker already sits exactly there and a second icon/label on top of it would
+ *    just overlap; set false for a map-clutter-free operation), keepMarkersOnCleanup (default false -
  *    the created markers are removed automatically once the aircraft is destroyed/deleted, or once a
  *    DESPAWN run reaches its exit point; set true to leave them on the map instead; never affects the
  *    aircraft or crew either way), name (marker label, default "Drop Zone").
@@ -248,11 +250,17 @@ if !(isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropQuickFlightSet
             _marker setMarkerText _text;
             _markers pushBack _marker;
         } forEach [["STANDBY", "standby", "ColorYellow", "STANDBY"], ["GREEN", "green", "ColorGreen", "GREEN LINE"], ["RED", "red", "ColorRed", "RED LINE"]];
-        private _point = createMarker [format ["%1_POINT", _prefix], _centre];
-        _point setMarkerType "mil_end";
-        _point setMarkerColor "ColorBlack";
-        _point setMarkerText _label;
-        _markers pushBack _point;
+        // When target was a marker name, that marker already sits exactly at _centre - creating
+        // another icon+label marker on top of it just doubles up (overlapping text, two stacked
+        // icons) instead of adding information. Only add the POINT marker for an ARRAY/OBJECT
+        // target, where nothing was already there to mark the drop point itself.
+        if !(typeName _target == "STRING" && {_target != ""}) then {
+            private _point = createMarker [format ["%1_POINT", _prefix], _centre];
+            _point setMarkerType "mil_end";
+            _point setMarkerColor "ColorBlack";
+            _point setMarkerText _label;
+            _markers pushBack _point;
+        };
     };
 
     // Cleanup watcher. Markers are removed automatically once the aircraft is destroyed/deleted, or

--- a/WMP_Compositions/[WMP]Halo_And_Static_Line_Paradrop_Examples/composition.sqe
+++ b/WMP_Compositions/[WMP]Halo_And_Static_Line_Paradrop_Examples/composition.sqe
@@ -129,7 +129,7 @@ class items
 		flags=2;
 		class Attributes
 		{
-			init="[this,""dz1"",-1,300,300] call Waldo_fnc_ParadropQuickFlightSetup;";
+			init="[this,""dz1"",-1,300,300,createHashMapFromArray[[""staticJumpEnabled"",true],[""haloJumpEnabled"",false],[""name"",""Static-Line Drop Zone""]]] call Waldo_fnc_ParadropQuickFlightSetup;";
 			name="c130Plane";
 			reportOwnPosition=1;
 		};


### PR DESCRIPTION
**When merged this pull request will:**

**Fix overlapping/garbled drop-zone markers (screenshot-confirmed).** `Waldo_fnc_ParadropQuickFlightSetup`'s `createMarkers` option (on by default) always created its own `_POINT` icon+label marker at the target position. When `target` is a marker name — the beginner-friendly, most common case, e.g. the paradrop example composition's `dz1`/`dz2` — that exact position already has the mission maker's own marker with its own icon and text, so both markers ended up drawn stacked on top of each other: two icons, two overlapping/garbled text labels. The `_POINT` marker is now only created for an `ARRAY`/`OBJECT` target, where nothing was already there.

**Explicit options for both composition aircraft.** `c130Plane` relied entirely on defaults (`staticJumpEnabled=true`, `haloJumpEnabled=false`) while `c130Plane_1` spelled its options out — an asymmetry that read as "forgot the static one's options" rather than two deliberately configured aircraft, and meant its runtime marker showed the generic default "Drop Zone" label instead of a name matching its own composition marker (part of what caused the garbled overlap above). Both aircraft now pass the same explicit `staticJumpEnabled`/`haloJumpEnabled`/`name` options.

All validators pass: `sqf_validator`, full `test_full_arma_audit` suite (105 tests).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq

---
_Generated by [Claude Code](https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq)_