### PR TITLE
Beginner-focused wiki pass + fix broken Dynamic AO Minimal composition

### DIFF
--- a/.claude/skills/mission-pack-config/references/dynamic-ao.md
+++ b/.claude/skills/mission-pack-config/references/dynamic-ao.md
@@ -49,8 +49,10 @@ replaces the old AO. Key bounds: `radius` 100–2000m, `patrolGroups` 0–12,
 ### Eden composition (beginner drop-in)
 
 `WMP_Compositions/[WMP]Dynamic_AO_Example_Minimal` anchors a randomized AO
-to a placed object with only `id` and `center` set — `patrolGroups`/
-`garrisonGroups` default to a small `3` each, every other category
+to a placed object with `id`, `center` and `faction` set (`faction` has no
+default and is the one truly required key beyond `id`/`center` — omitting
+it makes the whole call a silent no-op) — `patrolGroups`/`garrisonGroups`
+default to a small `3` each, every other category
 (static turrets, vehicle/air patrols, civilians, minefields, roadblocks)
 defaults to `0`/off. `_Full` shows every category/key explicitly on the
 same anchor object.

--- a/WMP_Compositions/README.md
+++ b/WMP_Compositions/README.md
@@ -68,7 +68,7 @@ copies of feature logic.
 | Hazard Emitter Moving Example (Full) | Contamination field that follows a vehicle, via `Waldo_fnc_HazardRegisterEmitter` directly, every option shown |
 | Dynamic AA Example (Minimal) | Smallest working anchor object - id and centre only |
 | Dynamic AA Example (Full) | Anchor object generating a radar, static and mobile AA site around itself, every option shown |
-| Dynamic AO Example (Minimal) | Smallest working anchor object - id and centre only |
+| Dynamic AO Example (Minimal) | Smallest working anchor object - id, centre and faction (faction has no default) |
 | Dynamic AO Example (Full) | Anchor object generating a randomized area of operations around itself, every option shown |
 | Explosive Wall Breaching Example (Minimal) | Smallest working profile - an empty HashMap uses every default |
 | Explosive Wall Breaching Example (Full) | Explicit demolition-charge profile with a visibly testable centre gap, every key shown |

--- a/WMP_Compositions/[WMP]Dynamic_AO_Example_Minimal/composition.sqe
+++ b/WMP_Compositions/[WMP]Dynamic_AO_Example_Minimal/composition.sqe
@@ -11,7 +11,7 @@ class items
 		class Attributes
 		{
 			name="WMP_DynamicAO_Anchor";
-			init="[createHashMapFromArray [[""id"", ""composition_ao_minimal""], [""center"", getPosATL this]]] call Waldo_fnc_DynamicAOCreate;";
+			init="[createHashMapFromArray [[""id"", ""composition_ao_minimal""], [""center"", getPosATL this], [""faction"", ""OPF_F""]]] call Waldo_fnc_DynamicAOCreate;";
 		};
 		id=1;
 		type="Land_HelipadEmpty_F";
@@ -20,7 +20,7 @@ class items
 	{
 		dataType="Comment";
 		class PositionInfo {position[]={0,-5,0};};
-		title="Dynamic AO (Minimal): the smallest working call - id and center are all that's required. Generates a default east-side, 500 m radius area of operations with 3 patrol groups (garrisons, statics and vehicles are all off unless configured). See the Dynamic AO Example (Full) composition to see and edit every option; every supported config key is in wiki/Dynamic-AO-Generation.md. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Dynamic-AO-Generation";
+		title="Dynamic AO (Minimal): the smallest working call - id, center and faction are all that's required (faction has no default and must be set, unlike most other keys here). Generates a default east-side, 500 m radius area of operations using OPF_F (vanilla CSAT) with 3 patrol groups (garrisons, statics and vehicles are all off unless configured). See the Dynamic AO Example (Full) composition to see and edit every option; every supported config key is in wiki/Dynamic-AO-Generation.md. Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Dynamic-AO-Generation";
 		id=2;
 	};
 };

--- a/wiki/ACRE-2-Long-Range-Radio-Presetting.md
+++ b/wiki/ACRE-2-Long-Range-Radio-Presetting.md
@@ -9,6 +9,32 @@ server sends the complete side/group setup to joining players, and each player's
 configures only the radios that player carries after ACRE is ready. Do not add ACRE waits or radio
 setup calls to multiplayer `init.sqf`.
 
+## Smallest working example: one group, one net
+
+Before the full nets/families/overrides model below, here is the minimum that gets one squad
+talking to each other on their own channel — everything else on this page is depth for when a
+mission needs more than this. Inside the `"sides"` row for `WEST` in `MissionConfig\acreConfig.sqf`
+(keep the shipped official ACRE preset name):
+
+```sqf
+[
+    "WEST", "default3",
+    [ // NETS: [key, label, family, value]
+        ["PLT1", "PLATOON 1", "PRC_LR", 2]
+    ],
+    [ // GROUPS: [editor groupId, assignment rows]
+        ["ALPHA-1-1", [                          // must match the Eden group's groupId
+            ["ACRE_PRC343", "ALL", [1, 1], "LEFT"],   // short-range squad radio, block 1 channel 1
+            ["ACRE_PRC152", "ALL", "PLT1", "RIGHT"]   // long-range radio tuned to the PLT1 net
+        ]]
+    ]
+]
+```
+
+Every carried PRC-343 in that group starts on block 1/channel 1, and every carried PRC-152 starts on
+the `PLT1` net. Read on for multiple nets, duplicate radios needing different tunings, per-player
+overrides and named displays.
+
 ## Settings to edit
 
 - `enabled`: master switch for the replacement lifecycle.

--- a/wiki/ACRE-2-Squad-Level-Radios-AN-PRC‐343-Automatic-Setup.md
+++ b/wiki/ACRE-2-Squad-Level-Radios-AN-PRC‐343-Automatic-Setup.md
@@ -2,6 +2,12 @@
 
 > **Use this page when:** you need repeatable PRC-343 block/channel allocation by side and group.
 
+_Associated Files: `MissionConfig\acreConfig.sqf`; `MissionScripts\MissionInit\ACRE2\`_
+
+This is the PRC-343-specific detail for one part of the group assignment row described in full on
+[ACRE2 Communications Configuration](ACRE-2-Long-Range-Radio-Presetting) — start there for the
+overall nets/groups model if this is your first time configuring ACRE2 radios.
+
 PRC-343 assignments come from `MissionConfig\acreConfig.sqf`. The server sends the completed setup
 to players, while each player's own computer configures the radio they carry. Side and group ID are
 both used, so identical callsigns on opposing sides do not overwrite one another.
@@ -38,6 +44,12 @@ it is ambiguous to a beginner. Unlisted occurrences remain untouched. Ear accept
 Both values must be between 1 and 16. Invalid assignments are rejected. With strict validation enabled, collisions are rejected; with strict mode disabled, they are retained and clearly reported. For a PRC-343 row whose target is `[]`, two numeric callsign components become block/channel, a single numeric component becomes the channel within the callsign prefix's deterministic block, and a callsign without numbers receives a deterministic free slot.
 
 The client converts the pair to ACRE's flat channel only when it applies a unique PRC-343 radio ID. The default `prc343PresetPolicy = "FULL_RANGE"` deliberately assigns the PRC-343 `default` preset on every side, exposing B1–B16 while leaving long-range radios on their normal side presets. Set the policy to `SIDE_ISOLATED` only when side-separated PRC-343 frequencies are required; WEST `default3`, EAST `default2`, and Independent `default4` then expose B1–B5. The CEOI continues to show the clearer block/channel form, and WMP rejects out-of-range blocks before ACRE can silently clamp them.
+
+## See also
+
+- [ACRE2 Communications Configuration](ACRE-2-Long-Range-Radio-Presetting)
+- [ACRE2 Automated CEOI Document](ACRE2-Automated-CEOI-Document)
+- [ACRE2 Babel Configuration](ACRE2-Babel-Configuration)
 
 <!-- WMP-WIKI-NAV -->
 ---

--- a/wiki/Airborne-Gunship-Support.md
+++ b/wiki/Airborne-Gunship-Support.md
@@ -18,7 +18,17 @@ interaction, including approximate remaining service time.
 
 The feature is disabled by default. Calling `Waldo_fnc_GunshipRegister` or using the registration Zeus module explicitly enables it.
 
-## Scripted setup
+## Three ways to get one flying
+
+1. **No scripting:** place a crewed aircraft in Eden, then in a running mission use the **Gunship - Register or Spawn** Zeus module on it (see Focused Zeus modules below).
+2. **Drop-in example:** place the `[WMP]Gunship_Support_Example_Minimal` composition from `WMP_Compositions/` — a crewed VTOL already registered with the minimum required keys.
+3. **Smallest working script call**, in the placed-and-crewed aircraft's own init field:
+   ```sqf
+   [createHashMapFromArray [["id", "spectre_1"], ["aircraft", this]]] call Waldo_fnc_GunshipRegister;
+   ```
+   Every other key below (callsign, side, home/orbit markers, altitude, radius, service envelope, turret profiles) has a working default — add only the ones a mission actually needs to change.
+
+## Scripted setup (every option)
 
 Run registration from `initServer.sqf` after the aircraft and player slots exist:
 

--- a/wiki/Custom-3D-World-Markers.md
+++ b/wiki/Custom-3D-World-Markers.md
@@ -12,6 +12,18 @@ one permanent loop per marker.
 
 ## Create or update a marker
 
+Smallest working call — a stable ID and an anchor, everything else takes its default:
+
+```sqf
+["generator_alpha", generator_1] call Waldo_fnc_Create3DMarker;
+```
+
+The anchor can be an object or an ATL position. Calling the function again with
+the same ID updates the existing marker in place. Calls made on clients are forwarded to
+the server automatically.
+
+Add an options HashMap as the third argument to override any default:
+
 ```sqf
 [
     "generator_alpha",
@@ -26,10 +38,6 @@ one permanent loop per marker.
     ]
 ] call Waldo_fnc_Create3DMarker;
 ```
-
-The anchor can be an object or an ATL position. Calling the function again with
-the same ID updates the existing marker. Calls made on clients are forwarded to
-the server automatically.
 
 | Option | Default | Purpose |
 |---|---|---|
@@ -57,6 +65,12 @@ the server automatically.
 Use stable, mission-specific IDs. Always pair colour with meaningful text and
 an appropriate icon so the marker remains understandable for colourblind
 players.
+
+## See also
+
+- [Eden Compositions](Eden-Compositions) — the `[WMP]Custom_3D_Marker_Example` Minimal/Full pair
+- [Optional Feature Systems](Optional-Feature-Systems)
+- [Mission Configuration Reference](Mission-Configuration-Reference)
 
 <!-- WMP-WIKI-NAV -->
 ---

--- a/wiki/Dynamic-AO-Generation.md
+++ b/wiki/Dynamic-AO-Generation.md
@@ -20,6 +20,18 @@ The modules are registered only when Zeus Enhanced is available. The script API 
 
 Call the generator on the server. A non-server call is forwarded to the server, but remote player requests are accepted only from an assigned curator.
 
+Unlike most other keys, **`faction` has no default and is genuinely required** alongside `id` and
+`center` — omitting it makes the whole call silently do nothing (no error, no spawned assets). The
+smallest working call is:
+
+```sqf
+[createHashMapFromArray [
+    ["id", "AO_NORTH"], ["center", getMarkerPos "ao_north"], ["faction", "OPF_F"]
+]] call Waldo_fnc_DynamicAOCreate;
+```
+
+For every other option set explicitly:
+
 ```sqf
 private _config = createHashMapFromArray [
     ["id", "AO_NORTH"], ["center", getMarkerPos "ao_north"],

--- a/wiki/Eden-Compositions.md
+++ b/wiki/Eden-Compositions.md
@@ -7,38 +7,22 @@ WMP compositions are shipped as a separate archive. They accelerate mission auth
 include the feature scripts themselves. Install the matching WMP release in the mission first.
 
 The catalogue is split into Foundation, Logistics, Air Operations, Combat Systems, Interface,
-Mission Systems and Mission Tools so Eden does not present one undifferentiated list.
+Mission Systems and Mission Tools so Eden does not present one undifferentiated list. The full,
+current, per-composition list lives in `WMP_Compositions/README.md` inside the pack (its "Current
+catalogue" table) — this page explains how to *read* a composition, not a duplicate inventory that
+would otherwise go stale as compositions are added.
 
-## Newly covered systems
+## Minimal and Full pairs
 
-- **Bomb Defusal Example:** an editable electronic device with the standard wire-cutting challenge
-  and explosive failure consequence.
-- **Construction Objects Example:** an ACE construction supply crate using the modern construction
-  audio profile.
-- **Electronic Warfare Examples:** one EMP-immune vehicle and one WEST-tracked vehicle, spaced for
-  immediate testing.
-- **Object Scaling Example:** a decorative object converted to a supported Simple Object at 175%
-  scale. The comment warns that conversion replaces the original object reference.
-- **Custom 3D Marker Example:** a signal relay with labelled marker options written as readable
-  key/value pairs in its init field.
+Every composition with real optional parameters ships as two folders:
 
-- **Vehicle Recovery Workshop Example:** a safely spaced workshop, recoverable MRAP and generic
-  `AUTO` carrier. All share workshop key `MAIN`; the workshop includes optional area and point
-  markers.
-- **Field Resupply Hub Example:** an unlimited, all-side hub. Assign portable crates to infantry
-  with Zeus or `[unit, currentCrates, maximumCrates] call Waldo_fnc_FieldResupplyAssignCarrier`.
-- **Radio Jammer Example:** a 300 m omnidirectional jammer affecting all sides and bands. It starts
-  active, is curator-visible, and uses the mission's configured disable/reactivate interaction.
-- **Hazardous Zone Example:** a fixed 15 m toxic leak with entry/exit notification, staged damage and
-  fatal exposure. Its inline profile is deliberately visible so it can be rewritten for scenario RP.
-- **Tactical Display Example:** a supported map board that opens the client Tactical Display. It
-  follows the viewer's side, uses a 2000 m radius and may show known enemy contacts.
-- **Loadout Save Point Example:** a laptop with both the ACE interaction and WMP-blue vanilla action;
-  the save includes supported ACRE radio state and is restored for that player only.
-- **Explosive Wall Breaching Example:** an explicit 8 m wall profile whose demolition-charge result
-  leaves two 4 m sections and a clearly visible central gap.
-- **Emergency Dismount Vehicle Example:** an upright, simulated MRAP that enables the feature without
-  risking a startup collision; overturn or destroy it during play to expose the action.
+- **`..._Minimal`** — the smallest call that actually works: only the function's truly required
+  arguments, relying entirely on its own documented defaults for everything else. Start here.
+- **`..._Full`** — the same object(s) with every option set explicitly, so a mission maker can see
+  and edit each one once the basics make sense.
+
+A composition without real optional parameters (a fixed prop, or a call that's already minimal by
+nature) ships as a single unsuffixed folder instead of a redundant pair.
 
 ## Locality rule
 
@@ -54,12 +38,23 @@ guidance from inside Eden.
 
 ## Why some features have no composition
 
-Generated AO/AA systems, airborne gunships and dynamic drop zones must be created once by the server;
-an Eden init runs on every machine, so their safe beginner path is `initServer.sqf` or Zeus rather
-than a misleading composition. Player accessibility, treatment feedback, persistence, UI themes,
-rally state, terrain-tree felling and automatic AI handlers likewise do not become clearer or safer
-when represented by a decorative Eden object. Use their `MissionConfig` settings, documented public
-setup call, full audit station or focused Zeus module instead.
+Dynamic AA, Dynamic AO Generation and Airborne Gunship Support all ship compositions — their
+registration functions (`Waldo_fnc_DynamicAACreate`, `Waldo_fnc_DynamicAOCreate`,
+`Waldo_fnc_GunshipRegister`) self-forward a non-server call to the server exactly like
+`Waldo_fnc_Jammer` or `Waldo_fnc_HazardRegisterZone`, which already shipped as compositions, so an
+Eden init running on every machine is safe for them too. Only **generated drop zones**
+(`Waldo_fnc_ParadropCreateDropZone`) remain excluded for a genuinely different reason: that function
+spawns and owns its own aircraft/crew, and an Eden object cannot represent "spawn this on demand" the
+way it represents "here is a real placed thing" — use `initServer.sqf` or the "Dynamic Paradrop" ZEN
+module instead. The [Halo and Static-Line Paradrop Examples](Vehicle-Actions-&-Paradrop) composition
+covers the placed-and-crewed-aircraft case instead.
+
+Player accessibility, treatment feedback, persistence enablement itself (though registering one
+specific persistent object is exactly as composable as the systems above — see the Persistence
+Object Example composition), UI themes, rally state, terrain-tree felling and automatic AI handlers
+likewise do not become clearer or safer when represented by a decorative Eden object. Use their
+`MissionConfig` settings, documented public setup call, full audit station or focused Zeus module
+instead.
 
 <!-- WMP-WIKI-NAV -->
 ---

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -12,6 +12,7 @@ Waldos Mission Pack is an Arma 3 mission scripting framework for mission makers 
 |---|---|
 | Install WMP in a mission | [Quickstart Guide](Quickstart-Guide) |
 | Find a feature | [Feature Index](Feature-Tutorials) |
+| Drop in a ready-made example instead of scripting from scratch | [Eden Compositions](Eden-Compositions) |
 | Configure mission entry files | [Mission Configuration Reference](Mission-Configuration-Reference) |
 | Set up or activate a feature | [Feature Setup and Activation](Feature-Setup-and-Activation) |
 | Find a feature setting | [Feature Configuration Files](Feature-Configuration-Files) |
@@ -38,6 +39,8 @@ Waldos Mission Pack is an Arma 3 mission scripting framework for mission makers 
 - [Mobile Command Post](Mobile-Command-Post-With-Integrated-Logistics-System)
 - [Virtual Vehicle Depot](Virtual-Vehicle-Depot)
 - [Vehicle Actions and Paradrop](Vehicle-Actions-&-Paradrop)
+- [Transport Services](Transport-Services) — reusable AI helicopter/ground pickup and delivery
+- [Vehicle Recovery and Squad Rally Points](Vehicle-Recovery-And-Squad-Rallies)
 
 ### Economy and base building
 

--- a/wiki/Interaction-Procedure-Access-Terminal.md
+++ b/wiki/Interaction-Procedure-Access-Terminal.md
@@ -2,11 +2,19 @@
 
 > **Use this page when:** you are configuring or operating the evidence-driven keypad procedure.
 
+_Associated Files: `MissionScripts\InteractionsMinigames\`, `Waldo_fnc_MiniGameInteractionSetup`_
+
 The `keypad` procedure represents an access terminal or safe controller whose authorization code must be recovered from on-screen records.
 
 | Operating card | Active terminal |
 |---|---|
 | ![Access operating card](images/interaction-procedures/interaction-keypad-briefing.png) | ![Industrial access terminal](images/interaction-procedures/interaction-keypad-active.png) |
+
+**Simplest setup** — every other option below has a working default:
+
+```sqf
+[this, "keypad"] call Waldo_fnc_MiniGameInteractionSetup;
+```
 
 ## Operator procedure
 

--- a/wiki/Interaction-Procedure-Breaker-Cabinet.md
+++ b/wiki/Interaction-Procedure-Breaker-Cabinet.md
@@ -2,11 +2,19 @@
 
 > **Use this page when:** you are configuring or operating the terminal-routing circuit procedure.
 
+_Associated Files: `MissionScripts\InteractionsMinigames\`, `Waldo_fnc_MiniGameInteractionSetup`_
+
 The `circuit` procedure represents a breaker cabinet, fuse panel, or communications relay whose isolated terminals must be routed to matching buses.
 
 | Operating card | Active cabinet |
 |---|---|
 | ![Breaker operating card](images/interaction-procedures/interaction-circuit-briefing.png) | ![Breaker cabinet](images/interaction-procedures/interaction-circuit-active.png) |
+
+**Simplest setup** — every other option below has a working default:
+
+```sqf
+[this, "circuit"] call Waldo_fnc_MiniGameInteractionSetup;
+```
 
 ## Operator procedure
 

--- a/wiki/Interaction-Procedure-Command-Uplink.md
+++ b/wiki/Interaction-Procedure-Command-Uplink.md
@@ -2,11 +2,19 @@
 
 > **Use this page when:** you are configuring or operating the directional command-entry procedure.
 
+_Associated Files: `MissionScripts\InteractionsMinigames\`, `Waldo_fnc_MiniGameInteractionSetup`_
+
 The `commandinput` procedure is a directional command-entry console inspired by field support and terminal authorization interfaces.
 
 | Operating card | Active uplink |
 |---|---|
 | ![Uplink operating card](images/interaction-procedures/interaction-commandinput-briefing.png) | ![Tactical command uplink](images/interaction-procedures/interaction-commandinput-active.png) |
+
+**Simplest setup** — every other option below has a working default:
+
+```sqf
+[this, "commandinput"] call Waldo_fnc_MiniGameInteractionSetup;
+```
 
 ## Operator procedure
 

--- a/wiki/Interaction-Procedure-Communications-Unit.md
+++ b/wiki/Interaction-Procedure-Communications-Unit.md
@@ -2,11 +2,19 @@
 
 > **Use this page when:** you are configuring or operating the radio-carrier tuning procedure.
 
+_Associated Files: `MissionScripts\InteractionsMinigames\`, `Waldo_fnc_MiniGameInteractionSetup`_
+
 The `radiotune` procedure represents a NATO-style radio, antenna controller, or distress-beacon receiver.
 
 | Operating card | Active radio |
 |---|---|
 | ![Radio operating card](images/interaction-procedures/interaction-radiotune-briefing.png) | ![Tactical communications unit](images/interaction-procedures/interaction-radiotune-active.png) |
+
+**Simplest setup** — every other option below has a working default:
+
+```sqf
+[this, "radiotune"] call Waldo_fnc_MiniGameInteractionSetup;
+```
 
 ## Operator procedure
 

--- a/wiki/Interaction-Procedure-Control-Sequence.md
+++ b/wiki/Interaction-Procedure-Control-Sequence.md
@@ -2,11 +2,19 @@
 
 > **Use this page when:** you are configuring or operating the observe-and-repeat control sequence.
 
+_Associated Files: `MissionScripts\InteractionsMinigames\`, `Waldo_fnc_MiniGameInteractionSetup`_
+
 The `sequence` procedure represents a guarded control console that plays progressively longer authorization signals.
 
 | Operating card | Active console |
 |---|---|
 | ![Sequence operating card](images/interaction-procedures/interaction-sequence-briefing.png) | ![Secure sequence console](images/interaction-procedures/interaction-sequence-active.png) |
+
+**Simplest setup** — every other option below has a working default:
+
+```sqf
+[this, "sequence"] call Waldo_fnc_MiniGameInteractionSetup;
+```
 
 ## Operator procedure
 

--- a/wiki/Interaction-Procedure-EOD-Controller.md
+++ b/wiki/Interaction-Procedure-EOD-Controller.md
@@ -2,11 +2,19 @@
 
 > **Use this page when:** you are configuring or operating the loom-identification and isolation procedure.
 
+_Associated Files: `MissionScripts\InteractionsMinigames\`, `Waldo_fnc_MiniGameInteractionSetup`_
+
 The `wirecut` procedure represents a rugged field controller used to isolate and sever one live lead. It is suitable for bombs, demolition charges, vehicle sabotage, and booby-trapped equipment.
 
 | Operating card | Active controller |
 |---|---|
 | ![EOD operating card](images/interaction-procedures/interaction-wirecut-briefing.png) | ![EOD controller](images/interaction-procedures/interaction-wirecut-active.png) |
+
+**Simplest setup** — every other option below has a working default:
+
+```sqf
+[this, "wirecut"] call Waldo_fnc_MiniGameInteractionSetup;
+```
 
 ## Operator procedure
 

--- a/wiki/Interaction-Procedure-Hydraulic-Manifold.md
+++ b/wiki/Interaction-Procedure-Hydraulic-Manifold.md
@@ -2,11 +2,19 @@
 
 > **Use this page when:** you are configuring or operating the coupled pressure-balancing procedure.
 
+_Associated Files: `MissionScripts\InteractionsMinigames\`, `Waldo_fnc_MiniGameInteractionSetup`_
+
 The `pressure` procedure represents a hydraulic, pneumatic, fuel-pressure, or coolant-control manifold with coupled lines.
 
 | Operating card | Active manifold |
 |---|---|
 | ![Pressure operating card](images/interaction-procedures/interaction-pressure-briefing.png) | ![Hydraulic manifold](images/interaction-procedures/interaction-pressure-active.png) |
+
+**Simplest setup** — every other option below has a working default:
+
+```sqf
+[this, "pressure"] call Waldo_fnc_MiniGameInteractionSetup;
+```
 
 ## Operator procedure
 

--- a/wiki/Interaction-Procedure-Lock-Cylinder.md
+++ b/wiki/Interaction-Procedure-Lock-Cylinder.md
@@ -2,11 +2,19 @@
 
 > **Use this page when:** you are configuring or operating the tension-and-pin lock procedure.
 
+_Associated Files: `MissionScripts\InteractionsMinigames\`, `Waldo_fnc_MiniGameInteractionSetup`_
+
 The `lockpick` procedure exposes the pin stacks, shear line, pick, tension state, and cylinder progress of a mechanical lock.
 
 | Operating card | Active cylinder |
 |---|---|
 | ![Lock operating card](images/interaction-procedures/interaction-lockpick-briefing.png) | ![Cutaway lock cylinder](images/interaction-procedures/interaction-lockpick-active.png) |
+
+**Simplest setup** — every other option below has a working default:
+
+```sqf
+[this, "lockpick"] call Waldo_fnc_MiniGameInteractionSetup;
+```
 
 ## Operator procedure
 

--- a/wiki/Interaction-Procedure-Maintenance-Hatch.md
+++ b/wiki/Interaction-Procedure-Maintenance-Hatch.md
@@ -2,11 +2,19 @@
 
 > **Use this page when:** you are configuring or operating the calibrated torque repair procedure.
 
+_Associated Files: `MissionScripts\InteractionsMinigames\`, `Waldo_fnc_MiniGameInteractionSetup`_
+
 The `repair` procedure represents a service hatch containing fasteners that must be tightened to their engraved torque specifications.
 
 | Operating card | Active hatch |
 |---|---|
 | ![Maintenance operating card](images/interaction-procedures/interaction-repair-briefing.png) | ![Maintenance hatch](images/interaction-procedures/interaction-repair-active.png) |
+
+**Simplest setup** — every other option below has a working default:
+
+```sqf
+[this, "repair"] call Waldo_fnc_MiniGameInteractionSetup;
+```
 
 ## Operator procedure
 

--- a/wiki/Interaction-Procedure-Ordnance-Diagnostics.md
+++ b/wiki/Interaction-Procedure-Ordnance-Diagnostics.md
@@ -2,11 +2,19 @@
 
 > **Use this page when:** you are configuring or operating the explosive-circuit matrix procedure.
 
+_Associated Files: `MissionScripts\InteractionsMinigames\`, `Waldo_fnc_MiniGameInteractionSetup`_
+
 The `minesweeper` procedure presents a portable explosive-circuit matrix. Use it for trigger diagnosis, minefield control units, fault maps, or damaged electronics.
 
 | Operating card | Active tablet |
 |---|---|
 | ![Diagnostic operating card](images/interaction-procedures/interaction-minesweeper-briefing.png) | ![Ordnance diagnostic tablet](images/interaction-procedures/interaction-minesweeper-active.png) |
+
+**Simplest setup** — every other option below has a working default:
+
+```sqf
+[this, "minesweeper"] call Waldo_fnc_MiniGameInteractionSetup;
+```
 
 ## Operator procedure
 

--- a/wiki/Optional-Feature-Extensions.md
+++ b/wiki/Optional-Feature-Extensions.md
@@ -4,6 +4,8 @@
 
 _Associated Files: `init.sqf`; feature implementations under their matching `MissionScripts/` domains_
 
+**First time setting up one of these systems?** This page assumes it's already enabled and running — for the first-time "turn it on" walkthrough, go to [Optional Feature Systems](Optional-Feature-Systems) (persistence, hazardous environments, tree felling, emergency dismount, WMP HUD, explosive breaching, object scaling) or [Waldo's AI Tuning](Waldos-AI-Tweak) (AI rebalance) instead. This page covers the extra options layered on top: deeper customisation and less-common configuration, plus field resupply and tactical display, which don't have their own dedicated page yet.
+
 These extensions remain disabled by default, independently configurable and safe to initialise more than once. They use feature-specific settings rather than a mandatory common profile layer.
 
 ## Persistence interoperability
@@ -47,30 +49,46 @@ Arma's direction commands to reset it to 1.
 
 ## AI rebalance
 
+For enabling the system and picking a built-in profile, see [Waldo's AI Tuning](Waldos-AI-Tweak). The rest of this section covers narrower targeting for a custom or overridden profile.
+
 Profiles can target existing units, new units or both. Include/exclude filters cover sides, factions and classes; individual units can set `Waldo_AI_Exclude`. Bounded random variance is optional. Original named skills are captured and can be restored when the feature stops. Locality handlers reapply the profile after a unit moves to a server or headless client.
 
 The system does not automatically alter difficulty in response to server performance or player success. Such feedback loops make results inconsistent and difficult to validate.
 
 ## Field resupply
 
-This finite-resource ammunition feature lets a hub refill carrier crate allowances, carriers deploy charge-limited crates, players take validated magazine types, and crates be salvaged. All ACE controls sit beneath a **Field Resupply** category on the carrier, hub or deployed crate. An assigned carrier wearing a backpack receives **Check Resupply Crates** and **Deploy Field Resupply**, with scroll-wheel fallbacks only when ACE Interact is unavailable. Deployment is restricted to being on foot. A deployed crate derives logical supply rows from the carrier's compatible loaded/carried magazine classes, but its physical inventory stays empty so Gear access cannot bypass charge consumption. A WMP-blue informational addAction identifies the crate and reports its remaining charges. Server checks enforce ownership, distance, side access, stock and capacity. Focused Zeus modules register a nearby hub, assign a nearby carrier, or grant additional portable crates during play.
+This finite-resource ammunition feature lets a hub refill carrier crate allowances, carriers deploy charge-limited crates, players take validated magazine types, and crates be salvaged. Quickest working setup — both calls are server-owned, safe to leave in each object's own Eden init field:
+
+1. Place an object to act as the refill hub (e.g. an ammo point). In its init field:
+   ```sqf
+   [this, west, -1] call Waldo_fnc_FieldResupplyRegisterHub;
+   // [hub, servicedSide, stock] - sideUnknown serves everyone, -1 stock is unlimited
+   ```
+2. Assign a player (or Zeus-placed AI mule) as a carrier — via Zeus's assignment module during play, or in the unit's init field:
+   ```sqf
+   [this, 3, 3] call Waldo_fnc_FieldResupplyAssignCarrier;
+   // [unit, startingCrates, maximumCrates]
+   ```
+3. The carrier (must be wearing a backpack) gets **Check Resupply Crates** (refill at the hub) and **Deploy Field Resupply** (drop a crate for others) under ACE Interact's **Field Resupply** category, with scroll-wheel fallbacks only when ACE Interact is unavailable. Deployment is restricted to being on foot.
+
+A deployed crate derives logical supply rows from the carrier's compatible loaded/carried magazine classes, but its physical inventory stays empty so Gear access cannot bypass charge consumption. A WMP-blue informational addAction identifies the crate and reports its remaining charges. Server checks enforce ownership, distance, side access, stock and capacity. Focused Zeus modules register a nearby hub, assign a nearby carrier, or grant additional portable crates during play — no scripting needed for a Zeus-run mission.
 
 Mission scripts can grant crates with `[_carrier, _amount, _expandCapacity] call Waldo_fnc_FieldResupplyGrantCrates`. The default `false` expansion flag clamps the grant to the carrier's existing spare capacity; `true` raises capacity enough to fit the entire grant. The server broadcasts the updated count and informs only the receiving player. If a grant occurs during startup, its notification waits until the stock fake loading/title presentation has finished, with a 60-second safety release for missions that replace the intro without publishing completion.
 
 Magazine allow/block lists, minimum magazine capacity, crate class, charge count, carry capacity and respawn retention are configurable. Capacity-based issue amounts default to 4 magazines for capacities up to 4 rounds, 3 up to 10, 8 up to 40, 3 up to 70 and 2 above 70; missions may replace those five amounts or select a fixed amount. Unused crates can be recovered by a carrier, while removing a partly consumed crate recovers no portable crate. It does not guess vehicle-ammunition compatibility or manufacture mod ammunition outside the configured rules.
 
-Scripted setup is server-owned:
-
-```sqf
-if (isServer) then {
-    [supplyHub, west, -1] call Waldo_fnc_FieldResupplyRegisterHub;
-    [mule, 3, 3] call Waldo_fnc_FieldResupplyAssignCarrier;
-};
-```
-
 ## Tactical display
 
-A registered world object provides a proximity- and line-of-sight-gated tactical map. It draws friendly units and only enemies already known to the player's group, within the configured radius. It closes when the display object is destroyed or the player leaves range. Use a map board or whiteboard-style object when the world fixture itself must visibly read as a tactical display; the full-pack audit uses a white map board rather than an infostand or data terminal.
+A registered world object provides a proximity- and line-of-sight-gated tactical map. It draws friendly units and only enemies already known to the player's group, within the configured radius. It closes when the display object is destroyed or the player leaves range. Quickest working setup:
+
+1. Place a map board or whiteboard-style object in Eden (e.g. `Land_MapBoard_F`) — Arma can't reliably project an interactive map onto arbitrary object materials, so a generic infostand or data terminal is not supported.
+2. In the object's init field (no `isServer` wrapper needed — the call forwards itself):
+   ```sqf
+   [this] call Waldo_fnc_TacticalDisplayRegister;
+   ```
+3. Walk up to it in game and use the interaction — a normal client map display opens, filtered to friendlies and already-known enemies within range.
+
+Every other argument (side, radius, known-enemies, an optional authentication gate) has a working default — see the full call below only when one of those needs changing.
 
 Registration can optionally require a shared authentication procedure before the ordinary display
 action becomes available. The semantic default is `commandinput / standard`; script and Zeus setup

--- a/wiki/Optional-Feature-Systems.md
+++ b/wiki/Optional-Feature-Systems.md
@@ -14,7 +14,26 @@ When Zeus Enhanced is loaded, the categorized WMP palette includes focused runti
 
 ## Persistence
 
-Set `Waldo_Persistence_Enable = true`. The server then looks for an available INIDBI2 runtime and disables persistence cleanly if none can be initialised. Database access remains server-only.
+Save/restore player state (and specific registered world objects) across a database, backed by the INIDBI2 extension. Quickest working setup:
+
+1. Install the INIDBI2 extension on the **server** (not required on clients) — see its own release for that step; WMP does not bundle it.
+2. Open `MissionConfig\persistenceConfig.sqf` and set `Waldo_Persistence_Enable` to `true`.
+3. Launch the mission on a server that has INIDBI2 installed. The server probes for a real, loaded extension (not just a declared dependency) and disables itself cleanly if the probe fails — check the RPT for `[WMP DIAG]` persistence lines if nothing is saving.
+4. Play, disconnect and reconnect (or use `Waldo_fnc_PersistenceStop` then restart the mission) to confirm loadout/medical state is restored.
+
+Database access remains server-only; clients only capture/apply their own state.
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `Waldo_Persistence_Enable` | `false` | Master opt-in; requires a working server INIDBI2 extension |
+| `Waldo_Persistence_SaveLoadout` | `true` | Filtered inventory (unique ACRE radio IDs stripped) |
+| `Waldo_Persistence_SaveMedical` | `true` | ACE medical state |
+| `Waldo_Persistence_SaveFoodWater` | `false` | Hunger/thirst state |
+| `Waldo_Persistence_SavePosition` | `false` | Off by default — can bypass mission flow (e.g. skip an intro area) |
+| `Waldo_Persistence_SaveRadios` | `false` | Per-player ACRE channel/spatial state |
+| `Waldo_Persistence_Scope` | `"MISSION"` | `"MISSION"` isolates records by mission+terrain; `"CAMPAIGN"` shares by database name across missions |
+| `Waldo_Persistence_DatabaseName` | `"WaldosMissionPack"` | Database identity; only matters when `Scope` is `"CAMPAIGN"` |
+| `Waldo_Persistence_DefaultCustomVariables` | `[]` | Extra variable names saved alongside the built-in fields — see [Optional Feature Extensions](Optional-Feature-Extensions) |
 
 Zeus can use **Persistence - Control** to start, reconfigure or stop the system, and **Persistence - Register Object** near an object to assign its stable key and saved fields during play. **Persistence - Save Now** requests an immediate state capture from connected players and writes selected registered objects without stopping persistence. It reports cleanly when the required runtime is not active.
 
@@ -37,7 +56,11 @@ The five booleans control cargo, damage, fuel, ammunition/pylons and position. K
 
 ## Patient treatment feedback
 
-Set `Waldo_TreatmentFeedback_Enable = true` to display ACE treatment start, completion and interruption events through the pack notification UI. ACE emits these events locally to the treating unit, so the feature securely forwards patient feedback to the patient's owning machine. Self-treatment remains local.
+Requires ACE Medical. Quickest working setup:
+
+1. Open `MissionConfig\interfaceConfig.sqf` and set `Waldo_TreatmentFeedback_Enable` to `true`.
+2. Have one player treat another (e.g. bandage a wound) with ACE Medical.
+3. The patient sees a WMP notification card at treatment start, completion and interruption — not the medic, since this is patient-facing feedback. ACE emits these events locally to the treating unit, so the feature securely forwards them to the patient's owning machine. Self-treatment remains local.
 
 Start, success and failure notifications can be enabled independently. Patient notification is enabled by default; optional medic feedback, medic names and body-region labels can be selected separately. Treatment cards replace one another in a dedicated padded bottom-centre region, so they do not consume the general notification stacks; `Waldo_TreatmentFeedback_Duration` controls their short post-event lifetime and defaults to three seconds. Titles, body-region names and treatment-class display-name overrides are configured through the player-local `Waldo_TreatmentFeedback_*` values in `MissionConfig\interfaceConfig.sqf`; colours follow the standard WMP semantic states.
 
@@ -45,7 +68,18 @@ Call `Waldo_fnc_TreatmentFeedbackInit` or `Waldo_fnc_TreatmentFeedbackStop` on i
 
 ## Hazardous environments
 
-Set `Waldo_Hazard_Enable = true`, then register any number of zones from `initServer.sqf`. A zone accepts a trigger, marker name, moving object emitter, `[position, radius]`, or `[position, axisA, axisB, angle, rectangle]`, plus an extensible profile hash map. The server publishes enablement and the complete registry as one ordered snapshot, so connected players and JIP clients start against the same state. Do not register shared zones separately on every client.
+Repeatable exposure zones (radiation is the shipped preset family) with real damage, protection and a HUD. Quickest working setup, using a shipped preset — no profile authoring needed:
+
+1. Open `MissionConfig\environmentConfig.sqf` and set `Waldo_Hazard_Enable` to `true`.
+2. Place a trigger or marker in Eden marking the danger area, e.g. name a marker `reactor_zone`.
+3. In `initServer.sqf`, register it against a shipped preset with one call:
+   ```sqf
+   ["reactor_leak", "reactor_zone", "MODERATE_RADIATION"] call Waldo_fnc_HazardRegisterPresetZone;
+   // [key, area, presetKey] - LOW_RADIATION / MODERATE_RADIATION / SEVERE_RADIATION are ready to use
+   ```
+4. Walk into the marked area. A continuous lower-left exposure panel appears, followed by damage once exposure crosses a threshold.
+
+For a custom (non-preset) profile, or to override specific preset fields, see the manual `Waldo_fnc_HazardRegisterZone` call and key table below. Set `Waldo_Hazard_Enable = true`, then register any number of zones from `initServer.sqf`. A zone accepts a trigger, marker name, moving object emitter, `[position, radius]`, or `[position, axisA, axisB, angle, rectangle]`, plus an extensible profile hash map. The server publishes enablement and the complete registry as one ordered snapshot, so connected players and JIP clients start against the same state. Do not register shared zones separately on every client.
 
 **Hazard - Create** builds a circular zone at the module position. After choosing a mission preset, the curator can give it a custom RP-facing name and entry/exit wording, choose linear or constant intensity, and configure range, exposure/recovery, exposure cap, damage, fatal threshold, vehicle/interior protection and entry/exit notifications. A zero damage value and zero fatal threshold produce a non-injuring roleplay zone; non-zero values create real ACE wounds (or vanilla damage without ACE). **Hazard - Remove Nearest** removes the nearest registered zone. Scripted profiles remain available for multiple damage tiers, custom protective-equipment rules and callbacks.
 
@@ -64,6 +98,26 @@ private _profile = (missionNamespace getVariable ["Waldo_Hazard_Presets", create
 ```
 
 Profiles can represent contamination, toxic gas, extreme temperature, vacuum or custom hazards. `damageThresholds` are ordered `[exposure, damage-per-evaluator-tick]` tiers; `fatalExposure` forces death at the configured exposure, or `-1` disables it. Crossing a new damaging tier produces one WMP warning by default; override `notifyDamageStages`, `damageMessage` or `damageStageMessages` for the scenario. Protection can come from equipment, vehicles or interiors. For dedicated-safe `onEnter`, `onExit` or `onTick` behaviour, store the callback function in `missionNamespace` and put its function-name string in the profile; raw CODE callbacks are intentionally not transmitted as JIP state. For a moving source, use `[_key, _object, _radius, _profile] call Waldo_fnc_HazardRegisterEmitter`. Unregister on the server with `Waldo_fnc_HazardUnregisterZone`, or stop only the current client's evaluation with `Waldo_fnc_HazardStop`.
+
+### Profile key quick reference
+
+The most commonly-tuned keys of a hazard profile hash map — a preset already sets sensible values for all of these, this table is for building a custom profile or overriding a preset:
+
+| Key | Default | Purpose |
+|---|---|---|
+| `label` | `""` | RP-facing name shown in entry/exit cards and the status panel |
+| `intensityMode` | `"LINEAR"` | `LINEAR` fades toward the edge; `CONSTANT` is full intensity everywhere inside the zone |
+| `rate` | `1` | Exposure gained per second while inside, at full intensity |
+| `decay` | `0.1` | Exposure lost per second while outside the zone |
+| `decontaminationRate` | `1` | Exposure lost per second while protected/decontaminating inside the zone |
+| `maximumExposure` | `1e10` (effectively uncapped) | Hard cap on accumulated exposure |
+| `damageThresholds` | `[]` | Ordered `[exposure, damage-per-tick]` tiers |
+| `fatalExposure` | unset | Exposure that forces death; `-1` disables it |
+| `protectIndoors` / `protectInVehicles` | preset-dependent | Whether being inside a building/vehicle reduces exposure |
+| `showStatus` | `true` (global default) | Per-profile override of the continuous lower-left panel |
+| `notifyTransitions` | `true` (global default) | Per-profile override of entry/exit cards |
+| `markerEnabled` | `false` | Registers a `Waldo_fnc_Create3DMarker` world marker — see below |
+| `detectorItems` / `detectorObjects` | unset | Restrict awareness (status/notices only, never protection) to players with a listed item or near a listed object |
 
 ### Tying a hazard to a world marker
 
@@ -104,9 +158,13 @@ Start and stop the automatic client action with `Waldo_fnc_TreeFellingInit` and
 
 ## Emergency dismount
 
-Set `Waldo_EmergencyDismount_Enable = true`. The local occupant monitor can extract a player from an overturned or destroyed land vehicle or boat, choose a clear nearby position, optionally preserve velocity and provide a short configurable damage-protection window.
+Automatically extracts a player from an overturned or destroyed land vehicle/boat. Quickest working setup:
 
-Use the `Waldo_EmergencyDismount_*` settings to select overturn/destruction triggers, normal exit versus eject, clear-exit geometry checks, momentum preservation, safe-position radius, bounded damage protection and unconscious recovery. Start and stop it with `Waldo_fnc_EmergencyDismountInit` and `Waldo_fnc_EmergencyDismountStop`; it intentionally has no ZEN module.
+1. Open `MissionConfig\environmentConfig.sqf` and set `Waldo_EmergencyDismount_Enable` to `true`.
+2. Play, roll a land vehicle onto its roof (or destroy it) with a player inside.
+3. The occupant is automatically extracted to a clear nearby position, with a short configurable damage-protection window.
+
+No further setup is required for ordinary land vehicles/boats — aircraft are excluded by default (see below). Use the `Waldo_EmergencyDismount_*` settings to select overturn/destruction triggers, normal exit versus eject, clear-exit geometry checks, momentum preservation, safe-position radius, bounded damage protection and unconscious recovery. Start and stop it with `Waldo_fnc_EmergencyDismountInit` and `Waldo_fnc_EmergencyDismountStop`; it intentionally has no ZEN module.
 
 Land vehicles also receive a local **Set Vehicle Upright** action on the vehicle itself when tipped and nearly stationary. The server validates proximity, forwards the operation to the vehicle's owning machine and places it above the terrain using its real model bounds and the local surface normal. Vehicle simulation must remain enabled for both the emergency extraction and upright mechanics.
 
@@ -196,13 +254,18 @@ cut a new hole into arbitrary model collision geometry. Breaching intentionally 
 
 ## Object scaling
 
-Scale one object on the server:
+Resizes a placed object at runtime — for a giant/miniature prop, or an intentionally undersized/oversized decoration. Two ways to use it:
 
-```sqf
-private _scaledStatue = [statue, 1.75, true] call Waldo_fnc_ObjectScale;
-```
+1. **Zeus (no scripting):** place **Scale Object** on the target, choose the scale, and explicitly permit decorative conversion if the target isn't already a Simple Object.
+2. **Script**, one call on the server:
+   ```sqf
+   private _scaledStatue = [statue, 1.75, true] call Waldo_fnc_ObjectScale;
+   // [object, scale, allowDecorativeConversion]
+   ```
 
-Arma officially supports runtime scaling for Simple Objects and attached objects. Merely disabling simulation on an ordinary object does not make scaling supported. The third argument explicitly converts an empty grounded decorative target to a Simple Object; conversion removes simulation, damage, inventory, crew, object-bound `addAction` entries and the original object reference, so always retain the returned object. Direction/orientation commands reset scale and must run first. Limits default to `0.1`–`10` and are server-owned in `initServer.sqf`. Remote requests are curator-only unless explicitly relaxed. For batches, tag objects with `Waldo_ObjectScale` and call `Waldo_fnc_ObjectScaleTagged`. Zeus can place **Scale Object** on a target, choose the scale and explicitly permit decorative conversion.
+**Always keep the returned object** — the third argument (`true`) converts an ordinary empty grounded decorative target into a Simple Object so scaling is actually supported; that conversion removes simulation, damage, inventory, crew, object-bound `addAction` entries and the original object reference, so the object your script/Eden variable name pointed at is gone and replaced.
+
+Arma officially supports runtime scaling for Simple Objects and attached objects only — merely disabling simulation on an ordinary object does not make scaling supported. Direction/orientation commands reset scale and must run first. Limits default to `0.1`–`10` and are server-owned in `initServer.sqf`. Remote requests are curator-only unless explicitly relaxed. For batches, tag objects with `Waldo_ObjectScale` and call `Waldo_fnc_ObjectScaleTagged`.
 
 ## See also
 

--- a/wiki/Vehicle-Recovery-And-Squad-Rallies.md
+++ b/wiki/Vehicle-Recovery-And-Squad-Rallies.md
@@ -8,6 +8,16 @@ Both systems keep authoritative registries and world mutation on the server and 
 
 Vehicle recovery is opt-in per object. Register one or more workshops, recoverable vehicles and optional carrier vehicles. A damaged, empty and stationary registered vehicle can be packaged into a transportable cargo object. When an unloaded, grounded package enters a workshop with the matching key, the server restores the vehicle at a clear position.
 
+Quickest working setup — every call below only needs its first argument (the object), so a mission maker can drop three objects and go, then tighten the details later:
+
+```sqf
+[this] call Waldo_fnc_RecoveryRegisterWorkshop;   // in a repair depot's init field - key/radius/side all default
+[this] call Waldo_fnc_RecoveryRegisterVehicle;    // in a damaged vehicle's init field - workshop key defaults too
+[this] call Waldo_fnc_RecoveryRegisterCarrier;    // in a truck's init field - mode defaults to AUTO
+```
+
+The `[WMP]Vehicle_Recovery_Workshop_Example_Minimal` composition (see [Eden Compositions](Eden-Compositions)) places all three pre-wired this way. For explicit control over every option:
+
 ```sqf
 [repairDepot, "FOB_ALPHA", 50, west] call Waldo_fnc_RecoveryRegisterWorkshop;
 [damagedTank, "FOB_ALPHA", 0.55, true, true, "B_Slingload_01_Cargo_F", true, 1]
@@ -75,6 +85,13 @@ Primary settings in `init.sqf` are:
 Direct regroup is disabled by default because it bypasses the normal respawn flow. When deliberately enabled, only a living member of the owning group can request it and the server selects a clear destination beside the active rally.
 
 Runtime ZEN changes are published as an ordered setting bundle before client actions start. JIP clients request the latest server snapshot; disabling the system removes local actions, clears its keyed initializer and removes active rallies.
+
+## See also
+
+- [Eden Compositions](Eden-Compositions)
+- [Optional Feature Systems](Optional-Feature-Systems)
+- [Transport Services](Transport-Services)
+- [Mission Configuration Reference](Mission-Configuration-Reference)
 
 <!-- WMP-WIKI-NAV -->
 ---

--- a/wiki/Waldos-Economy-Systems-Build-System.md
+++ b/wiki/Waldos-Economy-Systems-Build-System.md
@@ -46,6 +46,35 @@ In Zeus: **Build → Configure Buildings** (a tabbed editor for the many fields)
 * Boosts: buildings can shorten research and construction times, and raise resource storage caps.
 * Upkeep: a building can consume resources over time to keep running.
 
+### Full row reference
+
+Every field beyond `name` is optional and defaults sensibly if omitted — the example above only sets the first 12:
+
+| # | Field | Default | Purpose |
+|---|---|---|---|
+| 0 | `name` | required | Catalogue key and display name |
+| 1 | `description` | `""` | Shown in the build menu |
+| 2 | `costRows` | `[]` | `[["Resource", amount], ...]` |
+| 3 | `requirements` | `[]` | Research/building names that must exist first |
+| 4 | `buildTime` | `60` | Seconds, minimum `1` |
+| 5 | `icon` | resource default icon | Menu icon path |
+| 6 | `color` | resource default colour | Menu accent colour |
+| 7 | *(reserved)* | `false` | Internal "already built" flag — leave as `false` in a catalogue definition |
+| 8 | `className` | `""` | `CfgVehicles` classname spawned on completion |
+| 9 | `produceResource` | `""` | Resource name this building generates while standing |
+| 10 | `produceAmount` | `0` | Amount produced per interval |
+| 11 | `produceInterval` | `0` | Seconds between production ticks |
+| 12 | `researchSpeedBoost` | `0` | Reduces research time mission-wide while standing |
+| 13 | `buildSpeedBoost` | `0` | Reduces construction time mission-wide while standing |
+| 14 | `detectorRange` | `0` | Non-zero makes this a RADAR building (see below) |
+| 15 | `upkeepCosts` | `[]` | `[["Resource", amount], ...]` consumed per upkeep interval |
+| 16 | `upkeepInterval` | `0` | Seconds between upkeep charges |
+| 17 | `storageRows` | `[]` | `[["Resource", capacityBoost], ...]` |
+| 18 | `upgradeTo` | `""` | Name of the catalogue entry this building can upgrade into |
+| 19 | `buildLimit` | `0` | Maximum standing count per side; `0` is unlimited |
+| 20 | `availability` | `["ALL"]` | Sides allowed to build this entry |
+| 21 | `category` | `""` | Optional menu grouping label |
+
 ## Upgrades & limits
 
 Buildings can be **upgraded** into a higher tier, and you can cap how many of a building a side may have (**build limits**). Availability can be restricted per side.


### PR DESCRIPTION
**When merged this pull request will:**
- Fix `[WMP]Dynamic_AO_Example_Minimal`, which silently did nothing when placed: its init call omitted `faction`, the one key in `Waldo_fnc_DynamicAOCreate`'s config that has no default and is validated as required. Corrects the same wrong claim in the Claude skill's `dynamic-ao.md` reference, `WMP_Compositions/README.md`'s catalogue row, and adds an explicit warning to `wiki/Dynamic-AO-Generation.md`.
- Cross-check every other Minimal composition's target function against its actual post-`params` validation (not just its `params` defaults) — no other instances of this bug class found.
- Begin a beginner-friendly usage + parameters pass across the wiki (in progress, more commits to follow on this PR):
  - `Optional-Feature-Systems.md`: numbered quick-setup steps and parameter tables for Persistence, Patient treatment feedback, Hazardous environments (including the previously-undocumented one-call `Waldo_fnc_HazardRegisterPresetZone` beginner path), Emergency dismount, and Object scaling.
  - `Optional-Feature-Extensions.md`: reframed as the advanced/extra-options layer with a pointer back to first-time setup pages, plus quick-setup steps for Field Resupply and Tactical Display.
  - `Eden-Compositions.md`: fixed a stale, now-incorrect claim that Dynamic AA/AO and Gunship "must be created once by the server" and can't be compositions — they already ship as compositions using the same self-forwarding pattern as Jammer/Hazard. Replaced the hand-maintained (and already stale) "Newly covered systems" list with a pointer to `WMP_Compositions/README.md`'s own catalogue table.
  - `Airborne-Gunship-Support.md`, `Vehicle-Recovery-And-Squad-Rallies.md`, `Custom-3D-World-Markers.md`: added a smallest-working-call path before the full-parameter example, plus See Also sections where missing.
  - `ACRE-2-Long-Range-Radio-Presetting.md`: added a smallest-working one-group/one-net example using the verified real `acreConfig.sqf` positional-array schema.
  - PRC-343 page: added the missing Associated Files line and a See Also section.

Verified against `sqf_validator.py`, `config_style_checker.py`, `wiki_style_checker.py`, `documentation_contract_checker.py`, `claude_skill_validator.py`, and the full 105-test audit suite.

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_019n7ghy2hPz4bryM1X5oBNA)_