### PR TITLE
Fix lock-cylinder input delay by driving the pick sweep per-frame

### DIFF
--- a/MissionScripts/InteractionsMinigames/Challenges/challengeLockpick.sqf
+++ b/MissionScripts/InteractionsMinigames/Challenges/challengeLockpick.sqf
@@ -26,6 +26,7 @@ _display setVariable ["Waldo_MG_LP_Period", _period];
 _display setVariable ["Waldo_MG_LP_ZoneWidth", _zoneWidth];
 _display setVariable ["Waldo_MG_LP_ZoneStart", 0.15 + random (0.7 - _zoneWidth)];
 _display setVariable ["Waldo_MG_LP_Sweep", 0];
+_display setVariable ["Waldo_MG_LP_StartedAt", -1];
 _display setVariable ["Waldo_MG_LP_Tension", 0.5];
 _display setVariable ["Waldo_MG_LP_TensionTarget", 0.25 + random 0.5];
 _display setVariable ["Waldo_MG_LP_TensionTolerance", 0.10];
@@ -161,10 +162,23 @@ _display setVariable ["Waldo_MG_LP_UpdateZone", {
 }];
 [_display] call (_display getVariable ["Waldo_MG_LP_UpdateZone", {}]);
 
+// Single source of truth for the pick height, derived fresh from elapsed time
+// rather than read back off the last rendered animation tick. SET PIN must
+// judge the exact instant the player pressed it, not a value that can be up
+// to one scheduler tick stale - that gap is what read as an input delay.
+_display setVariable ["Waldo_MG_LP_ComputeSweep", {
+    params ["_display"];
+    private _startedAt = _display getVariable ["Waldo_MG_LP_StartedAt", -1];
+    if (_startedAt < 0) exitWith {0};
+    private _period = _display getVariable ["Waldo_MG_LP_Period", 2.8];
+    private _phase = ((diag_tickTime - _startedAt) mod _period) / _period;
+    if (_phase <= 0.5) then {_phase * 2} else {(1 - _phase) * 2}
+}];
+
 _display setVariable ["Waldo_MG_LP_SetPin", {
     params ["_display"];
     if (!(_display getVariable ["Waldo_IMG_Started", false]) || {_display getVariable ["Waldo_MG_UI_Done", false]}) exitWith {};
-    private _sweep = _display getVariable ["Waldo_MG_LP_Sweep", 0];
+    private _sweep = [_display] call (_display getVariable ["Waldo_MG_LP_ComputeSweep", {}]);
     private _zoneStart = _display getVariable ["Waldo_MG_LP_ZoneStart", 0];
     private _zoneWidth = _display getVariable ["Waldo_MG_LP_ZoneWidth", 0.16];
     private _tension = _display getVariable ["Waldo_MG_LP_Tension", 0.5];
@@ -209,15 +223,24 @@ _setButton ctrlAddEventHandler ["ButtonClick", {private _display = ctrlParent (_
     false
 }] call Waldo_fnc_MiniGameEquipmentAddDisplayHandler;
 
-private _animationWorker = [_display] spawn {
+// The pick sweep used to be driven by a spawned uiSleep loop. Scheduled scripts
+// share a per-frame execution budget with every other running script in the
+// mission, so under load that loop can fall meaningfully behind real elapsed
+// time - the rendered marker (and, before the SetPin fix above, the SET PIN
+// judgement itself) would visibly lag the moment the player actually pressed
+// the key. addMissionEventHandler ["EachFrame", ...] runs unscheduled, once
+// per rendered frame, independent of the scheduler queue, so the marker stays
+// locked to Waldo_MG_LP_ComputeSweep's own real-time result every frame.
+private _animationStarter = [_display] spawn {
     params ["_display"];
     waitUntil {isNull _display || {_display getVariable ["Waldo_IMG_Started", false]}};
-    if (!isNull _display) then {[_display] call (_display getVariable ["Waldo_MG_LP_UpdateTension", {}]);};
-    private _started = diag_tickTime;
-    while {!isNull _display && {!(_display getVariable ["Waldo_MG_UI_Done", false])}} do {
-        private _period = _display getVariable ["Waldo_MG_LP_Period", 2.8];
-        private _phase = ((diag_tickTime - _started) mod _period) / _period;
-        private _sweep = if (_phase <= 0.5) then {_phase * 2} else {(1 - _phase) * 2};
+    if (isNull _display) exitWith {};
+    [_display] call (_display getVariable ["Waldo_MG_LP_UpdateTension", {}]);
+    _display setVariable ["Waldo_MG_LP_StartedAt", diag_tickTime];
+    private _ehId = addMissionEventHandler ["EachFrame", {
+        private _display = uiNamespace getVariable ["Waldo_MG_ActiveChallengeDisplay", displayNull];
+        if (isNull _display || {_display getVariable ["Waldo_MG_UI_Done", false]}) exitWith {};
+        private _sweep = [_display] call (_display getVariable ["Waldo_MG_LP_ComputeSweep", {}]);
         _display setVariable ["Waldo_MG_LP_Sweep", _sweep];
         [_display, _display getVariable ["Waldo_MG_LP_Marker", controlNull], [3.78 + (26 * _sweep), 19.55, 0.45, 1.8], 0] call Waldo_fnc_MiniGameEquipmentSetPosition;
         private _index = _display getVariable ["Waldo_MG_LP_CurrentPin", 0];
@@ -226,10 +249,12 @@ private _animationWorker = [_display] spawn {
             [_display, _keyPins select _index, [6 + (_index * (19 / (_display getVariable ["Waldo_MG_LP_Pins", 1]))), 12.4 - (1.85 * _sweep), 1.1, 3.8], 0] call Waldo_fnc_MiniGameEquipmentSetPosition;
             [_display, _display getVariable ["Waldo_MG_LP_PickTip", controlNull], [6 + (_index * (19 / (_display getVariable ["Waldo_MG_LP_Pins", 1]))) + 0.3, 13.9 - (1.85 * _sweep), 0.45, 1.5], 0] call Waldo_fnc_MiniGameEquipmentSetPosition;
         };
-        uiSleep 0.016;
-    };
+    }];
+    private _ehHandlers = _display getVariable ["Waldo_MG_UI_EachFrameHandlers", []];
+    _ehHandlers pushBack _ehId;
+    _display setVariable ["Waldo_MG_UI_EachFrameHandlers", _ehHandlers];
 };
 private _workers = _display getVariable ["Waldo_MG_UI_Workers", []];
-_workers pushBack _animationWorker;
+_workers pushBack _animationStarter;
 _display setVariable ["Waldo_MG_UI_Workers", _workers];
 [_display] call Waldo_fnc_MiniGameEquipmentBriefing;

--- a/MissionScripts/InteractionsMinigames/Challenges/challengeLockpick.sqf
+++ b/MissionScripts/InteractionsMinigames/Challenges/challengeLockpick.sqf
@@ -237,10 +237,21 @@ private _animationStarter = [_display] spawn {
     if (isNull _display) exitWith {};
     [_display] call (_display getVariable ["Waldo_MG_LP_UpdateTension", {}]);
     _display setVariable ["Waldo_MG_LP_StartedAt", diag_tickTime];
+    // equipmentCleanup.sqf normally removes this handler via Waldo_MG_UI_EachFrameHandlers,
+    // but that array is owned by two independently-scheduled scripts with no lock between
+    // them: if Cleanup runs (and clears the array) before the pushBack below executes,
+    // this id is never recorded and the shared cleanup path silently misses it. The handler
+    // therefore also removes itself the first frame it observes Done, using its own id off
+    // the display, so it can never outlive the challenge even when that race is lost.
     private _ehId = addMissionEventHandler ["EachFrame", {
         private _display = uiNamespace getVariable ["Waldo_MG_ActiveChallengeDisplay", displayNull];
-        if (isNull _display || {_display getVariable ["Waldo_MG_UI_Done", false]}) exitWith {};
+        if (isNull _display) exitWith {};
+        if (_display getVariable ["Waldo_MG_UI_Done", false]) exitWith {
+            removeMissionEventHandler ["EachFrame", (_display getVariable ["Waldo_MG_LP_AnimEhId", -1])];
+        };
         private _sweep = [_display] call (_display getVariable ["Waldo_MG_LP_ComputeSweep", {}]);
+        // Kept in sync for the interaction-equipment QA automation harness, which polls this
+        // variable directly rather than calling ComputeSweep - do not remove as "dead state".
         _display setVariable ["Waldo_MG_LP_Sweep", _sweep];
         [_display, _display getVariable ["Waldo_MG_LP_Marker", controlNull], [3.78 + (26 * _sweep), 19.55, 0.45, 1.8], 0] call Waldo_fnc_MiniGameEquipmentSetPosition;
         private _index = _display getVariable ["Waldo_MG_LP_CurrentPin", 0];
@@ -250,6 +261,7 @@ private _animationStarter = [_display] spawn {
             [_display, _display getVariable ["Waldo_MG_LP_PickTip", controlNull], [6 + (_index * (19 / (_display getVariable ["Waldo_MG_LP_Pins", 1]))) + 0.3, 13.9 - (1.85 * _sweep), 0.45, 1.5], 0] call Waldo_fnc_MiniGameEquipmentSetPosition;
         };
     }];
+    _display setVariable ["Waldo_MG_LP_AnimEhId", _ehId];
     private _ehHandlers = _display getVariable ["Waldo_MG_UI_EachFrameHandlers", []];
     _ehHandlers pushBack _ehId;
     _display setVariable ["Waldo_MG_UI_EachFrameHandlers", _ehHandlers];

--- a/MissionScripts/InteractionsMinigames/Core/challengeUi.sqf
+++ b/MissionScripts/InteractionsMinigames/Core/challengeUi.sqf
@@ -107,6 +107,7 @@ _display setVariable ["Waldo_MG_UI_GridCell", [_contentW / 40, _contentH / 25]];
 _display setVariable ["Waldo_MG_UI_EquipmentControls", []];
 _display setVariable ["Waldo_MG_UI_DisplayHandlers", []];
 _display setVariable ["Waldo_MG_UI_Workers", []];
+_display setVariable ["Waldo_MG_UI_EachFrameHandlers", []];
 _display setVariable ["Waldo_MG_UI_DragControl", controlNull];
 _display setVariable ["Waldo_IMG_Profile", _profile];
 _display setVariable ["Waldo_IMG_AbortPending", false];

--- a/MissionScripts/InteractionsMinigames/Core/equipmentCleanup.sqf
+++ b/MissionScripts/InteractionsMinigames/Core/equipmentCleanup.sqf
@@ -1,4 +1,4 @@
-/* Cancels active input and removes every shared display handler and worker. */
+/* Cancels active input and removes every shared display handler, per-frame handler and worker. */
 disableSerialization;
 params [["_display", displayNull, [displayNull]], ["_phase", "CANCEL", [""]]];
 if (isNull _display) exitWith {false};
@@ -16,4 +16,8 @@ _display setVariable ["Waldo_MG_UI_DisplayHandlers", []];
     if (!scriptDone _x) then {terminate _x;};
 } forEach (_display getVariable ["Waldo_MG_UI_Workers", []]);
 _display setVariable ["Waldo_MG_UI_Workers", []];
+{
+    removeMissionEventHandler ["EachFrame", _x];
+} forEach (_display getVariable ["Waldo_MG_UI_EachFrameHandlers", []]);
+_display setVariable ["Waldo_MG_UI_EachFrameHandlers", []];
 true

--- a/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/InteractionsMinigames/Challenges/challengeLockpick.sqf
+++ b/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/InteractionsMinigames/Challenges/challengeLockpick.sqf
@@ -26,6 +26,7 @@ _display setVariable ["Waldo_MG_LP_Period", _period];
 _display setVariable ["Waldo_MG_LP_ZoneWidth", _zoneWidth];
 _display setVariable ["Waldo_MG_LP_ZoneStart", 0.15 + random (0.7 - _zoneWidth)];
 _display setVariable ["Waldo_MG_LP_Sweep", 0];
+_display setVariable ["Waldo_MG_LP_StartedAt", -1];
 _display setVariable ["Waldo_MG_LP_Tension", 0.5];
 _display setVariable ["Waldo_MG_LP_TensionTarget", 0.25 + random 0.5];
 _display setVariable ["Waldo_MG_LP_TensionTolerance", 0.10];
@@ -161,10 +162,23 @@ _display setVariable ["Waldo_MG_LP_UpdateZone", {
 }];
 [_display] call (_display getVariable ["Waldo_MG_LP_UpdateZone", {}]);
 
+// Single source of truth for the pick height, derived fresh from elapsed time
+// rather than read back off the last rendered animation tick. SET PIN must
+// judge the exact instant the player pressed it, not a value that can be up
+// to one scheduler tick stale - that gap is what read as an input delay.
+_display setVariable ["Waldo_MG_LP_ComputeSweep", {
+    params ["_display"];
+    private _startedAt = _display getVariable ["Waldo_MG_LP_StartedAt", -1];
+    if (_startedAt < 0) exitWith {0};
+    private _period = _display getVariable ["Waldo_MG_LP_Period", 2.8];
+    private _phase = ((diag_tickTime - _startedAt) mod _period) / _period;
+    if (_phase <= 0.5) then {_phase * 2} else {(1 - _phase) * 2}
+}];
+
 _display setVariable ["Waldo_MG_LP_SetPin", {
     params ["_display"];
     if (!(_display getVariable ["Waldo_IMG_Started", false]) || {_display getVariable ["Waldo_MG_UI_Done", false]}) exitWith {};
-    private _sweep = _display getVariable ["Waldo_MG_LP_Sweep", 0];
+    private _sweep = [_display] call (_display getVariable ["Waldo_MG_LP_ComputeSweep", {}]);
     private _zoneStart = _display getVariable ["Waldo_MG_LP_ZoneStart", 0];
     private _zoneWidth = _display getVariable ["Waldo_MG_LP_ZoneWidth", 0.16];
     private _tension = _display getVariable ["Waldo_MG_LP_Tension", 0.5];
@@ -209,15 +223,24 @@ _setButton ctrlAddEventHandler ["ButtonClick", {private _display = ctrlParent (_
     false
 }] call Waldo_fnc_MiniGameEquipmentAddDisplayHandler;
 
-private _animationWorker = [_display] spawn {
+// The pick sweep used to be driven by a spawned uiSleep loop. Scheduled scripts
+// share a per-frame execution budget with every other running script in the
+// mission, so under load that loop can fall meaningfully behind real elapsed
+// time - the rendered marker (and, before the SetPin fix above, the SET PIN
+// judgement itself) would visibly lag the moment the player actually pressed
+// the key. addMissionEventHandler ["EachFrame", ...] runs unscheduled, once
+// per rendered frame, independent of the scheduler queue, so the marker stays
+// locked to Waldo_MG_LP_ComputeSweep's own real-time result every frame.
+private _animationStarter = [_display] spawn {
     params ["_display"];
     waitUntil {isNull _display || {_display getVariable ["Waldo_IMG_Started", false]}};
-    if (!isNull _display) then {[_display] call (_display getVariable ["Waldo_MG_LP_UpdateTension", {}]);};
-    private _started = diag_tickTime;
-    while {!isNull _display && {!(_display getVariable ["Waldo_MG_UI_Done", false])}} do {
-        private _period = _display getVariable ["Waldo_MG_LP_Period", 2.8];
-        private _phase = ((diag_tickTime - _started) mod _period) / _period;
-        private _sweep = if (_phase <= 0.5) then {_phase * 2} else {(1 - _phase) * 2};
+    if (isNull _display) exitWith {};
+    [_display] call (_display getVariable ["Waldo_MG_LP_UpdateTension", {}]);
+    _display setVariable ["Waldo_MG_LP_StartedAt", diag_tickTime];
+    private _ehId = addMissionEventHandler ["EachFrame", {
+        private _display = uiNamespace getVariable ["Waldo_MG_ActiveChallengeDisplay", displayNull];
+        if (isNull _display || {_display getVariable ["Waldo_MG_UI_Done", false]}) exitWith {};
+        private _sweep = [_display] call (_display getVariable ["Waldo_MG_LP_ComputeSweep", {}]);
         _display setVariable ["Waldo_MG_LP_Sweep", _sweep];
         [_display, _display getVariable ["Waldo_MG_LP_Marker", controlNull], [3.78 + (26 * _sweep), 19.55, 0.45, 1.8], 0] call Waldo_fnc_MiniGameEquipmentSetPosition;
         private _index = _display getVariable ["Waldo_MG_LP_CurrentPin", 0];
@@ -226,10 +249,12 @@ private _animationWorker = [_display] spawn {
             [_display, _keyPins select _index, [6 + (_index * (19 / (_display getVariable ["Waldo_MG_LP_Pins", 1]))), 12.4 - (1.85 * _sweep), 1.1, 3.8], 0] call Waldo_fnc_MiniGameEquipmentSetPosition;
             [_display, _display getVariable ["Waldo_MG_LP_PickTip", controlNull], [6 + (_index * (19 / (_display getVariable ["Waldo_MG_LP_Pins", 1]))) + 0.3, 13.9 - (1.85 * _sweep), 0.45, 1.5], 0] call Waldo_fnc_MiniGameEquipmentSetPosition;
         };
-        uiSleep 0.016;
-    };
+    }];
+    private _ehHandlers = _display getVariable ["Waldo_MG_UI_EachFrameHandlers", []];
+    _ehHandlers pushBack _ehId;
+    _display setVariable ["Waldo_MG_UI_EachFrameHandlers", _ehHandlers];
 };
 private _workers = _display getVariable ["Waldo_MG_UI_Workers", []];
-_workers pushBack _animationWorker;
+_workers pushBack _animationStarter;
 _display setVariable ["Waldo_MG_UI_Workers", _workers];
 [_display] call Waldo_fnc_MiniGameEquipmentBriefing;

--- a/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/InteractionsMinigames/Challenges/challengeLockpick.sqf
+++ b/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/InteractionsMinigames/Challenges/challengeLockpick.sqf
@@ -237,10 +237,21 @@ private _animationStarter = [_display] spawn {
     if (isNull _display) exitWith {};
     [_display] call (_display getVariable ["Waldo_MG_LP_UpdateTension", {}]);
     _display setVariable ["Waldo_MG_LP_StartedAt", diag_tickTime];
+    // equipmentCleanup.sqf normally removes this handler via Waldo_MG_UI_EachFrameHandlers,
+    // but that array is owned by two independently-scheduled scripts with no lock between
+    // them: if Cleanup runs (and clears the array) before the pushBack below executes,
+    // this id is never recorded and the shared cleanup path silently misses it. The handler
+    // therefore also removes itself the first frame it observes Done, using its own id off
+    // the display, so it can never outlive the challenge even when that race is lost.
     private _ehId = addMissionEventHandler ["EachFrame", {
         private _display = uiNamespace getVariable ["Waldo_MG_ActiveChallengeDisplay", displayNull];
-        if (isNull _display || {_display getVariable ["Waldo_MG_UI_Done", false]}) exitWith {};
+        if (isNull _display) exitWith {};
+        if (_display getVariable ["Waldo_MG_UI_Done", false]) exitWith {
+            removeMissionEventHandler ["EachFrame", (_display getVariable ["Waldo_MG_LP_AnimEhId", -1])];
+        };
         private _sweep = [_display] call (_display getVariable ["Waldo_MG_LP_ComputeSweep", {}]);
+        // Kept in sync for the interaction-equipment QA automation harness, which polls this
+        // variable directly rather than calling ComputeSweep - do not remove as "dead state".
         _display setVariable ["Waldo_MG_LP_Sweep", _sweep];
         [_display, _display getVariable ["Waldo_MG_LP_Marker", controlNull], [3.78 + (26 * _sweep), 19.55, 0.45, 1.8], 0] call Waldo_fnc_MiniGameEquipmentSetPosition;
         private _index = _display getVariable ["Waldo_MG_LP_CurrentPin", 0];
@@ -250,6 +261,7 @@ private _animationStarter = [_display] spawn {
             [_display, _display getVariable ["Waldo_MG_LP_PickTip", controlNull], [6 + (_index * (19 / (_display getVariable ["Waldo_MG_LP_Pins", 1]))) + 0.3, 13.9 - (1.85 * _sweep), 0.45, 1.5], 0] call Waldo_fnc_MiniGameEquipmentSetPosition;
         };
     }];
+    _display setVariable ["Waldo_MG_LP_AnimEhId", _ehId];
     private _ehHandlers = _display getVariable ["Waldo_MG_UI_EachFrameHandlers", []];
     _ehHandlers pushBack _ehId;
     _display setVariable ["Waldo_MG_UI_EachFrameHandlers", _ehHandlers];

--- a/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/InteractionsMinigames/Core/challengeUi.sqf
+++ b/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/InteractionsMinigames/Core/challengeUi.sqf
@@ -107,6 +107,7 @@ _display setVariable ["Waldo_MG_UI_GridCell", [_contentW / 40, _contentH / 25]];
 _display setVariable ["Waldo_MG_UI_EquipmentControls", []];
 _display setVariable ["Waldo_MG_UI_DisplayHandlers", []];
 _display setVariable ["Waldo_MG_UI_Workers", []];
+_display setVariable ["Waldo_MG_UI_EachFrameHandlers", []];
 _display setVariable ["Waldo_MG_UI_DragControl", controlNull];
 _display setVariable ["Waldo_IMG_Profile", _profile];
 _display setVariable ["Waldo_IMG_AbortPending", false];

--- a/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/InteractionsMinigames/Core/equipmentCleanup.sqf
+++ b/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/InteractionsMinigames/Core/equipmentCleanup.sqf
@@ -1,4 +1,4 @@
-/* Cancels active input and removes every shared display handler and worker. */
+/* Cancels active input and removes every shared display handler, per-frame handler and worker. */
 disableSerialization;
 params [["_display", displayNull, [displayNull]], ["_phase", "CANCEL", [""]]];
 if (isNull _display) exitWith {false};
@@ -16,4 +16,8 @@ _display setVariable ["Waldo_MG_UI_DisplayHandlers", []];
     if (!scriptDone _x) then {terminate _x;};
 } forEach (_display getVariable ["Waldo_MG_UI_Workers", []]);
 _display setVariable ["Waldo_MG_UI_Workers", []];
+{
+    removeMissionEventHandler ["EachFrame", _x];
+} forEach (_display getVariable ["Waldo_MG_UI_EachFrameHandlers", []]);
+_display setVariable ["Waldo_MG_UI_EachFrameHandlers", []];
 true

--- a/releaseVerificationAndDeployment/serverTestMissions/WMP_ACRE2_Respawn_Test.VR/MissionScripts/InteractionsMinigames/Challenges/challengeLockpick.sqf
+++ b/releaseVerificationAndDeployment/serverTestMissions/WMP_ACRE2_Respawn_Test.VR/MissionScripts/InteractionsMinigames/Challenges/challengeLockpick.sqf
@@ -26,6 +26,7 @@ _display setVariable ["Waldo_MG_LP_Period", _period];
 _display setVariable ["Waldo_MG_LP_ZoneWidth", _zoneWidth];
 _display setVariable ["Waldo_MG_LP_ZoneStart", 0.15 + random (0.7 - _zoneWidth)];
 _display setVariable ["Waldo_MG_LP_Sweep", 0];
+_display setVariable ["Waldo_MG_LP_StartedAt", -1];
 _display setVariable ["Waldo_MG_LP_Tension", 0.5];
 _display setVariable ["Waldo_MG_LP_TensionTarget", 0.25 + random 0.5];
 _display setVariable ["Waldo_MG_LP_TensionTolerance", 0.10];
@@ -161,10 +162,23 @@ _display setVariable ["Waldo_MG_LP_UpdateZone", {
 }];
 [_display] call (_display getVariable ["Waldo_MG_LP_UpdateZone", {}]);
 
+// Single source of truth for the pick height, derived fresh from elapsed time
+// rather than read back off the last rendered animation tick. SET PIN must
+// judge the exact instant the player pressed it, not a value that can be up
+// to one scheduler tick stale - that gap is what read as an input delay.
+_display setVariable ["Waldo_MG_LP_ComputeSweep", {
+    params ["_display"];
+    private _startedAt = _display getVariable ["Waldo_MG_LP_StartedAt", -1];
+    if (_startedAt < 0) exitWith {0};
+    private _period = _display getVariable ["Waldo_MG_LP_Period", 2.8];
+    private _phase = ((diag_tickTime - _startedAt) mod _period) / _period;
+    if (_phase <= 0.5) then {_phase * 2} else {(1 - _phase) * 2}
+}];
+
 _display setVariable ["Waldo_MG_LP_SetPin", {
     params ["_display"];
     if (!(_display getVariable ["Waldo_IMG_Started", false]) || {_display getVariable ["Waldo_MG_UI_Done", false]}) exitWith {};
-    private _sweep = _display getVariable ["Waldo_MG_LP_Sweep", 0];
+    private _sweep = [_display] call (_display getVariable ["Waldo_MG_LP_ComputeSweep", {}]);
     private _zoneStart = _display getVariable ["Waldo_MG_LP_ZoneStart", 0];
     private _zoneWidth = _display getVariable ["Waldo_MG_LP_ZoneWidth", 0.16];
     private _tension = _display getVariable ["Waldo_MG_LP_Tension", 0.5];
@@ -209,15 +223,24 @@ _setButton ctrlAddEventHandler ["ButtonClick", {private _display = ctrlParent (_
     false
 }] call Waldo_fnc_MiniGameEquipmentAddDisplayHandler;
 
-private _animationWorker = [_display] spawn {
+// The pick sweep used to be driven by a spawned uiSleep loop. Scheduled scripts
+// share a per-frame execution budget with every other running script in the
+// mission, so under load that loop can fall meaningfully behind real elapsed
+// time - the rendered marker (and, before the SetPin fix above, the SET PIN
+// judgement itself) would visibly lag the moment the player actually pressed
+// the key. addMissionEventHandler ["EachFrame", ...] runs unscheduled, once
+// per rendered frame, independent of the scheduler queue, so the marker stays
+// locked to Waldo_MG_LP_ComputeSweep's own real-time result every frame.
+private _animationStarter = [_display] spawn {
     params ["_display"];
     waitUntil {isNull _display || {_display getVariable ["Waldo_IMG_Started", false]}};
-    if (!isNull _display) then {[_display] call (_display getVariable ["Waldo_MG_LP_UpdateTension", {}]);};
-    private _started = diag_tickTime;
-    while {!isNull _display && {!(_display getVariable ["Waldo_MG_UI_Done", false])}} do {
-        private _period = _display getVariable ["Waldo_MG_LP_Period", 2.8];
-        private _phase = ((diag_tickTime - _started) mod _period) / _period;
-        private _sweep = if (_phase <= 0.5) then {_phase * 2} else {(1 - _phase) * 2};
+    if (isNull _display) exitWith {};
+    [_display] call (_display getVariable ["Waldo_MG_LP_UpdateTension", {}]);
+    _display setVariable ["Waldo_MG_LP_StartedAt", diag_tickTime];
+    private _ehId = addMissionEventHandler ["EachFrame", {
+        private _display = uiNamespace getVariable ["Waldo_MG_ActiveChallengeDisplay", displayNull];
+        if (isNull _display || {_display getVariable ["Waldo_MG_UI_Done", false]}) exitWith {};
+        private _sweep = [_display] call (_display getVariable ["Waldo_MG_LP_ComputeSweep", {}]);
         _display setVariable ["Waldo_MG_LP_Sweep", _sweep];
         [_display, _display getVariable ["Waldo_MG_LP_Marker", controlNull], [3.78 + (26 * _sweep), 19.55, 0.45, 1.8], 0] call Waldo_fnc_MiniGameEquipmentSetPosition;
         private _index = _display getVariable ["Waldo_MG_LP_CurrentPin", 0];
@@ -226,10 +249,12 @@ private _animationWorker = [_display] spawn {
             [_display, _keyPins select _index, [6 + (_index * (19 / (_display getVariable ["Waldo_MG_LP_Pins", 1]))), 12.4 - (1.85 * _sweep), 1.1, 3.8], 0] call Waldo_fnc_MiniGameEquipmentSetPosition;
             [_display, _display getVariable ["Waldo_MG_LP_PickTip", controlNull], [6 + (_index * (19 / (_display getVariable ["Waldo_MG_LP_Pins", 1]))) + 0.3, 13.9 - (1.85 * _sweep), 0.45, 1.5], 0] call Waldo_fnc_MiniGameEquipmentSetPosition;
         };
-        uiSleep 0.016;
-    };
+    }];
+    private _ehHandlers = _display getVariable ["Waldo_MG_UI_EachFrameHandlers", []];
+    _ehHandlers pushBack _ehId;
+    _display setVariable ["Waldo_MG_UI_EachFrameHandlers", _ehHandlers];
 };
 private _workers = _display getVariable ["Waldo_MG_UI_Workers", []];
-_workers pushBack _animationWorker;
+_workers pushBack _animationStarter;
 _display setVariable ["Waldo_MG_UI_Workers", _workers];
 [_display] call Waldo_fnc_MiniGameEquipmentBriefing;

--- a/releaseVerificationAndDeployment/serverTestMissions/WMP_ACRE2_Respawn_Test.VR/MissionScripts/InteractionsMinigames/Challenges/challengeLockpick.sqf
+++ b/releaseVerificationAndDeployment/serverTestMissions/WMP_ACRE2_Respawn_Test.VR/MissionScripts/InteractionsMinigames/Challenges/challengeLockpick.sqf
@@ -237,10 +237,21 @@ private _animationStarter = [_display] spawn {
     if (isNull _display) exitWith {};
     [_display] call (_display getVariable ["Waldo_MG_LP_UpdateTension", {}]);
     _display setVariable ["Waldo_MG_LP_StartedAt", diag_tickTime];
+    // equipmentCleanup.sqf normally removes this handler via Waldo_MG_UI_EachFrameHandlers,
+    // but that array is owned by two independently-scheduled scripts with no lock between
+    // them: if Cleanup runs (and clears the array) before the pushBack below executes,
+    // this id is never recorded and the shared cleanup path silently misses it. The handler
+    // therefore also removes itself the first frame it observes Done, using its own id off
+    // the display, so it can never outlive the challenge even when that race is lost.
     private _ehId = addMissionEventHandler ["EachFrame", {
         private _display = uiNamespace getVariable ["Waldo_MG_ActiveChallengeDisplay", displayNull];
-        if (isNull _display || {_display getVariable ["Waldo_MG_UI_Done", false]}) exitWith {};
+        if (isNull _display) exitWith {};
+        if (_display getVariable ["Waldo_MG_UI_Done", false]) exitWith {
+            removeMissionEventHandler ["EachFrame", (_display getVariable ["Waldo_MG_LP_AnimEhId", -1])];
+        };
         private _sweep = [_display] call (_display getVariable ["Waldo_MG_LP_ComputeSweep", {}]);
+        // Kept in sync for the interaction-equipment QA automation harness, which polls this
+        // variable directly rather than calling ComputeSweep - do not remove as "dead state".
         _display setVariable ["Waldo_MG_LP_Sweep", _sweep];
         [_display, _display getVariable ["Waldo_MG_LP_Marker", controlNull], [3.78 + (26 * _sweep), 19.55, 0.45, 1.8], 0] call Waldo_fnc_MiniGameEquipmentSetPosition;
         private _index = _display getVariable ["Waldo_MG_LP_CurrentPin", 0];
@@ -250,6 +261,7 @@ private _animationStarter = [_display] spawn {
             [_display, _display getVariable ["Waldo_MG_LP_PickTip", controlNull], [6 + (_index * (19 / (_display getVariable ["Waldo_MG_LP_Pins", 1]))) + 0.3, 13.9 - (1.85 * _sweep), 0.45, 1.5], 0] call Waldo_fnc_MiniGameEquipmentSetPosition;
         };
     }];
+    _display setVariable ["Waldo_MG_LP_AnimEhId", _ehId];
     private _ehHandlers = _display getVariable ["Waldo_MG_UI_EachFrameHandlers", []];
     _ehHandlers pushBack _ehId;
     _display setVariable ["Waldo_MG_UI_EachFrameHandlers", _ehHandlers];

--- a/releaseVerificationAndDeployment/serverTestMissions/WMP_ACRE2_Respawn_Test.VR/MissionScripts/InteractionsMinigames/Core/challengeUi.sqf
+++ b/releaseVerificationAndDeployment/serverTestMissions/WMP_ACRE2_Respawn_Test.VR/MissionScripts/InteractionsMinigames/Core/challengeUi.sqf
@@ -107,6 +107,7 @@ _display setVariable ["Waldo_MG_UI_GridCell", [_contentW / 40, _contentH / 25]];
 _display setVariable ["Waldo_MG_UI_EquipmentControls", []];
 _display setVariable ["Waldo_MG_UI_DisplayHandlers", []];
 _display setVariable ["Waldo_MG_UI_Workers", []];
+_display setVariable ["Waldo_MG_UI_EachFrameHandlers", []];
 _display setVariable ["Waldo_MG_UI_DragControl", controlNull];
 _display setVariable ["Waldo_IMG_Profile", _profile];
 _display setVariable ["Waldo_IMG_AbortPending", false];

--- a/releaseVerificationAndDeployment/serverTestMissions/WMP_ACRE2_Respawn_Test.VR/MissionScripts/InteractionsMinigames/Core/equipmentCleanup.sqf
+++ b/releaseVerificationAndDeployment/serverTestMissions/WMP_ACRE2_Respawn_Test.VR/MissionScripts/InteractionsMinigames/Core/equipmentCleanup.sqf
@@ -1,4 +1,4 @@
-/* Cancels active input and removes every shared display handler and worker. */
+/* Cancels active input and removes every shared display handler, per-frame handler and worker. */
 disableSerialization;
 params [["_display", displayNull, [displayNull]], ["_phase", "CANCEL", [""]]];
 if (isNull _display) exitWith {false};
@@ -16,4 +16,8 @@ _display setVariable ["Waldo_MG_UI_DisplayHandlers", []];
     if (!scriptDone _x) then {terminate _x;};
 } forEach (_display getVariable ["Waldo_MG_UI_Workers", []]);
 _display setVariable ["Waldo_MG_UI_Workers", []];
+{
+    removeMissionEventHandler ["EachFrame", _x];
+} forEach (_display getVariable ["Waldo_MG_UI_EachFrameHandlers", []]);
+_display setVariable ["Waldo_MG_UI_EachFrameHandlers", []];
 true


### PR DESCRIPTION
**When merged this pull request will:**
- Fix the lock-cylinder (`lockpick`) field-equipment challenge so pressing SET PIN / Space judges the exact instant of the keypress instead of a value cached from the last animation tick, which is what read as an input delay relative to the visible sweep
- Add `Waldo_MG_LP_ComputeSweep`, which derives the pick height fresh from `diag_tickTime` on demand, and have `SetPin` call it directly instead of reading back `Waldo_MG_LP_Sweep`
- Replace the sweep animation's spawned `uiSleep(0.016)` loop with an unscheduled `EachFrame` mission event handler, so the rendered marker updates every rendered frame instead of falling behind under scheduler load from other running scripts
- Add a shared `Waldo_MG_UI_EachFrameHandlers` registry in `challengeUi.sqf` and remove any registered `EachFrame` handlers in `equipmentCleanup.sqf`, so this pattern is available to other challenges and cleans up deterministically alongside existing workers/display handlers
- Sync the checked-in `WMP_FPA.VR` and `WMP_ACRE2_Respawn_Test.VR` `MissionScripts` mirrors with the three updated source files (`challengeLockpick.sqf`, `challengeUi.sqf`, `equipmentCleanup.sqf`)

**Root cause:** the marker position and the SET PIN hit-test both read `Waldo_MG_LP_Sweep`, but that variable was only refreshed by a `spawn`'d loop running in Arma's scheduled environment, which shares a per-frame execution-time budget with every other running script in the mission. Under load it can fall behind real elapsed time, so the value being judged (and rendered) can be stale by more than the intended 16ms tick — perceived by the player as their keypress not lining up with where the marker visibly was.

Verified with the repo's static validators (`sqf_validator.py`, `interaction_ui_checker.py`, `performance_audit.py`, `config_style_checker.py`, `drawn_ui_checker.py`) plus the relevant unit tests — all pass with no new findings. (The mission-scripts drift check for two other, unrelated files was already failing before this change and is untouched by it.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FKjUiKZUxzpNYGkeGUhxe8)_