### PR TITLE
Require Zeus Enhanced, give Persistence its own wiki page, fix Zeus Modules doc gaps

### DIFF
--- a/.claude/skills/mission-pack-config/SKILL.md
+++ b/.claude/skills/mission-pack-config/SKILL.md
@@ -151,9 +151,15 @@ and the user may not think to mention it. Read `references/mod-detection.md`
 and either check the repo (mod-dependent code is always guarded by a
 `CfgPatches` check — grep for it) or ask the user directly:
 
-- CBA_A3 and ACE3 are **required** — assume present.
-- ACRE2, TFAR, Zeus Enhanced (ZEN), LAMBS are **optional** — ask, or check
-  what the user's `@mods` list / server config implies.
+- CBA_A3, ACE3 and Zeus Enhanced (ZEN) are **required** — assume present.
+  ZEN is specifically the in-Zeus authoring surface for most systems added
+  since v4.8 (Economy, Dynamic AA/AO, Gunship, Hazards, Transport, Recovery,
+  Breaching, notifications, and more); their underlying server-side systems
+  still run without it, but placement/configuration through Zeus does not,
+  so treat a report of a missing Zeus module category as an "is ZEN loaded"
+  question first.
+- ACRE2, TFAR, LAMBS are **optional** — ask, or check what the user's
+  `@mods` list / server config implies.
 - For a question about one of these mods' **own native behaviour** — not
   WMP's integration with it — route to `references/mods/*.md`
   (`cba.md`, `ace3.md`, `acre2-mod.md`, `tfar.md`, `zeus-enhanced-mod.md`,

--- a/.claude/skills/mission-pack-config/references/mod-detection.md
+++ b/.claude/skills/mission-pack-config/references/mod-detection.md
@@ -11,6 +11,12 @@ mission maker who doesn't understand why nothing happened.
 - **CBA_A3** — event system backbone, used everywhere.
 - **ACE3** — interaction menus, medical, arsenal, cargo/dragging, fortify,
   safe-mode locking. ~80 call sites across the pack.
+- **Zeus Enhanced (ZEN)** — the in-Zeus authoring surface for most systems
+  added since v4.8 (Economy, Dynamic AA/AO, Gunship, Hazards, Transport,
+  Recovery, Breaching, notifications, and more). WMP scripts still guard
+  every ZEN-dependent code path with a `zen_main` `CfgPatches` check (see
+  Consequences below for what happens if it's genuinely absent), but it is
+  now a listed required addon, not something to ask about first.
 
 ## Optional (ask the user, or check their mod list / server config)
 
@@ -18,7 +24,6 @@ mission maker who doesn't understand why nothing happened.
 |---|---|---|
 | ACRE2 | `acre_main` | Radio channel auto-assignment, jamming's custom signal hook |
 | TFAR | `task_force_radio` or `tfar_core` | Jamming's distance-multiplier throttle (no scripting setup needed otherwise — Eden Editor native) |
-| Zeus Enhanced (ZEN) | `zen_main` | The entire "Waldos Mission Modules" Zeus menu, all Economy Zeus authoring |
 | LAMBS series | (varies by module) | Not directly integrated by WMP scripts; complements AI behaviour generally |
 
 ## How to check in a live project
@@ -29,15 +34,17 @@ if (isClass(configFile >> "CfgPatches" >> "acre_main")) then { ... };
 
 If you have shell access to the mission's mod list / server launch config,
 grep for these mod folder names instead of asking. Otherwise just ask the
-user which of ACRE2 / TFAR / ZEN they're running — it's a fast question and
+user which of ACRE2 / TFAR they're running — it's a fast question and
 avoids configuring dead code.
 
 ## Consequences for common combinations
 
-- **No ZEN**: Economy Systems still runs server-side (income, research,
-  production, request handling) but has zero in-game authoring UI — the user
-  must hand-author `MissionConfig/economyConfig.sqf` instead. All 15 core +
-  19 Economy Zeus modules simply don't register. Same story for every other
+- **No ZEN** (off-label — ZEN is a required addon, but this still comes up
+  when a mission maker is testing without their full mod list loaded):
+  Economy Systems still runs server-side (income, research, production,
+  request handling) but has zero in-game authoring UI — the user must
+  hand-author `MissionConfig/economyConfig.sqf` instead. All 15 core + 19
+  Economy Zeus modules simply don't register. Same story for every other
   feature's ZEN modules (Dynamic AA, gunship, transport services,
   persistence, hazards, vehicle recovery, jammer, etc.) — the underlying
   script APIs and `MissionConfig` settings still work without ZEN, only the

--- a/.claude/skills/mission-pack-config/references/mods/zeus-enhanced-mod.md
+++ b/.claude/skills/mission-pack-config/references/mods/zeus-enhanced-mod.md
@@ -1,4 +1,4 @@
-# Zeus Enhanced (ZEN) — optional, as a mod
+# Zeus Enhanced (ZEN) — required, as a mod
 
 **What WMP wraps:** WMP's own "Waldos Mission Modules" and the newer
 domain-specific categories (WMP Combat Systems, WMP Logistics, WMP

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@ WaldosMissionPack (WMP) is an **Arma 3 mission scripting starter framework**. It
 
 The pack is used by 40+ milsim units. Mission makers are the primary audience — they configure the scripts through the init files and Eden Editor, not by writing new code.
 
-**Required Arma 3 mods:** CBA_A3, ACE 3  
-**Optional:** ACRE 2, TFAR, Zeus Enhanced, LAMBS series
+**Required Arma 3 mods:** CBA_A3, ACE 3, Zeus Enhanced  
+**Optional:** ACRE 2, TFAR, LAMBS series
 
 **Wiki (feature and Zeus module tutorials):** https://github.com/AdamWaldie/WaldosMissionPack/wiki
 

--- a/FEATURE_LOG.md
+++ b/FEATURE_LOG.md
@@ -72,6 +72,46 @@ Required direction:
 - replace the legacy third-party activation path only after the new implementation has passed hosted
   and dedicated-server acceptance, with beginner-friendly configuration and wiki documentation.
 
+### Field Resupply: replace charge-based deployed crates with real crate contents
+
+**Status:** Planned
+
+Redesign deployed Field Resupply crates so they behave like a normal populated supply crate
+(ACE Cargo/Gear access to real inventory) instead of the current limited-`TAKE`-count abstraction.
+Today `Waldo_fnc_FieldResupplyServerHandle`'s `DEPLOY` derives a fixed set of logical magazine rows
+from the deploying carrier's own inventory (`_getMagazineRows`, filtered by
+`Waldo_FieldResupply_AllowedMagazines`/`BlockedMagazines`/`MinimumMagazineRounds`, sized by
+`Waldo_FieldResupply_UseCapacityBasedAmounts`/`MagazinesPerType`/`CapacityAmounts`) and stores it as
+`Waldo_FieldResupply_CargoRows` against a fixed `Waldo_FieldResupply_ChargesPerCrate`; the crate keeps
+empty physical cargo on purpose so `TAKE` (`Waldo_fnc_FieldResupplyReceiveAmmo`) stays the only way to
+draw from it and `SALVAGE` decides recoverability by comparing `Waldo_FieldResupply_Charges` against
+`Waldo_FieldResupply_InitialCharges`. Replace that with real crate cargo populated the same way a
+standard supply crate is (`Waldo_fnc_SupplyCratePopulate`, scoped to the hub's serviced side), so a
+deployed crate can simply be deployed, opened, taken from and salvaged like any other logistics crate.
+
+Required direction:
+
+- populate a deployed crate's actual weapon/magazine/item cargo (via `Waldo_fnc_SupplyCratePopulate`
+  or an equivalent field-resupply-scoped populate path) instead of building
+  `Waldo_FieldResupply_CargoRows` from the carrier's own magazines;
+- drop the per-crate charge count entirely — `TAKE` becomes normal ACE Cargo/Gear interaction against
+  real inventory rather than a server-brokered logical grant gated on remaining charges;
+- redefine `SALVAGE` recoverability from actual remaining cargo (e.g. cargo emptiness/weight) instead
+  of the charges-vs-initial-charges comparison, since there is no charge counter left to compare;
+- decide the fate of the now-obsolete config surface
+  (`Waldo_FieldResupply_ChargesPerCrate`/`AllowedMagazines`/`BlockedMagazines`/
+  `MinimumMagazineRounds`/`UseCapacityBasedAmounts`/`MagazinesPerType`/`CapacityAmounts`) —
+  remove or fold into whatever options the reused populate path exposes (size scalar, side,
+  weapons/attachments/launchers toggles, matching `Waldo_fnc_SupplyCratePopulate`'s own parameters);
+- keep hub stock (`Waldo_FieldResupply_Stock`) and carrier portable-crate capacity
+  (`Waldo_FieldResupply_MaxCrates`/`Crates`) exactly as they are — those govern how many crates a hub
+  can issue and a carrier can carry, and are unrelated to this change;
+- keep the existing ACE dragging/carrying setup on deployed crates, and confirm ACE Cargo/Gear
+  interaction works correctly against the populated contents without the old `TAKE` action installed
+  alongside it;
+- update the Field Resupply ZEN modules, notifications, diagnostics coverage, wiki page section and
+  the audit mission's Field Resupply station to match the new deploy/take/salvage behaviour.
+
 ### Boat transport services
 
 **Status:** Planned

--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ https://github.com/AdamWaldie/WaldosMissionPack/wiki/Waldos-Mission-Pack-Zeus-Mo
 # Required Addons
 - CBA_A3
 - ACE 3 (Field Headquarters, Construction System, Quartermaster Logistics Spawner)
+- Zeus Enhanced & Compat (the in-Zeus authoring surface for most systems added since v4.8 - Economy, Dynamic AA/AO, Gunship, Hazards, Transport, Recovery, Breaching, notifications, and more)
 
 # Supported Addons
 - ACRE 2 (optional; configure or disable it in `MissionConfig\acreConfig.sqf`)
 - TFAR (inherent support through Eden configuration)
-- Zeus Enhanced & Compat
 - LAMBS Series of mods (Tutorial Mission Requires this, the pack can work without it)
 - All unit mods compatable
 

--- a/wiki/Feature-Catalogue.md
+++ b/wiki/Feature-Catalogue.md
@@ -8,7 +8,7 @@ This is the complete top-level index of mission systems currently supplied by Wa
 
 | Feature | What it provides | Primary setup and operation |
 |---|---|---|
-| [INIDBI2 Persistence](Optional-Feature-Systems#persistence) | Optional player and registered-object persistence with a server-runtime dependency gate | `MissionConfig\persistenceConfig.sqf`; database authority in `initServer.sqf`; **Persistence - Control**, **Register Object**, and **Save Now** in ZEN |
+| [INIDBI2 Persistence](Persistence) | Optional player and registered-object persistence with a server-runtime dependency gate | `MissionConfig\persistenceConfig.sqf`; database authority in `initServer.sqf`; **Persistence - Control**, **Register Object**, and **Save Now** in ZEN |
 | [Patient Treatment Feedback](Optional-Feature-Systems#patient-treatment-feedback) | Local ACE treatment start, completion and failure notifications using the pack notification UI | `MissionConfig\interfaceConfig.sqf` and scripted start/stop calls |
 | [Hazardous Environments](Optional-Feature-Systems#hazardous-environments) | Repeatable contamination, toxic, temperature, vacuum/no-oxygen and callback-driven zones | `MissionConfig\environmentConfig.sqf`; scripted registration or ZEN create/remove modules |
 | [Tree Felling](Optional-Feature-Systems#tree-felling) | Axe/hatchet-driven tree replacement, brush clearing, yields, protected areas and optional regrowth | Shared settings and scripted calls |

--- a/wiki/Feature-Configuration-Files.md
+++ b/wiki/Feature-Configuration-Files.md
@@ -124,6 +124,8 @@ See [ACRE2 Babel Configuration](ACRE2-Babel-Configuration),
 
 ## `persistenceConfig.sqf` — shared
 
+See [Persistence](Persistence) for setup steps, registering world objects, and the Zeus modules.
+
 | Setting | Purpose / units |
 |---|---|
 | `Waldo_Persistence_Enable` | Master opt-in; the server dependency gate can still reject a missing INIDBI2 extension. |

--- a/wiki/Feature-Tutorials.md
+++ b/wiki/Feature-Tutorials.md
@@ -86,7 +86,8 @@ Start with the [Quickstart Guide](Quickstart-Guide) for a new mission. Use the [
 
 | Feature | Use it for |
 |---|---|
-| [Optional Feature Systems](Optional-Feature-Systems) | Persistence, treatment feedback, hazards, tree felling, emergency dismount, WMP HUD, breaching, and object transforms |
+| [Persistence](Persistence) | Database-backed player state and registered-object save/restore via INIDBI2 |
+| [Optional Feature Systems](Optional-Feature-Systems) | Treatment feedback, hazards, tree felling, emergency dismount, WMP HUD, breaching, and object transforms |
 | [Optional Feature Extensions](Optional-Feature-Extensions) | Field resupply, tactical displays, advanced controls, and engine boundaries |
 | [Dynamic Anti-Air](Dynamic-Anti-Air) | Scripted or Zeus-authored radar-controlled air-defence zones |
 | [Dynamic AO Generation](Dynamic-AO-Generation) | Runtime faction-driven patrols, garrisons, vehicles, air, civilians, mines and roadblocks |

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -66,7 +66,8 @@ Waldos Mission Pack is an Arma 3 mission scripting framework for mission makers 
 ### Optional and advanced systems
 
 - [Complete Feature Catalogue](Feature-Catalogue) — the full pack inventory and default states.
-- [Optional Feature Systems](Optional-Feature-Systems) — persistence, treatment feedback, hazards, tree felling, emergency dismount, WMP HUD, breaching, and object transforms.
+- [Persistence](Persistence) — database-backed player state and registered-object save/restore via INIDBI2.
+- [Optional Feature Systems](Optional-Feature-Systems) — treatment feedback, hazards, tree felling, emergency dismount, WMP HUD, breaching, and object transforms.
 - [Optional Feature Extensions](Optional-Feature-Extensions) — field resupply, tactical displays, advanced controls, and engine boundaries.
 - [Dynamic Anti-Air](Dynamic-Anti-Air) — reusable radar-controlled air-defence zones for scripts and Zeus.
 - [Dynamic AO Generation](Dynamic-AO-Generation) — server-owned randomized areas of operations created during play.

--- a/wiki/Optional-Feature-Extensions.md
+++ b/wiki/Optional-Feature-Extensions.md
@@ -4,7 +4,7 @@
 
 _Associated Files: `init.sqf`; feature implementations under their matching `MissionScripts/` domains_
 
-**First time setting up one of these systems?** This page assumes it's already enabled and running — for the first-time "turn it on" walkthrough, go to [Optional Feature Systems](Optional-Feature-Systems) (persistence, hazardous environments, tree felling, emergency dismount, WMP HUD, explosive breaching, object scaling) or [Waldo's AI Tuning](Waldos-AI-Tweak) (AI rebalance) instead. This page covers the extra options layered on top: deeper customisation and less-common configuration, plus field resupply and tactical display, which don't have their own dedicated page yet.
+**First time setting up one of these systems?** This page assumes it's already enabled and running — for the first-time "turn it on" walkthrough, go to [Optional Feature Systems](Optional-Feature-Systems) (hazardous environments, tree felling, emergency dismount, WMP HUD, explosive breaching, object scaling), [Persistence](Persistence), or [Waldo's AI Tuning](Waldos-AI-Tweak) (AI rebalance) instead. This page covers the extra options layered on top: deeper customisation and less-common configuration, plus field resupply and tactical display, which don't have their own dedicated page yet.
 
 These extensions remain disabled by default, independently configurable and safe to initialise more than once. They use feature-specific settings rather than a mandatory common profile layer.
 
@@ -13,6 +13,8 @@ These extensions remain disabled by default, independently configurable and safe
 Registered objects can persist an allow-list of custom variables in addition to cargo, damage, fuel, ammunition and position. Pass variable names as the sixth registration option, or edit `Waldo_Persistence_DefaultCustomVariables`. Object scale, breach state and stable field-resupply state are included by default. Existing version-one object records remain loadable.
 
 Dynamic objects are not recreated automatically. Register stable editor objects with unique keys; use mission-specific recreation logic for objects that do not exist when a save is loaded.
+
+For enabling persistence itself, the full settings table and `Waldo_fnc_PersistenceRegisterObject`'s calling contract, see the [complete Persistence guide](Persistence).
 
 ## Hazardous environments and contact emitters
 

--- a/wiki/Optional-Feature-Systems.md
+++ b/wiki/Optional-Feature-Systems.md
@@ -14,63 +14,7 @@ When Zeus Enhanced is loaded, the categorized WMP palette includes focused runti
 
 ## Persistence
 
-Save/restore player state (and specific registered world objects) across a database, backed by the INIDBI2 extension. Quickest working setup:
-
-1. Install the INIDBI2 extension on the **server** (not required on clients) — see its own release for that step; WMP does not bundle it.
-2. Open `MissionConfig\persistenceConfig.sqf` and set `Waldo_Persistence_Enable` to `true`.
-3. Launch the mission on a server that has INIDBI2 installed. The server probes for a real, loaded extension (not just a declared dependency) and disables itself cleanly if the probe fails — check the RPT for `[WMP DIAG]` persistence lines if nothing is saving.
-4. Play, disconnect and reconnect (or use `Waldo_fnc_PersistenceStop` then restart the mission) to confirm loadout/medical state is restored.
-
-Database access remains server-only; clients only capture/apply their own state.
-
-| Setting | Default | Purpose |
-|---|---|---|
-| `Waldo_Persistence_Enable` | `false` | Master opt-in; requires a working server INIDBI2 extension |
-| `Waldo_Persistence_SaveLoadout` | `true` | Filtered inventory (unique ACRE radio IDs stripped) |
-| `Waldo_Persistence_SaveMedical` | `true` | ACE medical state |
-| `Waldo_Persistence_SaveFoodWater` | `false` | Hunger/thirst state |
-| `Waldo_Persistence_SavePosition` | `false` | Off by default — can bypass mission flow (e.g. skip an intro area) |
-| `Waldo_Persistence_SaveRadios` | `false` | Per-player ACRE channel/spatial state |
-| `Waldo_Persistence_Scope` | `"MISSION"` | `"MISSION"` isolates records by mission+terrain; `"CAMPAIGN"` shares by database name across missions |
-| `Waldo_Persistence_DatabaseName` | `"WaldosMissionPack"` | Database identity; only matters when `Scope` is `"CAMPAIGN"` |
-| `Waldo_Persistence_DefaultCustomVariables` | `[]` | Extra variable names saved alongside the built-in fields — see [Optional Feature Extensions](Optional-Feature-Extensions) |
-
-Zeus can use **Persistence - Control** to start, reconfigure or stop the system, and **Persistence - Register Object** near an object to assign its stable key and saved fields during play. **Persistence - Save Now** requests an immediate state capture from connected players and writes selected registered objects without stopping persistence. It reports cleanly when the required runtime is not active.
-
-Player persistence can independently save loadout, ACE medical state, food/water, position and supported radio state. Loadout and medical state are enabled by default; the more mission-sensitive fields are not. Tune the shared `Waldo_Persistence_*` values in `MissionConfig\persistenceConfig.sqf`. The server starts the database branch from `initServer.sqf`; each player starts only capture/apply work from `initPlayerLocal.sqf`.
-
-Player records are separated by Steam UID and, by default, database name + mission name + terrain.
-Keep `Waldo_Persistence_Scope = "MISSION"` for ordinary missions. Use `"CAMPAIGN"` only when
-several missions using the same `Waldo_Persistence_DatabaseName` intentionally share progress. The
-server validates the identity stored inside a record before sending it to a client.
-
-ACRE-aware persistence filters unique `_ID_n` radio classes before storage. When `Waldo_Persistence_SaveRadios` is enabled, channel and spatial state are stored separately by base radio class and same-type ordinal. A restore creates fresh unique radios first and then reapplies persisted state; when disabled, the current side/group mission plan is applied instead. ACRE being absent leaves ordinary loadouts unchanged.
-
-### Registering objects — `Waldo_fnc_PersistenceRegisterObject`
-
-Register an editor object from `initServer.sqf` or its own init field:
-
-```sqf
-[supplyCrate, "base_supply_1", [true, false, false, false, false]] call Waldo_fnc_PersistenceRegisterObject;
-// [object, key, [cargo, damage, fuel, ammo/pylons, position, customVariableNames]]
-```
-
-| Argument | Type | Meaning |
-|---|---|---|
-| `object` | Object | The thing to persist |
-| `key` | String | Stable, unique within the mission. Letters/digits/underscore/dash only — anything else is rejected (logged) rather than silently mangled |
-| `options[0..4]` | Bool (each) | Save cargo / damage / fuel / ammunition-pylons / position. Missing values default `true`, so a bare `[obj, "key"]` call saves everything |
-| `options[5]` | Array\<String\> | Extra serialisable variable names, beyond the five built-in fields. Defaults to `Waldo_Persistence_DefaultCustomVariables` when omitted — see [Optional Feature Extensions](Optional-Feature-Extensions) |
-
-Registering the **same key again** (a re-run init field, or using the ZEN module twice near the same object) **replaces** the previous entry rather than duplicating it — safe to call more than once. Registrations made while the database is still starting are queued by key and replayed once it's ready.
-
-**Calling contract.** This function is stricter than most WMP "no `isServer` wrapper needed" calls (`Waldo_fnc_Jammer`, `Waldo_fnc_HazardRegisterPresetZone`, ...), which self-forward to the server with `remoteExecCall` when invoked from a client — this one does **not** forward itself, and a client `remoteExecCall` is rejected outright. It only works:
-- from an object's own **Eden init field** (which runs identically on every machine; only the server's own execution of that line actually registers anything — that's what "no wrapper needed" means here, not "safe to `remoteExecCall`"), or
-- from a **direct `call`/`spawn`** by code already running on the server (`initServer.sqf`, another server-only script, or a server-side handler — see how the ZEN module below reaches it).
-
-A mission-specific curator/client-triggered registration flow needs its own authenticated server-side bridge mirroring that pattern; it must not `remoteExecCall` this function directly.
-
-Call `Waldo_fnc_PersistenceStop` to save registered objects and stop the system without deleting its database.
+Save/restore player state (and specific registered world objects) across a database, backed by the INIDBI2 extension. Off by default, and stays off unless the server also proves a working INIDBI2 runtime is actually loaded. See the [complete Persistence guide](Persistence) for setup steps, the full `Waldo_Persistence_*` settings table, registering objects with `Waldo_fnc_PersistenceRegisterObject`, and the three Zeus modules.
 
 ## Patient treatment feedback
 

--- a/wiki/Persistence.md
+++ b/wiki/Persistence.md
@@ -1,0 +1,91 @@
+# Persistence
+
+> **Use this page when:** you want player state or specific placed objects to survive disconnects and mission restarts through a database.
+
+_Associated Files: `MissionConfig/persistenceConfig.sqf`, `MissionScripts/Persistence/`; `initServer.sqf` (database authority startup), `initPlayerLocal.sqf` (per-player capture/apply)_
+
+Persistence saves and restores player state — and specific, explicitly registered world objects — across a real database, backed by the [INIDBI2](https://github.com/SzwedzikPL/inidbi2) extension. It is off by default and stays off unless both the mission maker enables it **and** the server can prove a working INIDBI2 runtime is actually loaded, not just declared as a dependency. Database access is always server-only; each client only captures and applies its own state.
+
+## Beginner quick start
+
+1. Install the INIDBI2 extension on the **server** (not required on clients) — see its own release for that step; WMP does not bundle it.
+2. Open `MissionConfig\persistenceConfig.sqf` and set `Waldo_Persistence_Enable` to `true`.
+3. Launch the mission on a server that has INIDBI2 installed. The server probes for a real, loaded extension (not just a declared dependency) and disables itself cleanly if the probe fails — check the RPT for `[WMP DIAG]` persistence lines if nothing is saving.
+4. Play, disconnect and reconnect (or use `Waldo_fnc_PersistenceStop` then restart the mission) to confirm loadout/medical state is restored.
+
+The `[WMP]Persistence_Object_Example_Minimal` and `[WMP]Persistence_Object_Example_Full` compositions demonstrate registering a placed object (see below) without any scripting beyond the object's own init field.
+
+## What gets saved
+
+Player persistence can independently save loadout, ACE medical state, food/water, position and supported radio state. Loadout and medical state are enabled by default; the more mission-sensitive fields are not. The server starts the database branch from `initServer.sqf`; each player starts only capture/apply work from `initPlayerLocal.sqf`.
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `Waldo_Persistence_Enable` | `false` | Master opt-in; requires a working server INIDBI2 extension |
+| `Waldo_Persistence_SaveLoadout` | `true` | Filtered inventory (unique ACRE radio IDs stripped) |
+| `Waldo_Persistence_SaveMedical` | `true` | ACE medical state |
+| `Waldo_Persistence_SaveFoodWater` | `false` | Hunger/thirst state |
+| `Waldo_Persistence_SavePosition` | `false` | Off by default — can bypass mission flow (e.g. skip an intro area) |
+| `Waldo_Persistence_SaveRadios` | `false` | Per-player ACRE channel/spatial state |
+| `Waldo_Persistence_Scope` | `"MISSION"` | `"MISSION"` isolates records by mission+terrain; `"CAMPAIGN"` shares by database name across missions |
+| `Waldo_Persistence_DatabaseName` | `"WaldosMissionPack"` | Database identity; only matters when `Scope` is `"CAMPAIGN"` |
+| `Waldo_Persistence_PlayerSaveInterval` | `60` | ADVANCED — seconds between automatic player writes; lower increases server I/O |
+| `Waldo_Persistence_ObjectSaveInterval` | `60` | ADVANCED — seconds between registered-world-object writes |
+| `Waldo_Persistence_DefaultCustomVariables` | `[]` | Extra variable names saved alongside the built-in fields — see [Optional Feature Extensions](Optional-Feature-Extensions#persistence-interoperability) |
+
+Tune the shared `Waldo_Persistence_*` values in `MissionConfig\persistenceConfig.sqf`.
+
+Player records are separated by Steam UID and, by default, database name + mission name + terrain. Keep `Waldo_Persistence_Scope = "MISSION"` for ordinary missions. Use `"CAMPAIGN"` only when several missions using the same `Waldo_Persistence_DatabaseName` intentionally share progress. The server validates the identity stored inside a record before sending it to a client.
+
+ACRE-aware persistence filters unique `_ID_n` radio classes before storage. When `Waldo_Persistence_SaveRadios` is enabled, channel and spatial state are stored separately by base radio class and same-type ordinal. A restore creates fresh unique radios first and then reapplies persisted state; when disabled, the current side/group mission plan is applied instead. ACRE being absent leaves ordinary loadouts unchanged.
+
+## Registering objects — `Waldo_fnc_PersistenceRegisterObject`
+
+Register an editor object from `initServer.sqf` or its own init field:
+
+```sqf
+[supplyCrate, "base_supply_1", [true, false, false, false, false]] call Waldo_fnc_PersistenceRegisterObject;
+// [object, key, [cargo, damage, fuel, ammo/pylons, position, customVariableNames]]
+```
+
+| Argument | Type | Meaning |
+|---|---|---|
+| `object` | Object | The thing to persist |
+| `key` | String | Stable, unique within the mission. Letters/digits/underscore/dash only — anything else is rejected (logged) rather than silently mangled |
+| `options[0..4]` | Bool (each) | Save cargo / damage / fuel / ammunition-pylons / position. Missing values default `true`, so a bare `[obj, "key"]` call saves everything |
+| `options[5]` | Array\<String\> | Extra serialisable variable names, beyond the five built-in fields. Defaults to `Waldo_Persistence_DefaultCustomVariables` when omitted — see [Optional Feature Extensions](Optional-Feature-Extensions#persistence-interoperability) |
+
+Registering the **same key again** (a re-run init field, or using the ZEN module twice near the same object) **replaces** the previous entry rather than duplicating it — safe to call more than once. Registrations made while the database is still starting are queued by key and replayed once it's ready.
+
+**Calling contract.** This function is stricter than most WMP "no `isServer` wrapper needed" calls (`Waldo_fnc_Jammer`, `Waldo_fnc_HazardRegisterPresetZone`, ...), which self-forward to the server with `remoteExecCall` when invoked from a client — this one does **not** forward itself, and a client `remoteExecCall` is rejected outright. It only works:
+- from an object's own **Eden init field** (which runs identically on every machine; only the server's own execution of that line actually registers anything — that's what "no wrapper needed" means here, not "safe to `remoteExecCall`"), or
+- from a **direct `call`/`spawn`** by code already running on the server (`initServer.sqf`, another server-only script, or a server-side handler — see how the ZEN module below reaches it).
+
+A mission-specific curator/client-triggered registration flow needs its own authenticated server-side bridge mirroring that pattern; it must not `remoteExecCall` this function directly.
+
+Call `Waldo_fnc_PersistenceStop` to save registered objects and stop the system without deleting its database.
+
+## Zeus modules
+
+Under **WMP Mission Tools**, three focused modules cover runtime control without any scripting:
+
+- **Persistence - Control** enables or disables persistence and configures player/object save intervals and the supported data categories. Enabling still requires a compatible INIDBI2 server runtime; placing the module does not silently bypass the dependency gate.
+- **Persistence - Register Object** selects the nearest object within 25 metres and registers its cargo, damage, fuel, ammunition/pylons and/or transform under an automatically generated stable runtime key.
+- **Persistence - Save Now** can immediately request saves from connected players, registered objects, or both without disabling the system.
+
+## Interoperability and extension
+
+Registered objects can persist an allow-list of custom variables in addition to cargo, damage, fuel, ammunition and position. Pass variable names as the sixth registration option, or edit `Waldo_Persistence_DefaultCustomVariables`. Object scale, breach state and stable field-resupply state are included by default. Existing version-one object records remain loadable.
+
+Dynamic objects are not recreated automatically. Register stable editor objects with unique keys; use mission-specific recreation logic for objects that do not exist when a save is loaded.
+
+## See also
+
+- [Optional Feature Systems](Optional-Feature-Systems)
+- [Optional Feature Extensions](Optional-Feature-Extensions)
+- [Waldos Mission Pack Zeus Modules](Waldos-Mission-Pack-Zeus-Modules)
+- [Mission Diagnostics](Mission-Diagnostics)
+
+<!-- WMP-WIKI-NAV -->
+---
+[Wiki home](Home) · [Quickstart](Quickstart-Guide) · [Feature index](Feature-Tutorials)

--- a/wiki/Quickstart-Guide.md
+++ b/wiki/Quickstart-Guide.md
@@ -14,8 +14,9 @@ WMP requires:
 
 - CBA_A3
 - ACE 3
+- Zeus Enhanced (the in-Zeus authoring surface for most systems added since v4.8 — Economy, Dynamic AA/AO, Gunship, Hazards, Transport, Recovery, Breaching, notifications, and more)
 
-Load optional integrations such as ACRE2, TFAR, Zeus Enhanced, or LAMBS only when your mission uses them.
+Load optional integrations such as ACRE2, TFAR, or LAMBS only when your mission uses them.
 
 ## 3. Copy WMP into the mission folder
 

--- a/wiki/Waldos-Mission-Pack-Zeus-Modules.md
+++ b/wiki/Waldos-Mission-Pack-Zeus-Modules.md
@@ -13,6 +13,7 @@ curator-authenticated server rule as the larger runtime systems.
 
 These modules allow users to:
 * Spawn a Logistics System Supply & Medical Crate to Zeus specification
+* Turn a crewed AI land-vehicle group into a managed [AI Convoy](AI-Convoy-System)
 * Set the mission to [ENDEX](ENDEX-Script-&-Custom-End-Screen)
 * End the mission utilising the [Custom End](ENDEX-Script-&-Custom-End-Screen)
 * Create and remove named [Dynamic Anti-Air](Dynamic-Anti-Air) systems
@@ -25,6 +26,7 @@ These modules allow users to:
 * Register vehicle-recovery workshops, recoverable vehicles and recovery carriers
 * Configure temporary squad rally respawns during play
 * Enable, time or lift SafeStart protection during play, even though it starts inactive by default
+* Send a [WMP notification card](Custom-UI-Notifications) to everyone, one side, a named group, or selected players
 
 WMP's Zeus modules require Zeus Enhanced. To keep the palette usable, they are grouped under **WMP Mission Flow**, **WMP Logistics**, **WMP Combat Systems**, **WMP Air Operations**, **WMP Mission Tools**, and **WMP Interface & QA**. Economy modules are grouped under **WMP Economy Systems**.
 
@@ -57,6 +59,10 @@ This module requires the [Automatic Fortify Setup](Automatic-ACE-Fortify-Setup),
 
 ![Fortify Budget Module GUI](https://i.imgur.com/GYunnuf.jpg)
 
+## AI Convoy Module
+
+Under **WMP Combat Systems**, **AI: Create Moving Convoy** turns the nearest crewed AI land-vehicle group within 150 m of the module into a managed convoy. Place the module on or near the lead vehicle. The dialog sets max speed, target separation and whether the convoy pushes through contact (keeps moving and only returns fire on the move) instead of stopping to engage. It calls the same [AI Convoy System](AI-Convoy-System) behaviour (`Waldo_fnc_SimpleAiConvoy`) available to scripts, dispatched to whichever machine currently owns the selected group. See [AI Convoy System](AI-Convoy-System) for the full parameter reference and the manual-stop script pattern.
+
 ## ENDEX Module
 
 The ENDEX module performs the following actions:
@@ -88,6 +94,10 @@ However, this variation allows the zeus to end the mission utilising a custom en
 
 Below is an example of the custom mission end screen:
 ![Mission End Screen Example](https://i.imgur.com/xmK9I1e.png)
+
+## Mission Flow: Send Notification
+
+Under **WMP Mission Flow**, sends a [WMP notification card](Custom-UI-Notifications) to a chosen audience instead of a single local player: title/message text, a type selector, duration, placement, a **Send to all players** checkbox, and a single ZEN-native **OWNERS** recipient picker (its own Sides/Groups/Players tabs, live multi-select, no typed callsign) for everything short of "everyone." Picked sides/groups/players are resolved into one deduplicated unit list before sending, so a player covered by more than one selection is never notified twice. Routed through a curator-authenticated server bridge before calling the same `Waldo_fnc_NotificationBroadcast` script API. See the [Custom UI Notifications](Custom-UI-Notifications) page for the full audience rules and the matching script call.
 
 ## Radio Jammer Modules
 
@@ -165,6 +175,8 @@ These modules are repeat-safe and send configuration through a server-authoritat
 **Vehicle Recovery - Register Workshop** assigns a key, delivery radius, nearby completion-notification radius, serviced side and optional delivery-area/exact-position map markers to the nearest object. Its exported call includes the same choices. **Register Vehicle** sets the matching key, damage and destroyed-vehicle policy, engineer restriction, recovery-object class, cargo preservation and restored fuel. Its friendly recovery-object dropdown is built from the mission-extensible `Waldo_Recovery_PackageClasses` pool. It can optionally replace immediate packaging with a simplified preparation procedure configured by enable, procedure and difficulty; repair is preselected. **Register Carrier** supports any nearby vehicle. Automatic handling uses its real configured vehicle cargo bay when a package fits and virtualizes otherwise; Virtual Manifest removes that engine dependency entirely, while Physical Cargo Bay deliberately enforces it. Loading range and a combined 1–10 package capacity are configurable. See [Vehicle Recovery and Squad Rally Points](Vehicle-Recovery-And-Squad-Rallies).
 
 ## AI Helicopter Landing
+
+[Improved AI Helicopter Landings](Improved-AI-Helicopter-Landings) intentionally has no ZEN module — it is a per-aircraft profile applied through `MissionConfig\aiConfig.sqf` and event-driven locality handlers, not a placeable or runtime-toggled system.
 
 ## Transport Services
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -87,6 +87,7 @@
 **Optional and Advanced Systems**
 
 * [Complete Feature Catalogue](Feature-Catalogue)
+* [Persistence](Persistence)
 * [Optional Feature Systems](Optional-Feature-Systems)
 * [Optional Feature Extensions](Optional-Feature-Extensions)
 * [Dynamic Anti-Air](Dynamic-Anti-Air)


### PR DESCRIPTION
**When merged this pull request will:**
- List Zeus Enhanced as a required addon alongside CBA_A3/ACE3 in `README.md`, `CLAUDE.md`, and `wiki/Quickstart-Guide.md`, and update the mission-pack-config skill's mod-detection guidance/ZEN mod reference to match (it no longer treats ZEN as "ask the user first")
- Add a `FEATURE_LOG.md` entry for the planned Field Resupply redesign: replace deployed crates' limited-`TAKE`-count/logical-row abstraction with real crate cargo populated the same way a standard supply crate is, so crates can be opened, taken from via ACE Cargo/Gear, and salvaged like any other logistics crate
- Give **Persistence** its own dedicated wiki page (`wiki/Persistence.md`) instead of only a hub-page section — it was the only "full system" per the Feature Catalogue's own tier without one (Dynamic AA, Transport Services, Vehicle Recovery, WMP HUD all have dedicated pages). Includes setup steps, the full settings table (restoring two settings — `Waldo_Persistence_PlayerSaveInterval`/`ObjectSaveInterval` — that had gone missing from the old hub-page table), `Waldo_fnc_PersistenceRegisterObject`'s calling contract, and the three Zeus modules. Trimmed the old hub section to a summary and updated every cross-reference (Feature-Catalogue, Feature-Tutorials, Home, `_Sidebar`, Feature-Configuration-Files, Optional-Feature-Extensions)
- Fix two real gaps found auditing `wiki/Waldos-Mission-Pack-Zeus-Modules.md` against the full 43-module core Zeus/script parity list: **"AI: Create Moving Convoy"** was completely absent (no section, no intro-bullet mention, no cross-reference to `AI-Convoy-System.md`), and **"## AI Helicopter Landing"** was a dangling empty header with no content. Also added a **"Mission Flow: Send Notification"** section/intro-bullet to the master page (it was previously documented only on `Custom-UI-Notifications.md`'s own page, with no cross-reference from the module index)
- `sqf_validator.py` (912 files), `config_style_checker.py`, `claude_skill_validator.py`, `wiki_style_checker.py` (80 pages), `check_wiki_assets.py`, and `documentation_contract_checker.py` all pass

This came out of an audit prompted by a report that Persistence had no wiki page — most other optional-feature sections (Field Resupply, Tactical Display, Hazards, Tree Felling, Emergency Dismount, Explosive Breaching, Object Scaling) turned out to already have solid beginner setup steps/parameter tables inside their hub pages, so this PR only touches the concrete gaps actually found rather than restructuring everything.

---
_Generated by [Claude Code](https://claude.ai/code/session_01797V55SZAFTLTeiyTwXj4A)_