### PR TITLE
Fix hazard dosimeter type label and Remove Nearest Hazard distance bug

### DIFF
--- a/MissionScripts/EnvironmentalSystems/HazardousEnvironments/hazardReadExposureLocal.sqf
+++ b/MissionScripts/EnvironmentalSystems/HazardousEnvironments/hazardReadExposureLocal.sqf
@@ -29,11 +29,28 @@ if (!local _target) exitWith {
     true
 };
 private _exposures = missionNamespace getVariable ["Waldo_Hazard_LocalExposure", createHashMap];
+// Waldo_Hazard_LocalExposure is keyed by zone runtime key (Waldo_fnc_HazardTick tracks each zone's
+// physical dose independently so decay/rate stays per-zone), not by hazard type - resolve each
+// zone's configured type/label from the shared registry the same way the live status panel does
+// instead of surfacing the raw generated zone key (e.g. "hazard_2_2026_8_10_17_39_45_167_1").
+private _zones = missionNamespace getVariable ["Waldo_Hazard_Zones", []];
+private _typeAggregates = createHashMap;
+{
+    _x params ["_key", "_area", "_profile"];
+    private _value = _exposures getOrDefault [_key, 0];
+    if (_value > 0) then {
+        private _type = _profile getOrDefault ["type", _profile getOrDefault ["label", "HAZARD"]];
+        private _label = _profile getOrDefault ["label", _type];
+        private _entry = _typeAggregates getOrDefault [_type, [_label, 0]];
+        _entry set [1, (_entry select 1) + _value];
+        _typeAggregates set [_type, _entry];
+    };
+} forEach _zones;
 private _rows = [];
 {
-    private _value = _exposures getOrDefault [_x, 0];
-    if (_value > 0) then {_rows pushBack format ["%1: %2", _x, _value toFixed 2]};
-} forEach ((keys _exposures) call BIS_fnc_sortAlphabetically);
+    (_typeAggregates get _x) params ["_label", "_sum"];
+    _rows pushBack format ["%1: %2", _label, _sum toFixed 2];
+} forEach ((keys _typeAggregates) call BIS_fnc_sortAlphabetically);
 private _body = if (_rows isEqualTo []) then {
     format ["%1 has no measurable exposure.", name _target]
 } else {

--- a/MissionScripts/ZenModules/RuntimeControl/featureRuntimeZen.sqf
+++ b/MissionScripts/ZenModules/RuntimeControl/featureRuntimeZen.sqf
@@ -626,7 +626,11 @@ switch (toUpperANSI _feature) do {
             getPosWorld _area
         };
         {
-            if (((_x select 1) call _getCentre) distance2D _modulePos < (((_nearest select 1) call _getCentre) distance2D _modulePos)) then {_nearest = _x};
+            // _getCentre's _area can itself be an Array (e.g. [position, radius] from HAZARD_CREATE, or
+            // [centre, a, b, angle, rectangle]) - it must be passed wrapped in its own argument array so
+            // params unpacks it as one whole "_area" parameter, not as that array's own positional args
+            // (which silently handed back a bare coordinate Number instead of the position array).
+            if (([_x select 1] call _getCentre) distance2D _modulePos < (([_nearest select 1] call _getCentre) distance2D _modulePos)) then {_nearest = _x};
         } forEach _zones;
         private _key = _nearest select 0;
         [


### PR DESCRIPTION
**When merged this pull request will:**
- Fix `Waldo_fnc_HazardReadExposureLocal` (the Hazard Dosimeter reading) showing the raw generated zone runtime key (e.g. `hazard_2_2026_8_10_17_39_45_167_1`) instead of the hazard's configured `type`/`label` (e.g. `RADIATION`)
- Fix the ZEN **Hazard - Remove Nearest** module throwing `distance2d: Type Number, expected Array,Object` when more than one hazard zone is registered

**Root causes:**
- `Waldo_Hazard_LocalExposure` (populated by `Waldo_fnc_HazardTick`) is keyed by each zone's unique generated runtime key, not by hazard type, since exposure/decay is tracked per-zone. The dosimeter read it directly instead of resolving each zone's configured `type`/`label` from the shared `Waldo_Hazard_Zones` registry, the way the live on-screen status panel already does — so it surfaced the internal key as if it were the hazard type.
- In `featureRuntimeZen.sqf`'s `HAZARD_REMOVE` case, the `_getCentre` helper used `params ["_area"]` but was invoked as `(_x select 1) call _getCentre`, passing the zone's `_area` value directly as `_this`. When `_area` is itself an Array (e.g. `[position, radius]`, as produced by `HAZARD_CREATE`), `params` unpacked it positionally instead of binding it as one whole parameter, so `_area` ended up being just the position, and the subsequent `_area select 0` returned a bare coordinate Number instead of a position Array/Object — which is exactly what `distance2D` then rejected.

**Fixes:**
- `hazardReadExposureLocal.sqf` now aggregates exposure by hazard `type` (summing zones that share a type) and displays each type's configured `label`, mirroring `Waldo_fnc_HazardTick`'s existing per-type status panel logic.
- `featureRuntimeZen.sqf` now wraps the argument in its own array (`[_x select 1] call _getCentre`) so the whole `_area` value binds correctly regardless of whether it's an Array, String, or Object.

Both `sqf_validator.py` and `performance_audit.py` pass locally.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CR4oLYqTEqeDYyNj6EC3d8)_