### PR TITLE
Improve diagnostics coverage/assistiveness; fix transport info action and paradrop loop reliability

### DIFF
--- a/MissionScripts/Logistics/TransportServices/transportManageChildrenLocal.sqf
+++ b/MissionScripts/Logistics/TransportServices/transportManageChildrenLocal.sqf
@@ -80,7 +80,7 @@ private _children = [];
                 "Waldo_Transport_ExactDestination", "Select Destination",
                 "\a3\ui_f_oldman\data\igui\cfg\holdactions\map_ca.paa",
                 {private _service = _this select 2; ["SET_DESTINATION", _service getVariable ["Waldo_TransportService_Type", "GROUND"], _service] call Waldo_fnc_TransportOpenMapLocal},
-                {private _service = _this select 2; _service getVariable ["Waldo_TransportService_State", ""] == "BOARDING" && {player in crew _service || {!isNull getAssignedCuratorLogic player}}}, {}, _service
+                {private _service = _this select 2; (_service getVariable ["Waldo_TransportService_State", ""] in ["BOARDING", "TO_DESTINATION"]) && {player in crew _service || {!isNull getAssignedCuratorLogic player}}}, {}, _service
             ] call ace_interact_menu_fnc_createAction;
             _controls pushBack [_destination, [], player];
             private _retry = [

--- a/MissionScripts/Logistics/TransportServices/transportRequestServer.sqf
+++ b/MissionScripts/Logistics/TransportServices/transportRequestServer.sqf
@@ -147,7 +147,12 @@ switch (_action) do {
         _retargetingPickup = true;
     };
     case "SET_DESTINATION": {
-        if (_state != "BOARDING" || {count _position < 2}) exitWith {};
+        // Symmetric with MOVE_PICKUP retargeting a still-inbound pickup: a destination already
+        // being travelled to can be changed too, not just the first one picked while boarding.
+        // The same fresh-serial/requestId mechanism below invalidates any superseded AI-owner
+        // loop before it can land, stop or report against the old destination.
+        if !(_state in ["BOARDING", "TO_DESTINATION"]) exitWith {};
+        if (count _position < 2) exitWith {};
         _phase = "DESTINATION";
     };
     case "RETRY": {

--- a/MissionScripts/Logistics/TransportServices/transportSetupVehicleLocal.sqf
+++ b/MissionScripts/Logistics/TransportServices/transportSetupVehicleLocal.sqf
@@ -87,7 +87,7 @@ _destinationId = _vehicle addAction [
     "<t color='#79C7FF'>Select This Transport's Destination</t>",
     {params ["_target"]; ["SET_DESTINATION", _target getVariable ["Waldo_TransportService_Type", "GROUND"], _target] call Waldo_fnc_TransportOpenMapLocal},
     [], -92, false, true, "",
-    "_target getVariable ['Waldo_TransportService_State',''] == 'BOARDING' && {_this in crew _target || {!isNull getAssignedCuratorLogic _this}}",
+    "(_target getVariable ['Waldo_TransportService_State',''] in ['BOARDING','TO_DESTINATION']) && {_this in crew _target || {!isNull getAssignedCuratorLogic _this}}",
     8
 ];
 _rtbId = _vehicle addAction [
@@ -127,7 +127,7 @@ if (_aceReady && {!(_vehicle getVariable ["Waldo_TransportService_AceInstalled",
     [_vehicle, 0, ["ACE_MainActions", _rootId], _move] call ace_interact_menu_fnc_addActionToObject;
     private _destination = [format ["%1_Destination", _rootId], "Select Destination", "\a3\ui_f_oldman\data\igui\cfg\holdactions\map_ca.paa", {
         params ["_target"]; ["SET_DESTINATION", _target getVariable ["Waldo_TransportService_Type", "GROUND"], _target] call Waldo_fnc_TransportOpenMapLocal;
-    }, {params ["_target", "_player"]; _target getVariable ["Waldo_TransportService_State", ""] == "BOARDING" && {_player in crew _target || {!isNull getAssignedCuratorLogic _player}}}] call ace_interact_menu_fnc_createAction;
+    }, {params ["_target", "_player"]; (_target getVariable ["Waldo_TransportService_State", ""] in ["BOARDING", "TO_DESTINATION"]) && {_player in crew _target || {!isNull getAssignedCuratorLogic _player}}}] call ace_interact_menu_fnc_createAction;
     [_vehicle, 0, ["ACE_MainActions", _rootId], _destination] call ace_interact_menu_fnc_addActionToObject;
     private _retry = [format ["%1_Retry", _rootId], "Retry Current Route", "\a3\ui_f\data\igui\cfg\actions\reload_ca.paa", {
         params ["_target", "_player"]; ["RETRY", _target getVariable ["Waldo_TransportService_Type", "GROUND"], _target, [], _player] remoteExecCall ["Waldo_fnc_TransportRequestServer", 2];

--- a/MissionScripts/Logistics/TransportServices/transportSetupVehicleLocal.sqf
+++ b/MissionScripts/Logistics/TransportServices/transportSetupVehicleLocal.sqf
@@ -55,13 +55,13 @@ private _type = _vehicle getVariable ["Waldo_TransportService_Type", "GROUND"];
 private _name = _vehicle getVariable ["Waldo_TransportService_Name", "Transport"];
 private _heli = _type == "HELICOPTER";
 private _role = ["Ground Transport", "Helicopter Transport"] select _heli;
-private _infoId = -1;
-private _moveId = -1;
-private _destinationId = -1;
-private _rtbId = -1;
-private _retryId = -1;
-if (!_aceReady) then {
-_infoId = _vehicle addAction [
+// The informational action is a discoverability cue, not a control ACE should take priority over -
+// installed alongside ACE (not only as a vanilla fallback), the same dual-surface policy used
+// elsewhere in the pack (loadout-save points, party tables, Field Hospital crates): a player who
+// hasn't opened ACE Self Interact on this exact vehicle should still be able to scroll-wheel it and
+// immediately see what it is and its current state. The four operational controls below remain
+// ACE-priority/vanilla-fallback only, since ACE's own equivalents already cover them when available.
+private _infoId = _vehicle addAction [
     format ["<t color='#79C7FF'>%1: %2</t>", _role, _name],
     {
         params ["_target", "_caller", "_actionId", "_arguments"];
@@ -71,6 +71,11 @@ _infoId = _vehicle addAction [
     [_type, _name, _role], -90, false, true, "",
     "_target getVariable ['Waldo_TransportService_Registered', false]", 8
 ];
+private _moveId = -1;
+private _destinationId = -1;
+private _rtbId = -1;
+private _retryId = -1;
+if (!_aceReady) then {
 _moveId = _vehicle addAction [
     "<t color='#79C7FF'>Move This Transport's Pickup Point</t>",
     {params ["_target"]; ["MOVE_PICKUP", _target getVariable ["Waldo_TransportService_Type", "GROUND"], _target] call Waldo_fnc_TransportOpenMapLocal},

--- a/MissionScripts/MissionFlowAndUi/runDiagnostics.sqf
+++ b/MissionScripts/MissionFlowAndUi/runDiagnostics.sqf
@@ -37,10 +37,17 @@ private _section = {
     params ["_area", "_title"];
     ["INFO", _area, "section", "SECTION", _title] call _log;
 };
+// _hint is an optional, plain-language remediation step (what to actually go and change) attached
+// to a failing or unconfigured-but-likely-wanted check. It is folded into the same detail text
+// (so the [area,feature,state,detail] report shape every consumer already reads stays unchanged)
+// rather than adding a new field, and it is what actually reaches the hosted-server systemChat line
+// a mission maker sees in the moment - the terse state=/detail= pair alone tells you *that*
+// something is wrong, a hint tells you *what to do about it*.
 private _status = {
-    params ["_category", "_name", "_state", ["_detail", ""], ["_warn", false]];
-    _report pushBack [_category, _name, _state, _detail];
-    [if (_warn) then {"ERROR"} else {"INFO"}, _category, _name, "CHECK", format ["state=%1 detail=%2", _state, _detail]] call _log;
+    params ["_category", "_name", "_state", ["_detail", ""], ["_warn", false], ["_hint", ""]];
+    private _fullDetail = if (_hint == "") then {_detail} else {format ["%1; fix: %2", _detail, _hint]};
+    _report pushBack [_category, _name, _state, _fullDetail];
+    [if (_warn) then {"ERROR"} else {"INFO"}, _category, _name, "CHECK", format ["state=%1 detail=%2", _state, _fullDetail]] call _log;
     if (_warn) then {_warnings = _warnings + 1;};
 };
 private _consumeFeatureReport = {
@@ -145,13 +152,20 @@ if (_configuredLoadoutSides == 0) then {
 // Configured classes. Blank values are unconfigured; bad non-blank values are errors.
 ["configuration", "Mission-maker class and threshold settings"] call _section;
 {
-    _x params ["_variable", "_label"];
+    _x params ["_variable", "_label", ["_hint", ""]];
     private _class = missionNamespace getVariable [_variable, ""];
     if (_class == "") then {
         ["configuration", _label, "UNCONFIGURED", _variable, false] call _status;
     } else {
         private _valid = isClass (configFile >> "CfgVehicles" >> _class);
-        ["configuration", _label, if (_valid) then {"LOADED"} else {"ERROR"}, format ["%1 = %2", _variable, _class], !_valid] call _status;
+        // A known real gotcha: this exact class only exists when RHS is loaded, and the check
+        // above already fails it as ERROR on a non-RHS mission - surface the actual fix, not just
+        // "class not found", since this specific default has silently broken static-line jumps on
+        // vanilla missions before.
+        private _resolvedHint = if (!_valid && {_class == "rhs_d6_Parachute"}) then {
+            format ["%1 defaults to the RHS class rhs_d6_Parachute; either load RHS or set %2 to the vanilla NonSteerable_Parachute_F.", _variable, _variable]
+        } else {_hint};
+        ["configuration", _label, if (_valid) then {"LOADED"} else {"ERROR"}, format ["%1 = %2", _variable, _class], !_valid, _resolvedHint] call _status;
     };
 } forEach [
     ["Logi_SupplyBoxClass", "supply-box"],
@@ -164,7 +178,14 @@ private _minAltitude = missionNamespace getVariable ["WALDO_STATIC_MINALTITUDE",
 private _maxAltitude = missionNamespace getVariable ["WALDO_STATIC_MAXALTITUDE", 350];
 private _maxSpeed = missionNamespace getVariable ["WALDO_STATIC_MAXSPEED", 310];
 private _thresholdsValid = _minAltitude < _maxAltitude && {_maxSpeed > 0};
-["configuration", "static-line-thresholds", if (_thresholdsValid) then {"LOADED"} else {"ERROR"}, format ["min=%1 max=%2 maxSpeed=%3", _minAltitude, _maxAltitude, _maxSpeed], !_thresholdsValid] call _status;
+["configuration", "static-line-thresholds", if (_thresholdsValid) then {"LOADED"} else {"ERROR"}, format ["min=%1 max=%2 maxSpeed=%3", _minAltitude, _maxAltitude, _maxSpeed], !_thresholdsValid, if (_thresholdsValid) then {""} else {"WALDO_STATIC_MINALTITUDE must be lower than WALDO_STATIC_MAXALTITUDE, and WALDO_STATIC_MAXSPEED must be positive - a jump hold-action condition that can never be true is the usual symptom."}] call _status;
+
+// HALO has no equivalent threshold check anywhere else in diagnostics - a nonsensical altitude
+// (negative, or below the static-line window, or absurdly high) silently produces a HALO jump
+// action that never becomes available, with nothing pointing a mission maker at the actual cause.
+private _haloAltitude = missionNamespace getVariable ["WALDO_PARA_HALOALTITUDE", 1000];
+private _haloAltitudeValid = _haloAltitude > 0 && {_haloAltitude <= 15000};
+["configuration", "halo-altitude-threshold", if (_haloAltitudeValid) then {"LOADED"} else {"ERROR"}, format ["WALDO_PARA_HALOALTITUDE=%1", _haloAltitude], !_haloAltitudeValid, if (_haloAltitudeValid) then {""} else {"Set WALDO_PARA_HALOALTITUDE to a positive, realistic HALO release altitude in metres AGL (1000 is the shipped default)."}] call _status;
 
 private _acreLoaded = isClass (configFile >> "CfgPatches" >> "acre_main");
 ["radio", "Radio configuration"] call _section;
@@ -183,6 +204,43 @@ if (_acreLoaded) then {
     ["radio", "acre-babel", if !(_babel getOrDefault ["enabled", false]) then {"DISABLED"} else {if (count (_babel getOrDefault ["languages", []]) > 0) then {"LOADED"} else {"ERROR"}}, format ["enabled=%1 languages=%2", _babel getOrDefault ["enabled", false], count (_babel getOrDefault ["languages", []])], (_babel getOrDefault ["enabled", false]) && {count (_babel getOrDefault ["languages", []]) == 0}] call _status;
 } else {
     ["radio", "acre-runtime", "UNAVAILABLE", "ACRE2 is not loaded; WMP radio presetting is inactive", false] call _status;
+};
+
+// Dedicated Paradrop coverage - previously this system had no runtime section of its own at all,
+// only the generic class-validity checks above. The single most useful thing diagnostics can add
+// here is visibility into the split between Waldo_fnc_AddVehicleFunctions' automatic jump-action
+// detection and a mission maker's own explicit setup (Waldo_fnc_ParadropQuickFlightSetup /
+// Waldo_fnc_VehicleJumpSetup / Waldo_fnc_ParadropCreateDropZone) - the two used to silently fight
+// over the same aircraft; Waldo_Paradrop_ManuallyConfigured is how that's resolved now, and a
+// mission maker has no other way to see which of their aircraft ended up in which group.
+["paradrop", "Paradrop jump-capable aircraft"] call _section;
+private _jumpCapableClasses = ["RHS_Mi24_base", "RHS_Mi8_base", "Heli_Transport_02_base_F", "RHS_C130J_Base", "B_T_VTOL_01_infantry_F"];
+private _jumpCapableAircraft = (allMissionObjects "Air") select {
+    private _type = typeOf _x;
+    _jumpCapableClasses findIf {_type isKindOf _x} >= 0
+};
+private _manuallyConfigured = _jumpCapableAircraft select {_x getVariable ["Waldo_Paradrop_ManuallyConfigured", false]};
+private _staticJumpInstalled = _jumpCapableAircraft select {(_x getVariable ["Waldo_Static_Jump_ActionId", -1]) >= 0};
+private _haloJumpInstalled = _jumpCapableAircraft select {(_x getVariable ["Waldo_Halo_Jump_ActionId", -1]) >= 0};
+if (_jumpCapableAircraft isEqualTo []) then {
+    ["paradrop", "jump-capable-aircraft", "UNCONFIGURED", "No auto-detected jump-capable aircraft (Blackfish/C130J/Mi8/Mi24/Heli_Transport_02) are present in the mission", false] call _status;
+} else {
+    private _autoDetected = count _jumpCapableAircraft - count _manuallyConfigured;
+    private _neitherJumpType = _jumpCapableAircraft select {!(_x in _staticJumpInstalled) && {!(_x in _haloJumpInstalled)}};
+    // Server-side object variables are set locally per interface client, not broadcast - this check
+    // can only see what has replicated to the server's own local state, which is why it reports
+    // "server-visible" rather than an absolute guarantee. It still catches the common case: an
+    // aircraft this server machine expects to have jump actions but doesn't.
+    ["paradrop", "jump-capable-aircraft", if (_neitherJumpType isEqualTo []) then {"ACTIVE"} else {"ERROR"}, format ["total=%1 manuallyConfigured=%2 autoDetected=%3 staticInstalled=%4 haloInstalled=%5 neitherInstalled=%6 (server-visible)", count _jumpCapableAircraft, count _manuallyConfigured, _autoDetected, count _staticJumpInstalled, count _haloJumpInstalled, count _neitherJumpType], !(_neitherJumpType isEqualTo []), if (_neitherJumpType isEqualTo []) then {""} else {"An aircraft with neither static-line nor HALO installed usually means its own object init field never ran a setup call, or WALDO_INIT_COMPLETE never became true in time - check the RPT for [WMP PARADROP] lines naming that aircraft."}] call _status;
+};
+
+private _dropZoneRegistry = missionNamespace getVariable ["Waldo_Paradrop_DropZones", createHashMap];
+private _dropZonePublic = missionNamespace getVariable ["Waldo_Paradrop_PublicDropZones", []];
+if (count (keys _dropZoneRegistry) == 0) then {
+    ["paradrop", "dynamic-drop-zones", "UNCONFIGURED", "No Waldo_fnc_ParadropCreateDropZone operations are registered", false] call _status;
+} else {
+    private _zoneConsistent = count (keys _dropZoneRegistry) == count _dropZonePublic;
+    ["paradrop", "dynamic-drop-zones", if (_zoneConsistent) then {"ACTIVE"} else {"ERROR"}, format ["registered=%1 publicJip=%2 ids=%3", count (keys _dropZoneRegistry), count _dropZonePublic, keys _dropZoneRegistry], !_zoneConsistent, if (_zoneConsistent) then {""} else {"The server registry and the broadcast JIP list have drifted apart - a JIP client may see a stale or missing drop zone. This usually means a custom script mutated the registry directly instead of going through Waldo_fnc_ParadropCreateDropZone/Waldo_fnc_ParadropRemoveDropZone."}] call _status;
 };
 
 ["systems", "Feature runtime state"] call _section;
@@ -216,6 +274,13 @@ private _deployedMhqs = {_x getVariable ["Waldo_MHQ_Status", false]} count _mhqO
 ["logistics", "mhq-runtime", if (_mhqObjects isEqualTo []) then {"UNCONFIGURED"} else {if (_deployedMhqs > 0) then {"ACTIVE"} else {"LOADED"}}, format ["configured=%1 deployed=%2", count _mhqObjects, _deployedMhqs], false] call _status;
 private _vvdPads = _missionObjects select {_x getVariable ["Waldo_VVD_ServerConfigured", false]};
 ["logistics", "vvd-runtime", if (_vvdPads isEqualTo []) then {"UNCONFIGURED"} else {"LOADED"}, format ["configuredSpawnPads=%1", count _vvdPads], false] call _status;
+private _aceMedicalLoaded = isClass (configFile >> "CfgPatches" >> "ace_medical");
+private _fieldHospitals = _missionObjects select {_x getVariable ["ace_medical_isMedicalFacility", false]};
+if (_fieldHospitals isEqualTo []) then {
+    ["logistics", "field-hospital-runtime", "UNCONFIGURED", "No crate has ace_medical_isMedicalFacility set; Waldo_fnc_MedicalCratePopulate was never called with _isFacility true", false] call _status;
+} else {
+    ["logistics", "field-hospital-runtime", if (_aceMedicalLoaded) then {"ACTIVE"} else {"ERROR"}, format ["facilityCrates=%1; per-object action installation is reported by the client audit", count _fieldHospitals], !_aceMedicalLoaded, if (_aceMedicalLoaded) then {""} else {"ACE medical is not loaded, so this locational treatment boost cannot take effect - load ace_medical or stop marking crates as facilities."}] call _status;
+};
 private _recoveryWorkshops = _missionObjects select {_x getVariable ["Waldo_Recovery_Workshop", false]};
 private _recoveryVehicles = _missionObjects select {_x getVariable ["Waldo_Recovery_Registered", false]};
 private _recoveryPackages = (missionNamespace getVariable ["Waldo_Recovery_Packages", []]) select {!isNull _x};
@@ -259,10 +324,11 @@ private _resupplyCarriers = allPlayers select {_x getVariable ["Waldo_FieldResup
     private _consistent = _serverCount == _publicCount;
     ["runtime-system", _feature, if (_serverCount == 0) then {"UNCONFIGURED"} else {if (_consistent) then {"ACTIVE"} else {"ERROR"}}, format ["server=%1 publicJip=%2", _serverCount, _publicCount], !_consistent] call _status;
 } forEach [
+    // paradrop-drop-zones is intentionally not repeated here - the dedicated Paradrop section above
+    // already reports Waldo_Paradrop_DropZones/PublicDropZones with a specific remediation hint.
     ["dynamic-aa", "Waldo_DynamicAA_Registry", "Waldo_DynamicAA_PublicSystems"],
     ["dynamic-ao", "Waldo_DynamicAO_Registry", "Waldo_DynamicAO_PublicSystems"],
-    ["airborne-gunship", "Waldo_Gunship_Registry", "Waldo_Gunship_PublicSystems"],
-    ["paradrop-drop-zones", "Waldo_Paradrop_DropZones", "Waldo_Paradrop_PublicDropZones"]
+    ["airborne-gunship", "Waldo_Gunship_Registry", "Waldo_Gunship_PublicSystems"]
 ];
 
 private _zenLoaded = isClass (configFile >> "CfgPatches" >> "zen_main");

--- a/MissionScripts/MissionFlowAndUi/runDiagnosticsClient.sqf
+++ b/MissionScripts/MissionFlowAndUi/runDiagnosticsClient.sqf
@@ -175,6 +175,21 @@ if (_vvdTerminals isEqualTo []) then {
     ["logistics", "vvd-actions", if (_vvdValid) then {"LOADED"} else {"ERROR"}, format ["terminals=%1 expectedMode=%2", count _vvdTerminals, if (_aceInteractLoaded) then {"ACE"} else {"VANILLA"}]] call _add;
 };
 
+private _fieldHospitals = _localObjects select {_x getVariable ["ace_medical_isMedicalFacility", false]};
+if (_fieldHospitals isEqualTo []) then {
+    ["logistics", "field-hospital-actions", "UNCONFIGURED", "No field hospital crate is present"] call _add;
+} else {
+    // Waldo_fnc_MedicalCrateFacilityActionLocal installs the vanilla addAction unconditionally and
+    // the ACE action only when ACE Interact is loaded (both together, not one as a fallback for the
+    // other) - a crate missing either the expected ACE path or its vanilla action id means the
+    // install call never reached that crate on this client.
+    private _fieldHospitalsMissingAction = _fieldHospitals select {
+        (_x getVariable ["Waldo_FieldHospital_VanillaActionId", -1]) < 0
+        || {_aceInteractLoaded && {(_x getVariable ["Waldo_FieldHospital_AceActionPath", []]) isEqualTo []}}
+    };
+    ["logistics", "field-hospital-actions", if (_fieldHospitalsMissingAction isEqualTo []) then {"LOADED"} else {"ERROR"}, format ["crates=%1 missingAction=%2 expectedMode=%3", count _fieldHospitals, count _fieldHospitalsMissingAction, if (_aceInteractLoaded) then {"ACE+VANILLA"} else {"VANILLA"}]] call _add;
+};
+
 private _warnings = {_x select 2 == "ERROR"} count _checks;
 ["core", "diagnostics", "INFO", "END", format ["checks=%1 errors=%2", count _checks, _warnings], _runId, format ["CLIENT:%1", clientOwner]] call Waldo_fnc_DiagnosticLog;
 [_runId, clientOwner, name player, getPlayerUID player, _checks] remoteExecCall ["Waldo_fnc_DiagnosticsReceiveClient", 2];

--- a/MissionScripts/Paradrop/paradropBuildFlightRoute.sqf
+++ b/MissionScripts/Paradrop/paradropBuildFlightRoute.sqf
@@ -110,8 +110,15 @@ private _addRouteWaypoint = {
     _waypoint setWaypointCompletionRadius _radius;
     _waypoint
 };
+// The green/centre/red run-line waypoints are deliberately tighter than standby/exit to keep the
+// jump line geometrically precise, but too tight for a fast aircraft's turning radius is a known
+// Arma AI failure mode: it can perpetually fail to satisfy the completion radius and circle trying,
+// rather than actually breaking off toward the next waypoint - which reads exactly as "only one
+// pass, then loitering" instead of continuing the loop. 50 m still keeps the line tight relative to
+// the run length while giving faster-than-default aircraft (missions commonly configure well above
+// the 220 km/h default) real room to satisfy it.
 {
-    [_x, "MOVE", if (_forEachIndex in [1, 2, 3]) then {30} else {100}] call _addRouteWaypoint;
+    [_x, "MOVE", if (_forEachIndex in [1, 2, 3]) then {50} else {100}] call _addRouteWaypoint;
 } forEach [_standby, _green, _centre, _red, _exit];
 if (_lifecycle == "LOOP") then {
     {[_x, "MOVE", 180] call _addRouteWaypoint} forEach [_crosswind, _downwind, _rejoin];

--- a/MissionScripts/Paradrop/paradropConfigureAircraftLocal.sqf
+++ b/MissionScripts/Paradrop/paradropConfigureAircraftLocal.sqf
@@ -8,7 +8,12 @@
  * 0: aircraft <OBJECT>
  * 1: configuration <HASHMAP> - staticJumpEnabled, staticMinimumAltitude,
  *    staticMaximumAltitude, staticMaximumSpeed, staticChuteClass, haloJumpEnabled,
- *    haloMinimumAltitude, haloBackpackClass and requireOpenDoor
+ *    haloMinimumAltitude, haloBackpackClass and requireOpenDoor. Both current callers
+ *    (Waldo_fnc_ParadropQuickFlightSetup, Waldo_fnc_ParadropCreateDropZone) always resolve and
+ *    normalize every threshold/class before calling this, so the getOrDefault fallbacks below are a
+ *    last-resort safety net for a direct/incomplete call, not something either caller relies on -
+ *    they still prefer the mission's own configured WALDO_STATIC_/WALDO_PARA_ defaults over the
+ *    shipped vanilla literals, for the same reason those callers do.
  *
  * Return Value:
  * Boolean - true when a valid local aircraft configuration was processed.
@@ -29,19 +34,19 @@ if (!hasInterface || {isNull _aircraft}) exitWith {false};
 
 [
     _aircraft,
-    _config getOrDefault ["staticMinimumAltitude", 180],
-    _config getOrDefault ["staticMaximumAltitude", 350],
-    _config getOrDefault ["staticMaximumSpeed", 310],
-    _config getOrDefault ["staticChuteClass", "NonSteerable_Parachute_F"],
-    _config getOrDefault ["requireOpenDoor", false],
+    _config getOrDefault ["staticMinimumAltitude", missionNamespace getVariable ["WALDO_STATIC_MINALTITUDE", 180]],
+    _config getOrDefault ["staticMaximumAltitude", missionNamespace getVariable ["WALDO_STATIC_MAXALTITUDE", 350]],
+    _config getOrDefault ["staticMaximumSpeed", missionNamespace getVariable ["WALDO_STATIC_MAXSPEED", 310]],
+    _config getOrDefault ["staticChuteClass", missionNamespace getVariable ["WALDO_STATIC_STATICCHUTE", "NonSteerable_Parachute_F"]],
+    _config getOrDefault ["requireOpenDoor", true],
     _config getOrDefault ["staticJumpEnabled", true]
 ] call Waldo_fnc_AddStaticJump;
 
 [
     _aircraft,
-    _config getOrDefault ["haloMinimumAltitude", 1000],
-    _config getOrDefault ["haloBackpackClass", "B_Parachute"],
-    _config getOrDefault ["requireOpenDoor", false],
+    _config getOrDefault ["haloMinimumAltitude", missionNamespace getVariable ["WALDO_PARA_HALOALTITUDE", 1000]],
+    _config getOrDefault ["haloBackpackClass", missionNamespace getVariable ["WALDO_PARA_HALOCHUTE", "B_Parachute"]],
+    _config getOrDefault ["requireOpenDoor", true],
     _config getOrDefault ["haloJumpEnabled", false]
 ] call Waldo_fnc_AddHaloJump;
 

--- a/MissionScripts/Paradrop/paradropCreateDropZone.sqf
+++ b/MissionScripts/Paradrop/paradropCreateDropZone.sqf
@@ -138,10 +138,16 @@ private _exit = _route get "exit";
 // what the aircraft is actually flying.
 private _routeAltitude = _route get "altitude";
 private _routeMaxSpeed = _route get "maxSpeed";
+// Fall back to the mission's own configured WALDO_STATIC_/WALDO_PARA_ envelope (airOperationsConfig.sqf),
+// not hardcoded literals - matches Waldo_fnc_ParadropQuickFlightSetup, so a ZEN-created drop zone that
+// doesn't override a threshold gets the mission maker's actual configured default, not the shipped
+// pack default regardless of what the mission configured.
 private _envelope = [
     _routeAltitude, _routeMaxSpeed,
-    _config getOrDefault ["staticMinimumAltitude", 180], _config getOrDefault ["staticMaximumAltitude", 350],
-    _config getOrDefault ["staticMaximumSpeed", 310], _config getOrDefault ["haloMinimumAltitude", 1000]
+    _config getOrDefault ["staticMinimumAltitude", missionNamespace getVariable ["WALDO_STATIC_MINALTITUDE", 180]],
+    _config getOrDefault ["staticMaximumAltitude", missionNamespace getVariable ["WALDO_STATIC_MAXALTITUDE", 350]],
+    _config getOrDefault ["staticMaximumSpeed", missionNamespace getVariable ["WALDO_STATIC_MAXSPEED", 310]],
+    _config getOrDefault ["haloMinimumAltitude", missionNamespace getVariable ["WALDO_PARA_HALOALTITUDE", 1000]]
 ] call Waldo_fnc_ParadropNormalizeJumpEnvelope;
 private _staticMinimum = _envelope get "staticMinimumAltitude";
 private _staticMaximum = _envelope get "staticMaximumAltitude";
@@ -155,6 +161,14 @@ _config set ["haloMinimumAltitude", _haloMinimum];
 // One object-keyed replay configures current clients and JIP clients with both selected jump
 // systems. The setup function reconciles repeated configuration rather than duplicating actions.
 [_aircraft, _config] remoteExec ["Waldo_fnc_ParadropConfigureAircraftLocal", 0, _aircraft];
+// Mirrors Waldo_fnc_ParadropQuickFlightSetup's own envelope log line - without this, a ZEN-created
+// operation's actual normalized envelope was invisible in the RPT, making a reported "jump action
+// doesn't work" impossible to diagnose from logs alone.
+diag_log format [
+    "[WMP PARADROP] Dynamic drop zone jump envelope: id=%1 aircraft=%2 static=%3 static-alt=%4-%5m static-speed<=%6 halo=%7 halo-alt>=%8.",
+    _id, _class, _config get "staticJumpEnabled", round _staticMinimum, round _staticMaximum,
+    round _staticMaximumSpeed, _config get "haloJumpEnabled", round _haloMinimum
+];
 
 private _jumpers = [];
 private _jumpGroup = grpNull;
@@ -235,8 +249,8 @@ missionNamespace setVariable ["Waldo_Paradrop_PublicDropZones", _public, true];
         };
         private _interval = ((_config getOrDefault ["jumpInterval", 2]) max 0.5) min 10;
         private _automaticMode = toUpperANSI (_config getOrDefault ["automaticJumpMode", "STATIC"]);
-        private _staticChute = _config getOrDefault ["staticChuteClass", _config getOrDefault ["chuteClass", "NonSteerable_Parachute_F"]];
-        private _haloChute = _config getOrDefault ["haloBackpackClass", "B_Parachute"];
+        private _staticChute = _config getOrDefault ["staticChuteClass", _config getOrDefault ["chuteClass", missionNamespace getVariable ["WALDO_STATIC_STATICCHUTE", "NonSteerable_Parachute_F"]]];
+        private _haloChute = _config getOrDefault ["haloBackpackClass", missionNamespace getVariable ["WALDO_PARA_HALOCHUTE", "B_Parachute"]];
         {
             if (_aircraft distance2D _red <= 150) exitWith {
                 diag_log format ["[WMP PARADROP] Red line reached; remaining jumpers retained id=%1", _id];

--- a/MissionScripts/Paradrop/paradropDropZoneZen.sqf
+++ b/MissionScripts/Paradrop/paradropDropZoneZen.sqf
@@ -154,12 +154,8 @@ private _defaultName = format ["DZ %1", round (serverTime mod 10000)];
         ["COMBO", ["After the pass", "Loop flies a wide circuit and realigns for another pass; retain makes one pass; despawn cleans the operation."], [["LOOP", "RETAIN", "DESPAWN"], ["Loop and repeat", "Single pass - retain aircraft", "Single pass - despawn"], 0]],
         ["COMBO", ["Circuit direction", "Side used for the wide return circuit."], [["LEFT", "RIGHT"], ["Left-hand circuit", "Right-hand circuit"], 0]],
         ["CHECKBOX", ["Enable static-line jump", "Adds the configured static-line player jump action to cargo."], true],
-        ["SLIDER", ["Static minimum altitude", "Preferred AGL floor. If it exceeds route altitude, the server lowers it to keep static-line actions usable."], [50, 1500, 180, 0]],
-        ["SLIDER", ["Static maximum altitude", "Preferred AGL ceiling. The server raises it above route altitude with turbulence margin when needed."], [50, 2500, 350, 0]],
-        ["SLIDER", ["Static maximum speed", "Preferred jump-speed ceiling. It is raised above route speed when needed so the aircraft cannot suppress its own action."], [80, 700, 310, 0]],
         ["COMBO", ["Static-line parachute", "Parachute vehicle created immediately after exit."], [_staticChutes, _staticLabels, 0]],
         ["CHECKBOX", ["Enable HALO jump", "Adds a HALO player jump action using a steerable parachute backpack."], false],
-        ["SLIDER", ["HALO minimum altitude", "Preferred AGL floor. If it exceeds route altitude, the server lowers it to the route altitude so HALO remains available."], [100, 5000, 1000, 0]],
         ["COMBO", ["HALO parachute backpack", "Steerable backpack equipped after HALO exit."], [_haloChutes, _haloLabels, 0]],
         ["CHECKBOX", ["Require open ramp/door", "Requires one of WMP's recognized ramp/door animation sources. Automatically disabled when the selected airframe exposes none."], true],
         ["CHECKBOX", ["Automatically sequence player cargo", "Forces embarked players out at the green line; normally leave off for jumpmaster-controlled player actions."], false],
@@ -173,20 +169,26 @@ private _defaultName = format ["DZ %1", round (serverTime mod 10000)];
         params ["_values", "_modulePosition"];
         _values params [
             "_name", "_side", "_class", "_direction", "_altitude", "_speed", "_approach", "_length", "_exit",
-            "_lifecycle", "_circuitDirection", "_staticEnabled", "_staticMin", "_staticMax", "_staticSpeed", "_staticChute",
-            "_haloEnabled", "_haloMin", "_haloChute", "_requireDoor", "_dropPlayers", "_automaticMode", "_count", "_interval", "_markers",
+            "_lifecycle", "_circuitDirection", "_staticEnabled", "_staticChute",
+            "_haloEnabled", "_haloChute", "_requireDoor", "_dropPlayers", "_automaticMode", "_count", "_interval", "_markers",
             "_keepMarkersOnCleanup"
         ];
         private _idBase = [_name, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-"] call BIS_fnc_filterString;
         if (_idBase == "") then {_idBase = "DZ"};
         private _id = [_idBase] call Waldo_fnc_CreateRuntimeId;
+        // No staticMinimumAltitude/staticMaximumAltitude/staticMaximumSpeed/haloMinimumAltitude keys
+        // here - Waldo_fnc_ParadropCreateDropZone always runs whatever it gets (its own mission-
+        // configured WALDO_STATIC_/WALDO_PARA_ defaults, absent an override) through
+        // Waldo_fnc_ParadropNormalizeJumpEnvelope regardless, so exposing raw numeric sliders here
+        // only invited Zeus to think precise tuning mattered/was their job when the server was
+        // always going to keep it jump-usable anyway. Enable/disable and chute class remain because
+        // those are genuine choices, not safety-critical numbers.
         private _config = createHashMapFromArray [
             ["id", _id], ["name", _name], ["centre", _modulePosition], ["side", _side], ["aircraftClass", _class],
             ["direction", _direction], ["altitude", _altitude], ["maximumSpeed", _speed], ["approachDistance", _approach],
             ["runLength", _length], ["exitDistance", _exit], ["lifecycle", _lifecycle], ["circuitDirection", _circuitDirection],
-            ["staticJumpEnabled", _staticEnabled], ["staticMinimumAltitude", _staticMin], ["staticMaximumAltitude", _staticMax],
-            ["staticMaximumSpeed", _staticSpeed], ["staticChuteClass", _staticChute], ["haloJumpEnabled", _haloEnabled],
-            ["haloMinimumAltitude", _haloMin], ["haloBackpackClass", _haloChute], ["requireOpenDoor", _requireDoor],
+            ["staticJumpEnabled", _staticEnabled], ["staticChuteClass", _staticChute], ["haloJumpEnabled", _haloEnabled],
+            ["haloBackpackClass", _haloChute], ["requireOpenDoor", _requireDoor],
             ["autoDropPlayers", _dropPlayers], ["automaticJumpMode", _automaticMode], ["jumperCount", round _count],
             ["createJumpers", _count > 0], ["jumpInterval", _interval], ["createMarkers", _markers],
             ["keepMarkersOnCleanup", _keepMarkersOnCleanup]

--- a/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
+++ b/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
@@ -97,6 +97,16 @@ if (isNull _aircraft || {!(_aircraft isKindOf "Air")}) exitWith {false};
 _aircraft setVariable ["Waldo_Paradrop_ManuallyConfigured", true, isServer];
 if !(isServer) exitWith {_this remoteExecCall ["Waldo_fnc_ParadropQuickFlightSetup", 2]; true};
 
+// This object's own init field runs on every machine (standard Eden behaviour), so every non-server
+// machine above just forwarded the exact same call here - with more than one client connected, the
+// server can receive it several times for the same aircraft. Waldo_fnc_ParadropBuildFlightRoute
+// deletes and rebuilds the whole group's waypoint list; a second rebuild landing mid-flight is
+// exactly how a LOOP aircraft ends up flying only one pass before falling back to loitering near
+// wherever its waypoint list happened to be cut off. Only the first arrival for this aircraft
+// actually builds the route.
+if (_aircraft getVariable ["Waldo_Paradrop_QuickSetupStarted", false]) exitWith {false};
+_aircraft setVariable ["Waldo_Paradrop_QuickSetupStarted", true];
+
 [_aircraft, _target, _direction, _altitude, _maxSpeed, _options] spawn {
     params ["_aircraft", "_target", "_direction", "_altitude", "_maxSpeed", "_options"];
 

--- a/wiki/Mission-Diagnostics.md
+++ b/wiki/Mission-Diagnostics.md
@@ -53,9 +53,10 @@ The server report checks:
 - configured crate, parachute, and paradrop values;
 - ACRE2 configuration, authoritative plan schema/revision, group counts and Babel readiness;
 - Economy, party-game, interaction-procedure, jamming, SafeStart, AAR/ENDEX, and custom 3D-marker state;
-- configured MHQ and VVD equipment;
+- configured MHQ, VVD and Field Hospital equipment;
 - recovery workshops, carriers, attached/virtual package state, Field Resupply hubs/carriers and Tactical Displays;
-- Hazard evaluator/audio state, typed helicopter/ground transport registries, and server/JIP registry parity for Dynamic AA, Dynamic AO, gunships and paradrop operations;
+- Hazard evaluator/audio state, typed helicopter/ground transport registries, and server/JIP registry parity for Dynamic AA, Dynamic AO and gunships;
+- Paradrop, in its own dedicated section: static-line/HALO altitude and chute-class thresholds, how many auto-detected jump-capable aircraft in the mission carry a server-visible static/HALO hold-action versus neither, the split between `Waldo_fnc_AddVehicleFunctions` auto-detection and a mission maker's own explicit setup call, and Dynamic Drop Zone registry/JIP parity;
 - ACE and Zeus integration availability.
 
 Each interface client reports:
@@ -67,9 +68,19 @@ Each interface client reports:
 - core and Economy Zeus module registration counts;
 - the custom 3D-marker renderer;
 - ACE or vanilla interaction installation on registered audit fixtures.
-- Tactical Display actions, WMP HUD eligibility/runtime state, transport actions and Hazard snapshot/evaluator state.
+- Tactical Display actions, WMP HUD eligibility/runtime state, transport actions, Field Hospital action installation and Hazard snapshot/evaluator state.
 
 The server rejects stale reports and reports whose claimed owner does not match the sending client. Missing client responses become warnings after four seconds.
+
+## Assistive hints
+
+A check that fails or is unexpectedly unconfigured can carry a short, plain-language remediation
+hint alongside its terse `state=`/`detail=` pair - not just *that* something is wrong, but *what to
+go and change*. A hint is folded into the same `detail` text as `"; fix: <hint>"`, so it reaches
+every existing consumer (RPT, `Waldo_Diagnostics_LastReport`, the hosted-server `systemChat` line)
+without changing the `[area, feature, state, detail]` report shape. For example, an invalid
+`WALDO_STATIC_STATICCHUTE` pointing at the RHS-only default without RHS loaded reports the exact
+variable to change and the vanilla fallback class to use, instead of just "class not found".
 
 ## Enabling diagnostics
 

--- a/wiki/Transport-Services.md
+++ b/wiki/Transport-Services.md
@@ -60,6 +60,7 @@ To travel:
 - **Request All Available** dispatches every eligible available transport of that type around one clicked centre. WMP uses enlarged, separate search slots instead of sending the fleet to one coordinate, then shows one combined result card instead of one card per vehicle.
 - **Return All Controlled to Base** returns every active same-type transport reserved by you or carrying you. Zeus may return every active transport of that type. “Available” vehicles are already at base and are therefore not included in RTB.
 - Repeating **Request Pickup** while that player's same-type transport is inbound or boarding moves the existing transport's pickup point. It never silently reserves a second vehicle.
+- **Select Destination** works the same way once a destination is already set: choosing it again while the transport is already travelling to that destination (`TO_DESTINATION`) retargets it, the same as retargeting a pickup - it does not require returning to `BOARDING` first.
 - Retargeting publishes a new request token before redispatch. Superseded AI-owner loops stop before they can land, stop or report against the old point.
 - The same named controls also exist directly on each transport. Being inside or near another transport no longer changes which object the action addresses.
 - The original requester may move pickup or order RTB while outside the vehicle. A passenger may select destination or order RTB for the transport they occupy. Zeus may manage any registered transport.

--- a/wiki/Transport-Services.md
+++ b/wiki/Transport-Services.md
@@ -41,7 +41,7 @@ The optional fifth argument is a readable HashMap. Omit it for the safe defaults
 ]] call Waldo_fnc_TransportRegister;
 ```
 
-Each registered vehicle has a WMP-blue informational action naming it as a **Helicopter Transport** or **Ground Transport**. The vehicle's ACE category and vanilla controls always include its configured name and affect that exact vehicle.
+Each registered vehicle has a WMP-blue informational action naming it as a **Helicopter Transport** or **Ground Transport** and reporting its current state - installed as a vanilla `addAction` alongside ACE, not only as a fallback when ACE is absent, so it's reachable without opening ACE Self Interact first. The vehicle's ACE category and vanilla controls always include its configured name and affect that exact vehicle; the four operational controls (move pickup, select destination, RTB, retry) remain ACE-priority with a vanilla fallback only when ACE genuinely isn't available.
 
 To travel:
 


### PR DESCRIPTION
**When merged this pull request will:**

**Mission Diagnostics coverage:**
- New dedicated Paradrop section (previously had none beyond generic class-validity checks): HALO altitude threshold validity (`WALDO_PARA_HALOALTITUDE` was never checked at all), a count of auto-detected jump-capable aircraft vs how many carry `Waldo_Paradrop_ManuallyConfigured` vs neither jump type installed (server-visible), and a dedicated Dynamic Drop Zone registry/JIP parity check with a specific remediation hint.
- New Field Hospital coverage: server-side facility-crate count/ACE-medical validity, client-side action-installation check mirroring the existing MHQ/VVD pattern.

**Mission Diagnostics assistiveness:**
- `_status` now accepts an optional "hint" — a short plain-language remediation step folded into the same `detail` text (`"; fix: <hint>"`), reaching RPT, `Waldo_Diagnostics_LastReport` and the hosted-server `systemChat` line without changing the report shape. Applied to the known `WALDO_STATIC_STATICCHUTE` RHS-default gotcha, static-line threshold ordering, and the new checks above.

**Transport Services fixes:**
- The informational `addAction` (naming a vehicle "Ground Transport: Ground One" and its current state) was nested inside `if (!_aceReady)`, so on any ACE-equipped mission — the normal case — it never installed at all. It's a discoverability cue, not a control ACE should take priority over, so it now installs alongside ACE, matching the pack's existing dual-surface policy (loadout-save points, party tables, Field Hospital crates). The four operational controls (move pickup/destination/RTB/retry) remain ACE-priority/vanilla-fallback only.
- **Select Destination** was hard-gated to `state == BOARDING` everywhere, so once a destination was set and the transport entered `TO_DESTINATION`, there was no way to change it again — unlike **Move Pickup Point**, which already supports retargeting while `TO_PICKUP` or `BOARDING`. The dispatch pipeline downstream of the phase gate is already fully generic (a fresh request serial/requestId invalidates any superseded AI-owner loop regardless of phase — the same mechanism that already makes pickup retargeting safe), so `SET_DESTINATION` now accepts `BOARDING` or `TO_DESTINATION` in all three places it's gated (server, the vehicle's own action, the self-menu action).

**Paradrop loop reliability**, toward a reported "only one pass then loiters near spawn, not looping":
- `Waldo_fnc_ParadropQuickFlightSetup`'s object init field runs on every machine; every non-server machine forwards the same call to the server. With more than one client connected, the server could receive it multiple times for the same aircraft, and the route builder deletes/rebuilds the whole group's waypoint list — a second rebuild landing mid-flight would explain exactly this symptom. Only the first arrival per aircraft now builds the route.
- The green/centre/red run-line waypoints used a 30 m completion radius — tight enough that a fast aircraft (this pack's own shipped composition uses 300/250 km/h, well above the 220 km/h default) can fail to satisfy it and circle trying rather than break off. Widened to 50 m.

All validators pass: `sqf_validator`, `documentation_contract_checker`, `wiki_style_checker`, `performance_audit`, full `test_full_arma_audit` suite (105 tests).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq

---
_Generated by [Claude Code](https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq)_