### PR TITLE
Show and keep transport service markers' status text updated

### DIFF
--- a/MissionScripts/Logistics/TransportServices/transportMonitorServer.sqf
+++ b/MissionScripts/Logistics/TransportServices/transportMonitorServer.sqf
@@ -2,6 +2,10 @@
  * Author: WaldoTheWarfighter, Val
  * Maintains registered transport markers and removes dead/deleted services from their typed pools.
  * It performs no movement planning and publishes availability booleans only when pool state changes.
+ * Besides tracking each vehicle's live position/facing, the marker's own text is kept in sync with
+ * that service's current state (Available, Boarding, To Pickup, To Destination, RTB, Disembarking,
+ * Stuck) - a marker that only ever shows the callsign gives no indication a transport is already
+ * busy without opening the interaction menu on it.
  * Locality and authority: server-only registry cleanup and JIP availability publication.
  *
  * Arguments: None.
@@ -10,6 +14,10 @@
  * Current caller: Waldo_fnc_TransportInitServer once per mission.
  */
 if (!isServer) exitWith {};
+private _stateLabels = createHashMapFromArray [
+    ["AVAILABLE", "Available"], ["BOARDING", "Boarding"], ["DISEMBARKING", "Disembarking"],
+    ["TO_PICKUP", "To Pickup"], ["TO_DESTINATION", "To Destination"], ["RTB", "RTB"], ["STUCK", "Stuck"]
+];
 while {missionNamespace getVariable ["Waldo_Transport_ServerStarted", false]} do {
     private _services = missionNamespace getVariable ["Waldo_Transport_Services", createHashMap];
     private _pools = missionNamespace getVariable ["Waldo_Transport_Pools", createHashMapFromArray [["HELICOPTER", []], ["GROUND", []]]];
@@ -36,7 +44,18 @@ while {missionNamespace getVariable ["Waldo_Transport_ServerStarted", false]} do
                 _services set [_id, _entry];
             };
             private _marker = _entry getOrDefault ["marker", ""];
-            if (_marker != "") then {_marker setMarkerPos getPosATL _vehicle; _marker setMarkerDir getDir _vehicle};
+            if (_marker != "") then {
+                _marker setMarkerPos getPosATL _vehicle;
+                _marker setMarkerDir getDir _vehicle;
+                private _state = _entry getOrDefault ["state", "AVAILABLE"];
+                private _stateLabel = _stateLabels getOrDefault [_state, _state];
+                private _markerText = format ["%1 - %2", _entry getOrDefault ["name", _id], _stateLabel];
+                private _lastMarkerText = _entry getOrDefault ["markerText", ""];
+                if (_markerText != _lastMarkerText) then {
+                    _marker setMarkerText _markerText;
+                    _entry set ["markerText", _markerText];
+                };
+            };
         };
     } forEach +(keys _services);
     missionNamespace setVariable ["Waldo_Transport_Services", _services];

--- a/MissionScripts/Logistics/TransportServices/transportRegister.sqf
+++ b/MissionScripts/Logistics/TransportServices/transportRegister.sqf
@@ -188,9 +188,14 @@ if (_config get "showMarker") then {
     deleteMarker _marker;
     createMarker [_marker, getPosATL _vehicle];
     _marker setMarkerType (if (_type == "HELICOPTER") then {"loc_heli"} else {"loc_car"});
-    _marker setMarkerText _displayName;
+    // Matches the "name - state" format Waldo_fnc_TransportMonitorServer keeps updated afterward -
+    // a freshly registered service is always AVAILABLE, so this is the same text the monitor's own
+    // first tick would set a moment later.
+    private _initialMarkerText = format ["%1 - Available", _displayName];
+    _marker setMarkerText _initialMarkerText;
     _marker setMarkerColor (switch (side driver _vehicle) do {case west: {"ColorWEST"}; case east: {"ColorEAST"}; case independent: {"ColorGUER"}; case civilian: {"ColorCIV"}; default {"ColorUNKNOWN"}});
     _entry set ["marker", _marker];
+    _entry set ["markerText", _initialMarkerText];
 };
 _services set [_id, _entry];
 missionNamespace setVariable ["Waldo_Transport_Services", _services];

--- a/wiki/Transport-Services.md
+++ b/wiki/Transport-Services.md
@@ -43,6 +43,8 @@ The optional fifth argument is a readable HashMap. Omit it for the safe defaults
 
 Each registered vehicle has a WMP-blue informational action naming it as a **Helicopter Transport** or **Ground Transport**. The vehicle's ACE category and vanilla controls always include its configured name and affect that exact vehicle.
 
+The optional service marker (`showMarker`) shows `<display name> - <state>` (for example `Raven One - Available`, `Raven One - To Pickup`, `Raven One - RTB`) and is kept in sync with the service's live position, facing and state every server tick - not just its display name at registration time. Set `showMarker` to `false` for a map-clutter-free operation instead.
+
 To travel:
 
 1. Open **ACE Self Interact > WMP Transport**.


### PR DESCRIPTION
**When merged this pull request will:**

Confirmed by screenshot: a registered transport's map marker showed only its callsign ("Raven One") forever, never anything about its current status — the marker's position/facing were already kept live by `Waldo_fnc_TransportMonitorServer`'s 2-second loop, but its text was set once at registration and never touched again.

The service entry's `state` (`AVAILABLE`/`BOARDING`/`DISEMBARKING`/`TO_PICKUP`/`TO_DESTINATION`/`RTB`/`STUCK` — already tracked and already broadcast on the vehicle as `Waldo_TransportService_State`) is now reflected in the marker text as `<name> - <state>` (e.g. `Raven One - Available`, `Raven One - To Pickup`), refreshed each monitor tick and only re-set when it actually changes. Registration itself now sets the same `<name> - Available` text immediately, instead of the bare name for the ~2 seconds until the monitor's first tick.

Documented in `wiki/Transport-Services.md`.

All validators pass: `sqf_validator`, `documentation_contract_checker`, `wiki_style_checker`, `performance_audit`, full `test_full_arma_audit` suite (105 tests).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq

---
_Generated by [Claude Code](https://claude.ai/code/session_012xgDFihuqWQnaBvUvE5jaq)_