### PR TITLE
Add Land_WoodenTable_large_F and Land_WoodenTable_small_F as Mini Games table classes

### DIFF
--- a/.claude/skills/mission-pack-config/references/minigames.md
+++ b/.claude/skills/mission-pack-config/references/minigames.md
@@ -23,7 +23,8 @@ lifecycle block into `init.sqf` yourself, WMP already runs it):
 
 Tables are detected **by class**: `Land_CampingTable_F`,
 `Land_CampingTable_small_F`, `Land_CampingTable_small_white_F`,
-`Land_TablePlastic_01_F`. If the user wants a different table object to
+`Land_TablePlastic_01_F`, `Land_WoodenTable_large_F`,
+`Land_WoodenTable_small_F`. If the user wants a different table object to
 work, that means adding its classname to `Waldo_MG_CFG_TABLE_CLASSES` in
 `MissionScripts/MiniGames/engine/config.sqf` — not something achievable
 purely from `init.sqf`. Other tuning constants (`Waldo_MG_CFG_*`) live in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -697,7 +697,8 @@ if (Waldo_MiniGames_Enable) then {
 ```
 
 Tables are detected by class (`Land_CampingTable_F`, `Land_CampingTable_small_F`,
-`Land_CampingTable_small_white_F`, `Land_TablePlastic_01_F`). Tuning constants (`Waldo_MG_CFG_*`,
+`Land_CampingTable_small_white_F`, `Land_TablePlastic_01_F`, `Land_WoodenTable_large_F`,
+`Land_WoodenTable_small_F`). Tuning constants (`Waldo_MG_CFG_*`,
 including `Waldo_MG_CFG_TABLE_CLASSES`) live at the top of `MissionScripts/MiniGames/engine/config.sqf`.
 
 **2. Field equipment procedures (single-player, generic hook).** Ten pass/fail procedures gate any

--- a/MissionScripts/MiniGames/engine/config.sqf
+++ b/MissionScripts/MiniGames/engine/config.sqf
@@ -186,7 +186,9 @@ Waldo_MG_CFG_TABLE_CLASSES = [
     "Land_CampingTable_F",
     "Land_CampingTable_small_F",
     "Land_CampingTable_small_white_F",
-    "Land_TablePlastic_01_F"
+    "Land_TablePlastic_01_F",
+    "Land_WoodenTable_large_F",
+    "Land_WoodenTable_small_F"
 ];
 Waldo_MG_CFG_SEAT_COUNT = 4;
 Waldo_MG_CFG_SEAT_OFFSETS = [

--- a/wiki/Waldos-Mini-Games-Table-Games.md
+++ b/wiki/Waldos-Mini-Games-Table-Games.md
@@ -29,6 +29,8 @@ This is the [Waldos Mini Games](Waldos-Mini-Games) sub-page for the seated games
    | `Land_CampingTable_small_F` | Small camping table |
    | `Land_CampingTable_small_white_F` | Small white camping table |
    | `Land_TablePlastic_01_F` | Plastic table |
+   | `Land_WoodenTable_large_F` | Large wooden table |
+   | `Land_WoodenTable_small_F` | Small wooden table |
 
 3. That's it. Walk a player up to the table and use either the scroll-menu or the nested ACE **Party Table** interaction to **Sit at Table**. Both routes submit the same server-validated request.
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add `Land_WoodenTable_large_F` and `Land_WoodenTable_small_F` to `Waldo_MG_CFG_TABLE_CLASSES` in `MissionScripts/MiniGames/engine/config.sqf`, so both are auto-detected as valid Mini Games party tables (no init-field code needed, same as the existing supported classes)
- Update the supported-table-classes documentation in `CLAUDE.md`, `wiki/Waldos-Mini-Games-Table-Games.md`, and `.claude/skills/mission-pack-config/references/minigames.md` to list the two new classes

Both `sqf_validator.py` and `config_style_checker.py` pass locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HRux2vAJvUPvT4DwqbNnk2)_