### PR TITLE
Fix real in-game parse error in ZEN Send Notification module

### DIFF
--- a/MissionScripts/ZenModules/Zen_notifyModule.sqf
+++ b/MissionScripts/ZenModules/Zen_notifyModule.sqf
@@ -50,7 +50,7 @@ params ["_modulePos", "_objectPos"];
         if (_audience == "UNITS") then {
             private _curator = getAssignedCuratorLogic player;
             if !(isNull _curator) then {
-                _units = ((curatorSelected _curator) param [0, []]) select {isPlayer _x};
+                _units = (curatorSelected select 0) select {isPlayer _x};
             };
             if (_units isEqualTo [] && {!isNull _objectPos} && {isPlayer _objectPos}) then {_units = [_objectPos];};
         };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix `Waldo_fnc_ZenNotify`'s "Selected Unit(s)" audience path, which called `curatorSelected` with an explicit curator argument (`curatorSelected _curator`) — the real SQF parser rejects this outright with `Error Missing )`, confirmed against an actual in-game RPT error, not just static analysis (bracket-balance checking alone can't catch this class of bug, since the line isn't bracket-mismatched — the parser is rejecting the argument shape itself).
- `curatorSelected` takes no argument. `paradropDropZoneZen.sqf`, the only other caller in the codebase, already uses it correctly as `curatorSelected select 0`. Reused that identical, already-proven-working form here instead of guessing at a different fix.

This is a genuine authoring bug that reached `main` because the file existed since its introducing commit with no reported runtime test — `sqf_validator.py`'s bracket-matching pass can't catch a real command used with the wrong argument shape, only actual Arma compilation can.

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_019n7ghy2hPz4bryM1X5oBNA)_