### PR TITLE
Sync mission-pack-config skill with recent transport/paradrop/AA/notification work

### DIFF
--- a/.claude/skills/mission-pack-config/references/dynamic-aa.md
+++ b/.claude/skills/mission-pack-config/references/dynamic-aa.md
@@ -69,11 +69,36 @@ optional radar-shutdown objective — the server auto-places radar/static/
 mobile assets in a spaced terrain-safe layout, no map clicks needed) and
 **Dynamic AA - Remove Nearest**.
 
+## Engagement model — five independent gates
+
+A hostile crewed aircraft may be targeted only when **all** of these hold;
+losing any one closes the defence group, clears its target, makes it
+forget/ignore engine-known targets, and blocks remote datalink targeting
+(a final owner-local fired-projectile gate stops the engine itself from
+firing at a target that was eligible a moment ago):
+
+1. It's a living Air vehicle with a hostile living crew.
+2. Horizontally inside the detection radius.
+3. Its ATL/ASL altitude is between the floor and ceiling.
+4. Horizontally inside the (separate, usually smaller) engagement radius.
+5. The system is enabled and has a live, enabled radar.
+
+Ground vehicles never pass gate 1 — Dynamic AA cannot be made to engage
+ground targets. Detection/engagement radii are horizontal only; altitude
+is a wholly separate floor/ceiling check.
+
 ## Gotchas
 
 - Detection is server-owned; AI state/targeting/ammo dispatch to each
   group's current owner, so systems keep working after AI moves to a
   headless client.
+- On a dedicated server, spawned crew/groups are explicitly verified on
+  the requested operational side after creation — this closes an earlier
+  bug where dedicated-server-spawned AA crew could end up on the wrong
+  side. A pre-planned `initServer.sqf`/Eden-init creation is queued until
+  the server's own initialization sentinel is ready rather than racing
+  network-object creation; a Zeus-created system runs after mission start
+  so it skips that queue.
 - Classnames are validated and two-pass placement-checked before anything
   spawns — if planning fails, nothing spawns; a materialisation failure
   rolls back every partial object/crew.

--- a/.claude/skills/mission-pack-config/references/economy/README.md
+++ b/.claude/skills/mission-pack-config/references/economy/README.md
@@ -25,6 +25,11 @@ request handling) but exposes **no in-game authoring menu** — the mission
 maker must hand-author `MissionConfig/economyConfig.sqf` instead. Check
 `../mod-detection.md` before assuming the Zeus menu route is available.
 
+In the Zeus module browser the suite's own module category is labelled
+**"WMP Economy Systems"** (a rename from the older "Waldos Economy
+Systems" category label) — the feature/system itself is still called
+Waldos Economy Systems everywhere else (docs, README, compositions).
+
 ## Architecture note (for context, not something to reconfigure)
 
 Registered under `class Waldo` in `WaldosFunctions.sqf`, callable as

--- a/.claude/skills/mission-pack-config/references/paradrop.md
+++ b/.claude/skills/mission-pack-config/references/paradrop.md
@@ -89,7 +89,14 @@ field:
   marker over** instead of leaving it untouched or stacking a second one
   on top: restyled to the same black "mil_end" look, labelled with `name`,
   rotation reset to 0. Never deleted by cleanup — this function didn't
-  create it, so it doesn't own deleting it either.
+  create it, so it doesn't own deleting it either. Setup reads the
+  marker's position/direction, creates the WMP-owned point/corridor
+  markers, then deletes the original Eden setup marker immediately (not
+  after the fact) — the drop-zone area and standby/green/red lines are
+  therefore visible in the pre-mission briefing map from the start rather
+  than appearing mid-mission. A dedicated client can still load its own
+  `mission.sqm` copy of that marker after the server's deletion; a
+  persistent client-local watcher hides that stale copy for it.
 - Builds a reliable standby → green → red → exit AI route (looping by
   default) using the exact same route logic as the Dynamic Drop Zone system
   (`Waldo_fnc_ParadropBuildFlightRoute`) — both stay in sync, fixes to one
@@ -117,7 +124,11 @@ field:
   normalized as above), `lifecycle` (`LOOP` default/`RETAIN`/`DESPAWN`),
   `circuitDirection` (`LEFT` default/`RIGHT`),
   `approachDistance`/`runLength`/`exitDistance`, `name` (marker label,
-  default `"Drop Zone"`), `createMarkers` (**on by default** — the same
+  default `"Drop Zone"`), `aircraftInvincible` (**off by default** —
+  protects the aircraft from normal engine damage for the operation's
+  life, locality-aware so protection reapplies if ownership moves between
+  server/headless client/player client; scripted `setDamage`/`setHit`
+  calls can still damage it), `createMarkers` (**on by default** — the same
   AREA/STANDBY/GREEN/RED/POINT markers as the Dynamic Drop Zone system, so
   the mission maker sees a working drop zone immediately; pass `false` for
   a clutter-free operation), `keepMarkersOnCleanup` (**off by default** —
@@ -166,7 +177,7 @@ private _drop = createHashMapFromArray [
     ["staticChuteClass", "NonSteerable_Parachute_F"],
     ["haloJumpEnabled", false], ["haloBackpackClass", "B_Parachute"],
     ["jumperCount", 0], ["autoDropPlayers", false], ["createMarkers", true],
-    ["keepMarkersOnCleanup", false]
+    ["keepMarkersOnCleanup", false], ["aircraftInvincible", false]
 ];
 [_drop] call Waldo_fnc_ParadropCreateDropZone;
 ```
@@ -199,11 +210,25 @@ without a recognised door/ramp animation.
 **Paradrop - Create Drop Zone**, **Paradrop - Embark Players**, **Paradrop -
 Remove Operation**. The create dialog separates operational side (AI pilot +
 any requested AI jumpers) from physical airframe (any faction's aircraft
-class). Default aircraft: one AI pilot, **zero AI cargo** — cargo seats are
-left for players. Embark uses the player standing under the module first,
-then curator selection; falls back to a physical boarding object (default a
-flagpole) with a blue **Board Paradrop Aircraft** addAction if no player
-target is given.
+class), plus an **Invincible drop aircraft** checkbox (off by default — the
+same `aircraftInvincible` setting both script APIs use). Default aircraft:
+one AI pilot, **zero AI cargo** — cargo seats are left for players. Embark
+uses the player standing under the module first, then curator selection;
+falls back to a physical boarding object (default a flagpole) with a blue
+**Board Paradrop Aircraft** addAction if no player target is given.
+
+**Embark Players** and **Remove Operation** list both registry-backed
+Dynamic Drop Zone operations *and* aircraft set up with
+`Waldo_fnc_ParadropQuickFlightSetup` (a mission maker's own placed/crewed
+Eden aircraft) in one unified list — entries are labelled **[DYNAMIC]** or
+**[EDEN]**. Removing an [EDEN] entry follows the same rules as a dynamic
+one: its markers, live aircraft marker and registration are cleared;
+**Delete aircraft** additionally removes the aircraft/AI crew unless
+players are currently aboard, while leaving the checkbox off retains the
+aircraft but strips its WMP jump interactions. Zeus-created operations
+also skip the `requireOpenDoor` ramp/door prerequisite the script/Eden
+paths use, since their AI aircraft don't give the passenger a dependable
+door control.
 
 Mission makers can extend the friendly-name dropdowns before startup:
 

--- a/.claude/skills/mission-pack-config/references/safestart.md
+++ b/.claude/skills/mission-pack-config/references/safestart.md
@@ -38,6 +38,20 @@ per-player radius anchor instead — no marker needed.
 Manual and timed go-live notices explain which protections were removed and
 stay visible for `Waldo_SafeStart_GoLiveHintDuration` seconds (default 12).
 
+## Player-side panel and acknowledgement
+
+Only one compact SafeStart panel exists per player; starting or changing a
+countdown updates the existing panel rather than stacking another. Each
+player can open **ACE Self Interactions > WMP Interface > Acknowledge
+SafeStart** while protection is active to hide *only their own* panel —
+this never touches weapons/damage/confinement, the timer, or any other
+player's display. Acknowledging the plain waiting phase hides the panel
+until a countdown starts; the countdown is treated as a new phase and
+reopens it (so a player who dismissed the wait still sees go-live
+approaching), and it can be acknowledged a second time to hide it again
+until go-live. The acknowledgement itself is cleared whenever SafeStart
+ends and never carries forward into a later activation.
+
 ## Relationship to ENDEX
 
 Separate authoritative state — see `endex-aar.md`.

--- a/.claude/skills/mission-pack-config/references/transport-services.md
+++ b/.claude/skills/mission-pack-config/references/transport-services.md
@@ -13,8 +13,8 @@ separate typed pools; a request can never cross-reserve.
 ["Waldo_Transport_DefaultBoardingSeconds", 300, false],
 ["Waldo_Transport_DefaultDestinationDwell", 45, false],
 ["Waldo_HeliTransport_DefaultAltitude", 50, false],
-["Waldo_HeliTransport_DefaultLzSearchRadius", 250, false],
-["Waldo_HeliTransport_DefaultLzClearanceScale", 2.0, false], // multiplier on real helicopter model bounding box
+["Waldo_HeliTransport_DefaultLzSearchRadius", 500, false],
+["Waldo_HeliTransport_DefaultLzClearanceScale", 1.5, false], // multiplier on real helicopter model bounding box
 ["Waldo_HeliTransport_DefaultSeparation", 60, false],
 ["Waldo_GroundTransport_DefaultRoadSearchRadius", 200, false],
 ["Waldo_GroundTransport_DefaultSeparation", 18, false],
@@ -58,6 +58,20 @@ Base** returns everything reserved by or carrying the player. A stuck
 transport publishes **STUCK** rather than silently dropping the
 reservation — retry via the same menu or send it to RTB.
 
+External vehicle interaction (approaching the vehicle from outside) is
+identification/status only — it names the vehicle and reports its current
+state. The operational controls (move pickup, select destination, RTB,
+retry) live in that exact vehicle's **own ACE self-interaction tree** —
+any player physically occupying it can reach them there, independent of
+who originally requested it or which seat they're in. An occupant can
+select a destination immediately after boarding at base without a prior
+pickup request. Outside the vehicle, only the original requester may move
+pickup or order RTB; a passenger inside may select destination or order
+RTB for the transport they occupy; Zeus may manage any registered
+transport. The server validates control against exact current crew
+membership (object + UID) — a request from someone not actually aboard is
+rejected, so this can't be spoofed by proximity alone.
+
 ## Zeus
 
 **WMP Transport > Transport Service - Register** (on an existing AI-crewed
@@ -75,6 +89,12 @@ clearance, improved-landing and other options set explicitly, including
 
 ## Gotchas
 
+- At destination the transport waits (up to `destinationDwell`, default
+  `45`s) for every player passenger to physically leave before ordering
+  RTB — it never forces anyone out by default. Only with `forceDisembark`
+  explicitly enabled does WMP request `moveOut` at the timeout, giving a
+  short exit-animation grace before RTB. A newer destination/RTB order
+  always invalidates a stale wait.
 - Registrations survive WMP vehicle-recovery reconstruction via the
   built-in `Waldo_TransportService_Registration` recovery variable — no
   extra work needed if the mission also uses `vehicle-recovery-rallies.md`.

--- a/.claude/skills/mission-pack-config/references/ui-notifications.md
+++ b/.claude/skills/mission-pack-config/references/ui-notifications.md
@@ -1,7 +1,8 @@
 # WMP UI notifications and recovery
 
-Padded, safe-zone-aware notification card, callable directly by mission
-makers:
+Padded, safe-zone-aware notification card. `Waldo_fnc_ShowUiNotification`
+shows a card **only on the machine that calls it** — it does not pick an
+audience for you:
 
 ```sqf
 ["OBJECTIVE UPDATED", "Secure the relay station.", "INFO", 10, "TOP", "OBJECTIVE", "JOINT OPERATIONS"]
@@ -20,6 +21,100 @@ Args: `[title, message, state, duration, placement, channel, source]`.
   `BOTTOM_RIGHT`. `TOP` is reserved for mission-flow banners (Safestart,
   ENDEX) — don't route ordinary feature notifications there.
 - Client-local, dedicated-server safe.
+- Two more positional args exist beyond `source`: `policy` (`AUTO`/`FIFO`/
+  `REPLACE` — `AUTO` picks `REPLACE` for a persistent card and `FIFO` for a
+  timed one) and `priority`/`allowLocalOverride` — see
+  `wiki/Custom-UI-Notifications.md` if a mission needs to override the
+  default stacking/placement-override behaviour rather than just show a
+  card.
+- `["CHANNEL"] call Waldo_fnc_DismissUiNotification;` clears one channel's
+  active/queued card locally and returns whether anything was removed.
+
+## Sending to an audience, not just the calling machine
+
+`Waldo_fnc_ShowUiNotification` never resolves *who* sees a card — for that,
+use one of these two (both wrap the same broadcast backend):
+
+### `Waldo_fnc_SendNotification` — the beginner-friendly mission-script call
+
+Safe to call from **any** machine (a trigger, an object init field,
+`initServer.sqf`, another script) with no `isServer` wrapper — a client
+call forwards to the server automatically, same pattern as
+`Waldo_fnc_Jammer`:
+
+```sqf
+["COMMAND", "Move to the marked assembly area.", "INFO"] call Waldo_fnc_SendNotification;
+["FALL BACK", "Return to base.", "WARNING", west, 10] call Waldo_fnc_SendNotification;
+["ORDERS", "Move to Checkpoint Blue.", "INFO", group player] call Waldo_fnc_SendNotification;
+["DRIVER", "Your vehicle is ready.", "SUCCESS", _driver] call Waldo_fnc_SendNotification;
+```
+
+Args: `[title, message, type, recipients, duration, placement, channel,
+source]` — only `title`/`message` are required. `recipients` (default
+`"ALL"`) accepts `"ALL"`, a side (`west`/`east`/`independent`/`civilian`),
+a `GROUP`, one player `OBJECT`, or an `ARRAY` of player objects;
+non-player/null entries are ignored. `duration` defaults `8`, clamped
+`1-60` (`0` persists). Invalid `type`/`placement` values are silently
+replaced with `INFO`/`TOP_RIGHT` (logged to RPT) rather than erroring.
+These cards are live-only and are **not** replayed to players who join
+later.
+
+### `Waldo_fnc_NotificationBroadcast` — named audiences, exact reached-count
+
+Server-authoritative (same self-forwarding pattern). Use this instead of
+`SendNotification` when you need `GROUP`-by-name matching, an explicit
+`UNITS` array, or the exact number of players actually reached back as a
+return value:
+
+```sqf
+[createHashMapFromArray [
+    ["title", "FALL BACK"], ["message", "Regroup at the rally point."], ["state", "WARNING"],
+    ["duration", 10], ["placement", "TOP"], ["audience", "SIDE"], ["side", west]
+]] call Waldo_fnc_NotificationBroadcast;
+```
+
+One HashMap argument: every `Waldo_fnc_ShowUiNotification` field
+(`title`/`message`/`state`/`duration`/`placement`/`channel`/`source`) plus
+`audience` (`ALL` default / `SIDE` / `GROUP` / `UNITS`), `side` (read for
+`SIDE`), `group` (group callsign, matched case-insensitively against
+`groupId`, read for `GROUP`), and `units` (array of player objects, read
+for `UNITS`). Returns the number of distinct players reached.
+
+### Eden composition (beginner drop-in)
+
+**Waldos Mission Pack Compositions - Interface > `[WMP] Notification
+Trigger`** places a ready-made 25 m any-player notification area. The
+visible entity is an empty-helipad anchor (not a raw Eden Trigger — WMP
+creates the real trigger on the server, which also avoids an Arma/Eden
+native crash seen with a hand-authored SQE Trigger entity); move the
+anchor to move the area, edit its **Init** field to change radius/title/
+message/type:
+
+```sqf
+[this, 25, "MESSAGE FROM COMMAND", "Move to the marked assembly area.", "INFO"]
+    call Waldo_fnc_NotificationTrigger;
+```
+
+Positions: anchor object, radius (metres), title, message, type. Optional
+later positions accept recipients, duration, repeatable, placement,
+channel, source — full typed list in `notificationTrigger.sqf`'s header.
+Re-running setup on the same anchor safely replaces its old server
+trigger.
+
+### Zeus module
+
+**Waldos Mission Modules > Mission Flow: Send Notification** — title/
+message fields, a type selector, a duration slider, a placement selector,
+a **Send to all players** checkbox, and one ZEN-native **OWNERS**
+recipient picker (its own Sides/Groups/Players tabs, live multi-select, no
+typed callsign) covering everything short of "everyone." Mixed selections
+(a side plus extra individual players) are resolved into one deduplicated
+unit list so nobody is notified twice; checking **Send to all players**
+ignores the picker entirely; dropping the module directly on a player
+pre-selects them. Routes through the curator-authenticated
+`Waldo_fnc_ZenNotifyServer` bridge before calling
+`Waldo_fnc_NotificationBroadcast` — same authorization pattern as the EMP
+and Signal Tracker modules.
 
 ## Flow tuning (`MissionConfig\interfaceConfig.sqf` — player local)
 

--- a/.claude/skills/mission-pack-config/references/zeus-modules.md
+++ b/.claude/skills/mission-pack-config/references/zeus-modules.md
@@ -28,9 +28,14 @@ question, not as the primary config doc for any one feature.
 | Radio Jammer - Remove Nearest | `Waldo_fnc_ZenJammerRemove` | `jamming.md` |
 | EMP Detonation | `Waldo_fnc_ZenEMP` | `emp.md` |
 | Plant Signal Tracker | `Waldo_fnc_ZenTracker` | `trackers.md` |
+| Mission Flow: Send Notification | `Waldo_fnc_ZenNotify` → `Waldo_fnc_ZenNotifyServer` → `Waldo_fnc_NotificationBroadcast` | `ui-notifications.md` |
 
 Waldos Economy Systems registers its own separate, larger set of Zeus
-modules (15 core + 19 Economy) — see `economy/README.md`, not this file.
+modules (15 core + 19 Economy) under its own Zeus category — labelled
+**"WMP Economy Systems"** in the module browser (renamed from the older
+"Waldos Economy Systems" category label; the *feature/system* is still
+called Waldos Economy Systems everywhere else) — see `economy/README.md`,
+not this file.
 
 ## Other WMP Zeus categories (not "Waldos Mission Modules")
 


### PR DESCRIPTION
**When merged this pull request will:**
- Document the previously-undocumented `Waldo_fnc_SendNotification` (beginner mission-script notification API) and `Waldo_fnc_NotificationBroadcast` (audience-targeted broadcast) in `ui-notifications.md`, plus the `[WMP] Notification Trigger` composition/`Waldo_fnc_NotificationTrigger`
- Add the missing "Mission Flow: Send Notification" row to `zeus-modules.md` and note the Economy suite's Zeus category is now labelled "WMP Economy Systems" (`zeus-modules.md`, `economy/README.md`)
- Fix stale `Waldo_HeliTransport_DefaultLzSearchRadius` (250 → 500) and `Waldo_HeliTransport_DefaultLzClearanceScale` (2.0 → 1.5) defaults in `transport-services.md`
- Document in `transport-services.md` that occupant transport controls (Set Destination/RTB) now live in the vehicle's own ACE self-interaction tree rather than external interaction, that boarding at base allows selecting a destination without a prior pickup request, and the `destinationDwell`/`forceDisembark` wait-then-RTB behavior
- Document the five independent Dynamic AA engagement gates and the dedicated-server crew-side verification/creation-queue fix in `dynamic-aa.md`
- Document the compact per-player SafeStart panel and the new "Acknowledge SafeStart" self-interaction in `safestart.md`
- Document the `aircraftInvincible` paradrop option, the unified `[DYNAMIC]`/`[EDEN]` Embark/Remove Operation registry, and that drop-zone markers now publish immediately (with a dedicated-client hide watcher for the consumed Eden setup marker) in `paradrop.md`

## Why

Requested by the maintainer: PRs #77–#81 landed a large batch of fixes and small new mission-maker-facing surfaces (transport occupant controls, Dynamic AA hardening, paradrop marker/registry fixes, a new beginner notification API, SafeStart acknowledgement, an Economy Zeus category rename) that the `.claude/skills/mission-pack-config` skill hadn't been updated to reflect since its last touch. This PR only updates skill reference files under `.claude/skills/mission-pack-config/references/` — no script/config behavior changes.

## Validation

- `python3 releaseVerificationAndDeployment/claude_skill_validator.py` — OK
- `python3 releaseVerificationAndDeployment/documentation_contract_checker.py` — PASSED (11 files)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BT88DtMrJQTuLNKhYWL7y2)_