### PR TITLE
Fix paradrop loop drift, declutter drop zone markers, fix transport map bug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,7 +256,10 @@ a jump action gated on altitude/speed thresholds the plane's own route can never
 concrete "jump action never becomes available" failure this closes; `ParadropCreateDropZone` below
 normalizes off the same route-returned basis. `createMarkers` defaults to `true`
 (AREA/STANDBY/GREEN/RED/POINT markers, same layout as `ParadropCreateDropZone`) so a mission maker
-sees a working drop zone immediately — pass `false` for a map-clutter-free operation. Markers are
+sees a working drop zone immediately — pass `false` for a map-clutter-free operation. AREA/STANDBY/
+GREEN/RED are created invisible (alpha 0 — still real, queryable markers at the exact route
+positions) so only the single named POINT marker at the drop point is actually shown on the map,
+instead of the previous five-marker stack. Markers are
 removed automatically on aircraft death/deletion or once a `DESPAWN` lifecycle run reaches its exit
 point; set `keepMarkersOnCleanup` to `true` to opt out and leave them on the map instead. Neither
 this nor the opt-out ever deletes the aircraft or its crew, since this entry point never owns their

--- a/MissionScripts/Logistics/TransportServices/transportOpenMapLocal.sqf
+++ b/MissionScripts/Logistics/TransportServices/transportOpenMapLocal.sqf
@@ -10,7 +10,14 @@
  * Current callers: WMP transport ACE and vanilla self-actions.
  */
 params [["_action", "REQUEST_PICKUP", [""]], ["_type", "GROUND", [""]], ["_vehicle", objNull, [objNull]]];
-if (!hasInterface || {visibleMap}) exitWith {false};
+if !(hasInterface) exitWith {false};
+// Previously bailed out whenever the map was already open (visibleMap), on the assumption that
+// meant a still-pending selection from an earlier call to this same function. That's wrong when the
+// player simply had the map open for any other reason (e.g. opened it manually, or self-interacted
+// for transport while already looking at the map) - the request silently did nothing. A genuinely
+// pending transport click handler is still tracked below and gets replaced (not stacked) by this
+// call; an already-open map for any other reason now just gets this handler attached to it instead
+// of blocking the request, matching Waldo_fnc_GunshipSelectOrbitLocal's proven pattern.
 private _oldHandler = missionNamespace getVariable ["Waldo_Transport_MapHandler", -1];
 if (_oldHandler >= 0) then {removeMissionEventHandler ["MapSingleClick", _oldHandler]};
 missionNamespace setVariable ["Waldo_Transport_MapHandler", -1];

--- a/MissionScripts/Paradrop/paradropBuildFlightRoute.sqf
+++ b/MissionScripts/Paradrop/paradropBuildFlightRoute.sqf
@@ -121,8 +121,38 @@ private _addRouteWaypoint = {
     [_x, "MOVE", if (_forEachIndex in [1, 2, 3]) then {50} else {100}] call _addRouteWaypoint;
 } forEach [_standby, _green, _centre, _red, _exit];
 if (_lifecycle == "LOOP") then {
-    {[_x, "MOVE", 180] call _addRouteWaypoint} forEach [_crosswind, _downwind, _rejoin];
-    [_spawn, "CYCLE", 120] call _addRouteWaypoint;
+    {[_x, "MOVE", 180] call _addRouteWaypoint} forEach [_crosswind, _downwind, _rejoin, _spawn];
+    // Arma's native "CYCLE" waypoint type does not reliably resume at waypoint index 0 - the engine
+    // resumes at whichever waypoint in the group's list is geometrically nearest to the cycle
+    // waypoint's own position. For this route's shape that is "rejoin" (~_approach*0.6 away), not
+    // "standby" (a full _approach away by design) - so a native CYCLE waypoint here collapses the
+    // loop into a tight rejoin<->spawn shuttle after the very first pass instead of re-flying the
+    // marked standby->green->red->exit line, and anything anchored to that flight (drop timing, a
+    // mission maker's own per-pass marker/trigger logic) ends up scattered relative to where the
+    // first clean pass put it. Force a deterministic restart at index 0 instead of trusting that
+    // engine heuristic.
+    // This function clears and rebuilds the group's whole waypoint list on every call (see the file
+    // header), so a stray second call against the same still-flying group (both callers already
+    // guard against that themselves, but this loop must not assume it will always be true) must not
+    // stack a second copy of this watcher on top of the first.
+    if !(_flightGroup getVariable ["Waldo_Paradrop_CycleGuardStarted", false]) then {
+        _flightGroup setVariable ["Waldo_Paradrop_CycleGuardStarted", true];
+        [_flightGroup, _spawn] spawn {
+            params ["_flightGroup", "_spawn"];
+            while {!isNull _flightGroup && {count units _flightGroup > 0}} do {
+                waitUntil {
+                    sleep 1;
+                    isNull _flightGroup
+                    || {count units _flightGroup == 0}
+                    || {!alive leader _flightGroup}
+                    || {(leader _flightGroup) distance2D _spawn < 150}
+                };
+                if (isNull _flightGroup || {count units _flightGroup == 0} || {!alive leader _flightGroup}) exitWith {};
+                _flightGroup setCurrentWaypoint [_flightGroup, 0];
+                sleep 5; // clear the spawn radius before re-arming so this doesn't refire mid-restart.
+            };
+        };
+    };
 };
 if (_lifecycle == "RETAIN") then {
     private _loiter = [_hold, "LOITER", 250] call _addRouteWaypoint;

--- a/MissionScripts/Paradrop/paradropCreateDropZone.sqf
+++ b/MissionScripts/Paradrop/paradropCreateDropZone.sqf
@@ -4,7 +4,9 @@
  *
  * Operational side controls crew and generated jumper allegiance; airframe class is deliberately
  * independent. The server owns registry, groups, waypoints, jump timing and cleanup. Global Arma
- * markers provide normal JIP visibility without a custom replay layer. The aircraft carries only
+ * markers provide normal JIP visibility without a custom replay layer. The AREA/STANDBY/GREEN/RED
+ * route markers are created invisible (alpha 0, still real/queryable markers) so only the single
+ * named POINT marker at the drop point is actually shown on the map. The aircraft carries only
  * one AI pilot by default, receives the selected static-line/HALO actions on every client and can
  * fly a wide re-alignment circuit, remain after one pass or despawn. Jump envelopes are normalized
  * against the selected route altitude and speed so customization cannot silently make every jump
@@ -196,6 +198,12 @@ if (_config getOrDefault ["createMarkers", true]) then {
     _zoneMarker setMarkerDir _direction;
     _zoneMarker setMarkerSize [100, (_runLength * 0.65) max 200];
     _zoneMarker setMarkerColor "ColorBlack";
+    // AREA/STANDBY/GREEN/RED stay invisible (alpha 0) - they remain real markers at the exact route
+    // positions (still queryable by name, e.g. getMarkerPos, and still visible to a mission maker who
+    // reveals them deliberately) but are not shown on the map. The single named marker below is
+    // layered on top of this whole set as the one thing players actually see, instead of the previous
+    // five-marker stack.
+    _zoneMarker setMarkerAlpha 0;
     _markers pushBack _zoneMarker;
     {
         _x params ["_suffix", "_position", "_colour", "_text"];
@@ -206,6 +214,7 @@ if (_config getOrDefault ["createMarkers", true]) then {
         _marker setMarkerSize [30, 4];
         _marker setMarkerColor _colour;
         _marker setMarkerText _text;
+        _marker setMarkerAlpha 0;
         _markers pushBack _marker;
     } forEach [["STANDBY", _standby, "ColorYellow", "STANDBY"], ["GREEN", _green, "ColorGreen", "GREEN LINE"], ["RED", _red, "ColorRed", "RED LINE"]];
     private _point = createMarker [format ["%1_POINT", _prefix], _centre];

--- a/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
+++ b/MissionScripts/Paradrop/paradropQuickFlightSetup.sqf
@@ -51,10 +51,11 @@
  *    which waypoints get added and is one of the two automatic marker-cleanup triggers below),
  *    circuitDirection (LEFT/RIGHT, default LEFT), approachDistance/runLength/exitDistance (metres,
  *    default 2500 each), createMarkers (default true - AREA/STANDBY/GREEN/RED markers matching
- *    Waldo_fnc_ParadropCreateDropZone's layout, so a mission maker sees a working drop zone
- *    immediately, plus a POINT marker at the target - but only when target was not itself a marker
- *    name, since that marker already sits exactly there and a second icon/label on top of it would
- *    just overlap; set false for a map-clutter-free operation), keepMarkersOnCleanup (default false -
+ *    Waldo_fnc_ParadropCreateDropZone's layout, created invisible (alpha 0, still real/queryable
+ *    markers) so a mission maker gets the route's positional markers without the map clutter, plus a
+ *    visible POINT marker at the target - but only when target was not itself a marker name, since
+ *    that marker already sits exactly there and a second icon/label on top of it would just overlap;
+ *    set false for a map-clutter-free operation), keepMarkersOnCleanup (default false -
  *    the created markers are removed automatically once the aircraft is destroyed/deleted, or once a
  *    DESPAWN run reaches its exit point; set true to leave them on the map instead; never affects the
  *    aircraft or crew either way), name (marker label, default "Drop Zone").
@@ -248,6 +249,12 @@ _aircraft setVariable ["Waldo_Paradrop_QuickSetupStarted", true];
         _zoneMarker setMarkerDir _resolvedDirection;
         _zoneMarker setMarkerSize [100, (_runLength * 0.65) max 200];
         _zoneMarker setMarkerColor "ColorBlack";
+        // AREA/STANDBY/GREEN/RED stay invisible (alpha 0) - they remain real markers at the exact
+        // route positions (still queryable by name, e.g. getMarkerPos, and still visible to a mission
+        // maker who reveals them deliberately) but are not shown on the map. The POINT marker below is
+        // layered on top of this whole set as the one thing players actually see, instead of the
+        // previous stacked five-marker layout.
+        _zoneMarker setMarkerAlpha 0;
         _markers pushBack _zoneMarker;
         {
             _x params ["_suffix", "_key", "_colour", "_text"];
@@ -258,6 +265,7 @@ _aircraft setVariable ["Waldo_Paradrop_QuickSetupStarted", true];
             _marker setMarkerSize [30, 4];
             _marker setMarkerColor _colour;
             _marker setMarkerText _text;
+            _marker setMarkerAlpha 0;
             _markers pushBack _marker;
         } forEach [["STANDBY", "standby", "ColorYellow", "STANDBY"], ["GREEN", "green", "ColorGreen", "GREEN LINE"], ["RED", "red", "ColorRed", "RED LINE"]];
         // When target was a marker name, that marker already sits exactly at _centre - creating


### PR DESCRIPTION
**When merged this pull request will:**
- Fix `Waldo_fnc_ParadropBuildFlightRoute` so a LOOP-lifecycle drop zone aircraft reliably re-flies the full marked circuit on every pass. Arma's native `CYCLE` waypoint resumes at whichever waypoint is geometrically nearest to it — for this route's shape that is `rejoin` (~1500m away), not the intended `standby` (a full `approach` leg, 2500m by default, away by design) — which collapsed the loop into a tight rejoin↔spawn shuttle after the first clean pass. Replaced the `CYCLE` waypoint with a plain `MOVE` waypoint plus a small single-start-guarded watcher that explicitly resets the group to waypoint index 0 once it returns near spawn.
- Declutter drop zone map markers in both `Waldo_fnc_ParadropCreateDropZone` and `Waldo_fnc_ParadropQuickFlightSetup`: the AREA/STANDBY/GREEN/RED route markers are now created invisible (`setMarkerAlpha 0` — still real, positioned, queryable markers), so only the single named POINT marker is actually shown on the map instead of the previous five-marker stack.
- Fix `Waldo_fnc_TransportOpenMapLocal` silently doing nothing when a player self-interacts for transport while the map is already open for any other reason. It previously bailed out on `visibleMap` regardless of cause; now it only guards on `hasInterface` and a genuinely pending transport click handler, matching the working pattern already used by `Waldo_fnc_GunshipSelectOrbitLocal` for the same class of problem.
- Documentation: updated the affected function headers and the `CLAUDE.md` Paradrop section to describe the new invisible-marker layout, matching the project's documentation standard.

All changes verified against `sqf_validator.py`, `config_style_checker.py`, and `performance_audit.py` (no new high-severity findings) before pushing.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_019n7ghy2hPz4bryM1X5oBNA)_