### PR TITLE
Fix listen-host targeting bugs in gunship, field resupply and ZEN runtime toggles

### DIFF
--- a/MissionScripts/CombatSystems/AirborneGunship/gunshipPublishState.sqf
+++ b/MissionScripts/CombatSystems/AirborneGunship/gunshipPublishState.sqf
@@ -45,5 +45,9 @@ missionNamespace setVariable ["Waldo_Gunship_PublicSystems", _summaries, true];
     ],
     false
 ] remoteExecCall ["Waldo_fnc_FeatureRuntimeReceiveState", -2];
-[] remoteExecCall ["Waldo_fnc_GunshipSetupLocal", -2, "Waldo_Gunship_LocalSetup"];
+// Target 0 (all machines), not -2 ("all clients except owner 2"): a listen server's host shares
+// owner 2 with the embedded server, so -2 silently never reconciled controller actions/markers on
+// the hosting player's own client. Waldo_fnc_GunshipSetupLocal already guards on hasInterface, so
+// target 0 stays a safe no-op on a pure dedicated server.
+[] remoteExecCall ["Waldo_fnc_GunshipSetupLocal", 0, "Waldo_Gunship_LocalSetup"];
 _summaries

--- a/MissionScripts/CombatSystems/AirborneGunship/gunshipSetupLocal.sqf
+++ b/MissionScripts/CombatSystems/AirborneGunship/gunshipSetupLocal.sqf
@@ -3,9 +3,11 @@
  * Reconciles JIP-safe gunship markers and controller actions on one client.
  *
  * This repeat-safe client function consumes Waldo_Gunship_PublicSystems. It removes only actions
- * created by this feature, restores controller controls after respawn/JIP, and exposes status-only
- * feedback while an assigned aircraft is in transit, RTB or service. It is called by initPlayerLocal,
- * public-state publication and the audit refresh control.
+ * created by this feature and restores controller controls after respawn/JIP. A status readout is
+ * always available to the assigned controller; Designate Orbit and Return for Service also stay
+ * available while the aircraft is still in transit to its orbit (matching what the server actually
+ * permits), while per-turret weapon control only appears once the aircraft is on station or already
+ * controlled. It is called by initPlayerLocal, public-state publication and the audit refresh control.
  *
  * Arguments:
  * None
@@ -85,62 +87,72 @@ private _newVanillaActions = [];
     };
 
     if (_controller isEqualTo player) then {
-        private _available = _status in ["ON_STATION", "CONTROLLED"];
+        // Designate Orbit and Return for Service are legitimately available while the aircraft is
+        // still TRANSIT-ing to its orbit (the server's SET_ORBIT/SERVICE operations already allow
+        // this), so gating the whole menu behind a single ON_STATION/CONTROLLED "_available" boolean
+        // hid both of those actions - and the entire operational menu - during that window, most
+        // visibly right after initial registration/controller assignment. Only weapon control
+        // genuinely requires the aircraft to be physically on station.
+        private _canOrbitOrService = _status in ["TRANSIT", "ON_STATION", "CONTROLLED"];
+        private _canTakeControl = _status in ["ON_STATION", "CONTROLLED"];
         if !(isNil "ace_interact_menu_fnc_createAction") then {
             private _categoryId = format ["Waldo_Gunship_%1", _id];
             private _category = [_categoryId, format ["Gunship: %1", _callsign], "\A3\ui_f\data\map\vehicleicons\iconPlane_ca.paa", {}, {true}] call ace_interact_menu_fnc_createAction;
             [player, 1, ["ACE_SelfActions"], _category] call ace_interact_menu_fnc_addActionToObject;
             private _paths = [[player, 1, ["ACE_SelfActions", _categoryId]]];
-            if (_available) then {
-            private _orbitAction = [format ["%1_Orbit", _categoryId], "Designate Orbit", "\A3\ui_f\data\igui\cfg\simpletasks\types\map_ca.paa", {private _args = _this select 2; [(_args select 0)] call Waldo_fnc_GunshipSelectOrbitLocal}, {(_this select 2) select 1}, {}, [_id, _available]] call ace_interact_menu_fnc_createAction;
-            [player, 1, ["ACE_SelfActions", _categoryId], _orbitAction] call ace_interact_menu_fnc_addActionToObject;
-            _paths pushBack [player, 1, ["ACE_SelfActions", _categoryId, format ["%1_Orbit", _categoryId]]];
-            {
-                _x params ["_label", "_path"];
-                private _actionId = format ["%1_Turret_%2", _categoryId, _forEachIndex];
-                private _action = [_actionId, format ["Take Control: %1", _label], "\A3\ui_f\data\IGUI\Cfg\holdactions\holdAction_connect_ca.paa", {private _args = _this select 2; [(_args select 0), "TAKE_CONTROL", [_args select 1], player] remoteExecCall ["Waldo_fnc_GunshipServerHandle", 2]}, {(_this select 2) select 2}, {}, [_id, _path, _available]] call ace_interact_menu_fnc_createAction;
-                [player, 1, ["ACE_SelfActions", _categoryId], _action] call ace_interact_menu_fnc_addActionToObject;
-                _paths pushBack [player, 1, ["ACE_SelfActions", _categoryId, _actionId]];
-            } forEach _turretProfiles;
+            private _statusAction = [format ["%1_Status", _categoryId], format ["Status: %1", _status], "\A3\ui_f\data\igui\cfg\simpletasks\types\repair_ca.paa", {
+                private _args = _this select 2;
+                _args params ["_callsign", "_status", "_completeAt"];
+                private _detail = switch (_status) do {
+                    case "SERVICING": {format ["Service underway. Approximately %1 seconds remaining. Tasking and weapon control are locked.", ceil ((_completeAt - serverTime) max 0)]};
+                    case "RTB": {"Returning to the service orbit. Tasking and weapon control are locked."};
+                    case "TRANSIT": {"En route to its orbit. Orbit and service can be redirected now; weapon control unlocks once on station."};
+                    default {"The aircraft is currently unavailable for tasking."};
+                };
+                [format ["%1: %2", _callsign, _detail]] call Waldo_fnc_GunshipNotifyLocal;
+            }, {true}, {}, [_callsign, _status, _serviceCompleteAt]] call ace_interact_menu_fnc_createAction;
+            [player, 1, ["ACE_SelfActions", _categoryId], _statusAction] call ace_interact_menu_fnc_addActionToObject;
+            _paths pushBack [player, 1, ["ACE_SelfActions", _categoryId, format ["%1_Status", _categoryId]]];
+            if (_canOrbitOrService) then {
+                private _orbitAction = [format ["%1_Orbit", _categoryId], "Designate Orbit", "\A3\ui_f\data\igui\cfg\simpletasks\types\map_ca.paa", {private _args = _this select 2; [(_args select 0)] call Waldo_fnc_GunshipSelectOrbitLocal}, {(_this select 2) select 1}, {}, [_id, _canOrbitOrService]] call ace_interact_menu_fnc_createAction;
+                [player, 1, ["ACE_SelfActions", _categoryId], _orbitAction] call ace_interact_menu_fnc_addActionToObject;
+                _paths pushBack [player, 1, ["ACE_SelfActions", _categoryId, format ["%1_Orbit", _categoryId]]];
+                private _serviceAction = [format ["%1_Service", _categoryId], "Return for Service", "\A3\ui_f\data\igui\cfg\simpletasks\types\repair_ca.paa", {private _args = _this select 2; [(_args select 0), "SERVICE", [], player] remoteExecCall ["Waldo_fnc_GunshipServerHandle", 2]}, {(_this select 2) select 1}, {}, [_id, _canOrbitOrService]] call ace_interact_menu_fnc_createAction;
+                [player, 1, ["ACE_SelfActions", _categoryId], _serviceAction] call ace_interact_menu_fnc_addActionToObject;
+                _paths pushBack [player, 1, ["ACE_SelfActions", _categoryId, format ["%1_Service", _categoryId]]];
+            };
+            if (_canTakeControl) then {
+                {
+                    _x params ["_label", "_path"];
+                    private _actionId = format ["%1_Turret_%2", _categoryId, _forEachIndex];
+                    private _action = [_actionId, format ["Take Control: %1", _label], "\A3\ui_f\data\IGUI\Cfg\holdactions\holdAction_connect_ca.paa", {private _args = _this select 2; [(_args select 0), "TAKE_CONTROL", [_args select 1], player] remoteExecCall ["Waldo_fnc_GunshipServerHandle", 2]}, {(_this select 2) select 2}, {}, [_id, _path, _canTakeControl]] call ace_interact_menu_fnc_createAction;
+                    [player, 1, ["ACE_SelfActions", _categoryId], _action] call ace_interact_menu_fnc_addActionToObject;
+                    _paths pushBack [player, 1, ["ACE_SelfActions", _categoryId, _actionId]];
+                } forEach _turretProfiles;
+            };
             private _releaseAction = [format ["%1_Release", _categoryId], "Release Weapon Control", "\A3\ui_f\data\igui\cfg\actions\getout_ca.paa", {private _id = _this select 2; [_id, "RELEASE_CONTROL", [], player] remoteExecCall ["Waldo_fnc_GunshipServerHandle", 2]}, {missionNamespace getVariable ["Waldo_Gunship_ControlledId", ""] == (_this select 2)}, {}, _id] call ace_interact_menu_fnc_createAction;
             [player, 1, ["ACE_SelfActions", _categoryId], _releaseAction] call ace_interact_menu_fnc_addActionToObject;
             _paths pushBack [player, 1, ["ACE_SelfActions", _categoryId, format ["%1_Release", _categoryId]]];
-            private _serviceAction = [format ["%1_Service", _categoryId], "Return for Service", "\A3\ui_f\data\igui\cfg\simpletasks\types\repair_ca.paa", {private _args = _this select 2; [(_args select 0), "SERVICE", [], player] remoteExecCall ["Waldo_fnc_GunshipServerHandle", 2]}, {(_this select 2) select 1}, {}, [_id, _available]] call ace_interact_menu_fnc_createAction;
-            [player, 1, ["ACE_SelfActions", _categoryId], _serviceAction] call ace_interact_menu_fnc_addActionToObject;
-            _paths pushBack [player, 1, ["ACE_SelfActions", _categoryId, format ["%1_Service", _categoryId]]];
-            } else {
-                private _statusAction = [format ["%1_Status", _categoryId], format ["Status: %1", _status], "\A3\ui_f\data\igui\cfg\simpletasks\types\repair_ca.paa", {
-                    private _args = _this select 2;
-                    _args params ["_callsign", "_status", "_completeAt"];
-                    private _detail = if (_status == "SERVICING" && {_completeAt >= 0}) then {
-                        format ["Service underway. Approximately %1 seconds remaining. Tasking and weapon control are locked.", ceil ((_completeAt - serverTime) max 0)]
-                    } else {
-                        if (_status == "RTB") then {"Returning to the service orbit. Tasking and weapon control are locked."} else {"The aircraft is currently unavailable for tasking."}
-                    };
-                    [format ["%1: %2", _callsign, _detail]] call Waldo_fnc_GunshipNotifyLocal;
-                }, {true}, {}, [_callsign, _status, _serviceCompleteAt]] call ace_interact_menu_fnc_createAction;
-                [player, 1, ["ACE_SelfActions", _categoryId], _statusAction] call ace_interact_menu_fnc_addActionToObject;
-                _paths pushBack [player, 1, ["ACE_SelfActions", _categoryId, format ["%1_Status", _categoryId]]];
-            };
             _newAceActions append _paths;
         } else {
             private _actions = [];
-            if (_available) then {
-            _actions pushBack (player addAction [format ["%1: Designate Orbit", _callsign], {[(_this select 3)] call Waldo_fnc_GunshipSelectOrbitLocal}, _id, 1.5, false, true, "", str _available]);
-            {
-                _x params ["_label", "_path"];
-                _actions pushBack (player addAction [format ["%1: Control %2", _callsign, _label], {private _args = _this select 3; [_args select 0, "TAKE_CONTROL", [_args select 1], player] remoteExecCall ["Waldo_fnc_GunshipServerHandle", 2]}, [_id, _path], 1.5, false, true, "", str _available]);
-            } forEach _turretProfiles;
-            _actions pushBack (player addAction [format ["%1: Return for Service", _callsign], {[_this select 3, "SERVICE", [], player] remoteExecCall ["Waldo_fnc_GunshipServerHandle", 2]}, _id, 1.5, false, true, "", str _available]);
-            _actions pushBack (player addAction [format ["%1: Release Weapon Control", _callsign], {[_this select 3, "RELEASE_CONTROL", [], player] remoteExecCall ["Waldo_fnc_GunshipServerHandle", 2]}, _id, 1.5, false, true, "", "missionNamespace getVariable ['Waldo_Gunship_ControlledId', ''] != ''"]);
-            } else {
-                _actions pushBack (player addAction [format ["<t color='#79C7FF'>%1: Status (%2)</t>", _callsign, _status], {
-                    private _args = _this select 3;
-                    _args params ["_callsign", "_status", "_completeAt"];
-                    private _remaining = if (_status == "SERVICING") then {format ["; %1 seconds remaining", ceil ((_completeAt - serverTime) max 0)]} else {""};
-                    [format ["%1 is %2%3. Tasking and weapon control are locked.", _callsign, toLowerANSI _status, _remaining]] call Waldo_fnc_GunshipNotifyLocal;
-                }, [_callsign, _status, _serviceCompleteAt], 1.5, false, true]);
+            _actions pushBack (player addAction [format ["<t color='#79C7FF'>%1: Status (%2)</t>", _callsign, _status], {
+                private _args = _this select 3;
+                _args params ["_callsign", "_status", "_completeAt"];
+                private _remaining = if (_status == "SERVICING") then {format ["; %1 seconds remaining", ceil ((_completeAt - serverTime) max 0)]} else {""};
+                [format ["%1 is %2%3.", _callsign, toLowerANSI _status, _remaining]] call Waldo_fnc_GunshipNotifyLocal;
+            }, [_callsign, _status, _serviceCompleteAt], 1.5, false, true]);
+            if (_canOrbitOrService) then {
+                _actions pushBack (player addAction [format ["%1: Designate Orbit", _callsign], {[(_this select 3)] call Waldo_fnc_GunshipSelectOrbitLocal}, _id, 1.5, false, true, "", str _canOrbitOrService]);
+                _actions pushBack (player addAction [format ["%1: Return for Service", _callsign], {[_this select 3, "SERVICE", [], player] remoteExecCall ["Waldo_fnc_GunshipServerHandle", 2]}, _id, 1.5, false, true, "", str _canOrbitOrService]);
             };
+            if (_canTakeControl) then {
+                {
+                    _x params ["_label", "_path"];
+                    _actions pushBack (player addAction [format ["%1: Control %2", _callsign, _label], {private _args = _this select 3; [_args select 0, "TAKE_CONTROL", [_args select 1], player] remoteExecCall ["Waldo_fnc_GunshipServerHandle", 2]}, [_id, _path], 1.5, false, true, "", str _canTakeControl]);
+                } forEach _turretProfiles;
+            };
+            _actions pushBack (player addAction [format ["%1: Release Weapon Control", _callsign], {[_this select 3, "RELEASE_CONTROL", [], player] remoteExecCall ["Waldo_fnc_GunshipServerHandle", 2]}, _id, 1.5, false, true, "", "missionNamespace getVariable ['Waldo_Gunship_ControlledId', ''] != ''"]);
             _newVanillaActions append _actions;
         };
     };

--- a/MissionScripts/Logistics/FieldResupply/fieldResupplyServerHandle.sqf
+++ b/MissionScripts/Logistics/FieldResupply/fieldResupplyServerHandle.sqf
@@ -141,7 +141,12 @@ switch (toUpperANSI _operation) do {
         _unit setVariable ["Waldo_FieldResupply_Crates", _carried - 1, true];
         if !(isNil "ace_dragging_fnc_setDraggable") then {[_crate, true, [0, 0, 0], 0] call ace_dragging_fnc_setDraggable};
         if !(isNil "ace_dragging_fnc_setCarryable") then {[_crate, true, [0, 2, 1], 0] call ace_dragging_fnc_setCarryable};
-        [_crate] remoteExecCall ["Waldo_fnc_FieldResupplySetupCrateLocal", -2, format ["Waldo_FieldResupply_Crate_%1", netId _crate]];
+        // Target 0 (all machines), matching FieldResupplyRegisterHub's own equivalent call - not -2
+        // ("all clients", which excludes owner 2). On a listen server the host's own client shares
+        // owner 2 with the server, so -2 silently skipped installing the crate's local actions on
+        // exactly the machine most mission makers test from; FieldResupplySetupCrateLocal already
+        // guards with hasInterface, so target 0 stays a safe no-op on a pure dedicated server.
+        [_crate] remoteExecCall ["Waldo_fnc_FieldResupplySetupCrateLocal", 0, format ["Waldo_FieldResupply_Crate_%1", netId _crate]];
         [format ["Field resupply deployed with %1 uses; %2 portable crate(s) remain.", _charges, _carried - 1], "SUCCESS"] call _notify;
         true
     };
@@ -154,7 +159,12 @@ switch (toUpperANSI _operation) do {
         };
         private _charges = _crate getVariable ["Waldo_FieldResupply_Charges", 0];
         if (_charges <= 0) exitWith {["This Field Resupply crate is exhausted.", "WARNING"] call _notify; false};
-        private _compatibleClasses = ([_unit] call _getMagazineRows) apply {_x select 0};
+        // compatibleMagazines reflects what the unit's current weapons can load, not what they
+        // currently happen to be carrying - a unit that has fired dry on a magazine type (or is
+        // carrying none of it for any other reason) must still be able to draw more of it from the
+        // crate. Deriving this from _getMagazineRows (which reads the unit's own inventory) made
+        // that exact "actually needs a refill" case always report no compatible ammunition.
+        private _compatibleClasses = compatibleMagazines _unit;
         private _storedRows = _crate getVariable ["Waldo_FieldResupply_CargoRows", []];
         private _grantRows = _storedRows select {(_x param [0, "", [""]]) in _compatibleClasses};
         if (count _grantRows == 0) exitWith {
@@ -183,7 +193,11 @@ switch (toUpperANSI _operation) do {
         private _maximum = _unit getVariable ["Waldo_FieldResupply_MaxCrates", 0];
         private _carried = _unit getVariable ["Waldo_FieldResupply_Crates", 0];
         if (_recoverable && {_carried >= _maximum}) exitWith {["Carrier capacity is full.", "WARNING"] call _notify; false};
-        [] remoteExecCall ["", format ["Waldo_FieldResupply_Crate_%1", netId _crate]];
+        // Cancel the crate's persistent JIP-replay entry before deleting it - the JIP id is the
+        // 3rd remoteExecCall argument, not the 2nd (target); passing it as target previously called
+        // a no-op function at a garbage destination and left the JIP entry (and its now-dangling
+        // crate object reference) stored for any future joining player.
+        [] remoteExecCall ["", 0, format ["Waldo_FieldResupply_Crate_%1", netId _crate]];
         deleteVehicle _crate;
         if (_recoverable) then {
             _unit setVariable ["Waldo_FieldResupply_Crates", _carried + 1, true];

--- a/MissionScripts/Persistence/persistenceStop.sqf
+++ b/MissionScripts/Persistence/persistenceStop.sqf
@@ -14,11 +14,15 @@
 
 params [["_localOnly", false, [false]]];
 
-if !(isServer) exitWith {
-    if !(_localOnly) then {[] remoteExecCall ["Waldo_fnc_PersistenceStop", 2]};
+private _stopClientLoop = {
     private _clientHandle = missionNamespace getVariable ["Waldo_Persistence_ClientLoop", scriptNull];
     if !(scriptDone _clientHandle) then {terminate _clientHandle};
     missionNamespace setVariable ["Waldo_Persistence_ClientStarted", false];
+};
+
+if !(isServer) exitWith {
+    if !(_localOnly) then {[] remoteExecCall ["Waldo_fnc_PersistenceStop", 2]};
+    call _stopClientLoop;
 };
 
 private _remoteAuthorized = true;
@@ -39,4 +43,9 @@ private _handle = missionNamespace getVariable ["Waldo_Persistence_ServerLoop", 
 if !(scriptDone _handle) then {terminate _handle};
 missionNamespace setVariable ["Waldo_Persistence_ServerStarted", false];
 [true] remoteExecCall ["Waldo_fnc_PersistenceStop", -2];
+// -2 ("all clients except owner 2") never reaches a listen server's own host client, since the
+// host shares owner 2 with the embedded server - so on a listen server this machine's own
+// Waldo_Persistence_ClientLoop (started under hasInterface in persistenceInit.sqf) was never
+// terminated by the broadcast above. Stop it directly here too.
+if (hasInterface) then {call _stopClientLoop};
 diag_log "[WMP PERSISTENCE] Persistence stopped; stored records were retained.";

--- a/MissionScripts/ZenModules/RuntimeControl/featureRuntimeApply.sqf
+++ b/MissionScripts/ZenModules/RuntimeControl/featureRuntimeApply.sqf
@@ -98,9 +98,16 @@ switch (toUpperANSI _action) do {
             ["Waldo_TreatmentFeedback_NotifyPatient", _notifyPatient], ["Waldo_TreatmentFeedback_NotifyMedic", _notifyMedic],
             ["Waldo_TreatmentFeedback_ShowMedicName", _showMedic], ["Waldo_TreatmentFeedback_ShowBodyPart", _showBodyPart]
         ] call _publishAll;
+        // -2 ("all clients except owner 2") never reaches a listen server's own host client, since
+        // the host shares owner 2 with the embedded server - so the direct hasInterface calls below
+        // are required to actually apply this on a hosting player's own machine, not just remote
+        // clients. Every target function here already guards on hasInterface, so these are safe
+        // no-ops on a pure dedicated server.
         [] remoteExecCall ["Waldo_fnc_TreatmentFeedbackStop", -2];
+        if (hasInterface) then {[] call Waldo_fnc_TreatmentFeedbackStop};
         if (_enable) then {
             [] remoteExecCall ["Waldo_fnc_TreatmentFeedbackInit", -2, "Waldo_TreatmentFeedback_RuntimeInit"];
+            if (hasInterface) then {[] call Waldo_fnc_TreatmentFeedbackInit};
         } else {
             [] remoteExecCall ["", "Waldo_TreatmentFeedback_RuntimeInit"];
         };
@@ -182,9 +189,12 @@ switch (toUpperANSI _action) do {
             ["Waldo_Rally_PlacementDistance", (_placement max 1) min 10], ["Waldo_Rally_MaximumSlope", (_slope max 0) min 45],
             ["Waldo_Rally_AllowRegroup", _regroup]
         ] call _publishAll;
+        // See the listen-host note above TREATMENT_CONFIG's equivalent calls.
         [] remoteExecCall ["Waldo_fnc_RallyPointStop", -2];
+        if (hasInterface) then {[] call Waldo_fnc_RallyPointStop};
         if (_enable) then {
             [] remoteExecCall ["Waldo_fnc_RallyPointInit", -2, "Waldo_Rally_RuntimeInit"];
+            if (hasInterface) then {[] call Waldo_fnc_RallyPointInit};
         } else {
             [] call Waldo_fnc_RallyPointRemoveAllServer;
             [] remoteExecCall ["", "Waldo_Rally_RuntimeInit"];
@@ -202,10 +212,13 @@ switch (toUpperANSI _action) do {
             ["Waldo_TreeFelling_HitCooldown", _cooldown max 0.1], ["Waldo_TreeFelling_ClearBushes", _clearBushes],
             ["Waldo_TreeFelling_BushRadius", _bushRadius max 0]
         ] call _publishAll;
+        // See the listen-host note above TREATMENT_CONFIG's equivalent calls.
         if (_enable) then {
             [] remoteExecCall ["Waldo_fnc_TreeFellingInit", -2, "Waldo_TreeFelling_RuntimeInit"];
+            if (hasInterface) then {[] call Waldo_fnc_TreeFellingInit};
         } else {
             [] remoteExecCall ["Waldo_fnc_TreeFellingStop", -2];
+            if (hasInterface) then {[] call Waldo_fnc_TreeFellingStop};
             [] remoteExecCall ["", "Waldo_TreeFelling_RuntimeInit"];
         };
     };
@@ -218,10 +231,13 @@ switch (toUpperANSI _action) do {
             ["Waldo_EmergencyDismount_ClearPositionRadius", _clearRadius max 0], ["Waldo_EmergencyDismount_RequireClearExit", _requireClear],
             ["Waldo_EmergencyDismount_UseEject", _useEject], ["Waldo_EmergencyDismount_RecoverUnconscious", _recover]
         ] call _publishAll;
+        // See the listen-host note above TREATMENT_CONFIG's equivalent calls.
         if (_enable) then {
             [] remoteExecCall ["Waldo_fnc_EmergencyDismountInit", -2, "Waldo_EmergencyDismount_RuntimeInit"];
+            if (hasInterface) then {[] call Waldo_fnc_EmergencyDismountInit};
         } else {
             [] remoteExecCall ["Waldo_fnc_EmergencyDismountStop", -2];
+            if (hasInterface) then {[] call Waldo_fnc_EmergencyDismountStop};
             [] remoteExecCall ["", "Waldo_EmergencyDismount_RuntimeInit"];
         };
     };


### PR DESCRIPTION
## Summary

Two separate bug reports, root-caused and fixed, plus a follow-up audit of the same bug class.

### "Assigning a player as controller for gunship via the ZEN module doesn't make the ACE options available to the player"

Two contributing bugs, both fixed:

1. **Menu gating too strict.** The local self-action menu (`gunshipSetupLocal.sqf`) gated the *entire* operational menu behind a single `status in ["ON_STATION","CONTROLLED"]` boolean. But the server already allows `SET_ORBIT` (Designate Orbit) and `SERVICE` (Return for Service) while the aircraft is still `TRANSIT`-ing to its orbit — exactly the window right after initial registration/assignment. The UI was stricter than the server, so a freshly assigned controller saw only a bare status line and nothing else. Split into `_canOrbitOrService` (`TRANSIT`/`ON_STATION`/`CONTROLLED`) and `_canTakeControl` (`ON_STATION`/`CONTROLLED`, since weapon control genuinely needs the aircraft physically on station), matching what the server permits, and always show the status entry.
2. **Listen-host targeting bug.** `gunshipPublishState.sqf` reconciled every client's controls via `remoteExecCall [..., -2, ...]`. `-2` means "every machine except owner 2" — and on a listen server, the hosting player's own client *shares* owner 2 with the embedded server, so the host's own client never received the reconciliation call. Changed to `0` (all machines); the target function already guards on `hasInterface`, so this is a safe no-op on a dedicated server.

### "Field resupply crates cannot be interacted with to get refills, salvage or check charges once deployed"

Three bugs found and fixed in `fieldResupplyServerHandle.sqf`:

1. Same listen-host targeting bug as above: the deployed crate's local action installer was also dispatched with `-2`, so a mission hosted by the interacting player never got the crate's Take/Salvage/Inspect actions installed at all. Changed to `0`.
2. **TAKE compatibility bug.** It compared the crate's stored magazine rows against what the requesting unit *currently carries*, so a unit that had run completely dry on a magazine type — the exact scenario Field Resupply exists to fix — could never draw more of it. Now uses `compatibleMagazines _unit`, which reflects what the unit's equipped weapons can load regardless of current inventory.
3. **SALVAGE JIP-cancel bug.** The cleanup call passed the crate's JIP id as the `target` argument instead of the `jip` argument (`remoteExecCall [function, target, jip]`), so it silently failed to cancel the crate's persistent JIP-replay entry before deletion.

### Follow-up: audit of every other `-2` remoteExecCall for the same listen-host bug

Went through every `remoteExecCall [..., -2, ...]` in the codebase. Most already called their target function locally before/instead of the `-2` broadcast, correctly covering a listen server's own host client. Two more genuine gaps found and fixed:

- **`persistenceStop.sqf`**: the client-loop teardown only ran inside the `if !(isServer)` branch, which a listen host's own execution never enters — and the closing `-2` broadcast never reached it either, leaving `Waldo_Persistence_ClientLoop` running on the host after persistence was stopped server-side. Extracted the teardown into a shared codeblock and also run it locally under `hasInterface` after the server-side stop.
- **`featureRuntimeApply.sqf`**: the ZEN runtime-control toggles for **Treatment Feedback**, **Rally Points**, **Tree Felling** and **Emergency Dismount** dispatched their Init/Stop functions purely via `remoteExecCall [..., -2, ...]` with no local call at all — so toggling any of these four from the in-game ZEN dialog never took effect on a listen server's own host client. Added the matching `hasInterface`-guarded local call alongside each `-2` dispatch, mirroring the pattern the `AI_CONFIG` case already used correctly (target `0`).

Sites intentionally left as `-2` (confirmed not a bug): `aiRebalanceInit`/`aiRebalanceStop` and `improvedHelicopterLandingConfigureServer.sqf` already call their target function locally before remoteExec-ing to `-2`. `VVDInit.sqf`'s `-2` is a deliberate, commented recursion guard (target `0` would re-enter its own publish branch) and needs a different fix shape if ever revisited. The remaining `-2` sites (`gunshipPublishState`/`fieldResupplyRegisterHub` routing through `FeatureRuntimeReceiveState`) are redundant fast-path pushes on top of a value already set directly on the local machine by an unconditional broadcast `setVariable` moments earlier, so a missed push there changes nothing.

## Verification

- `sqf_validator.py` — pass
- `config_style_checker.py` — pass
- `zeus_script_parity_checker.py` — pass
- `performance_audit.py` — pass, no new high-severity findings
- `documentation_contract_checker.py` — pass
- `test_full_arma_audit.py` — 105/105 pass

🤖 Generated with [Claude Code](https://claude.ai/code)
