### PR TITLE
Add Mission Diagnostics coverage for undiagnosed modules

### DIFF
--- a/.claude/skills/mission-pack-config/references/diagnostics.md
+++ b/.claude/skills/mission-pack-config/references/diagnostics.md
@@ -37,3 +37,12 @@ HUD state, 3D markers, and ACE-vs-vanilla actions.
 The latest report broadcasts as `Waldo_Diagnostics_LastReport`:
 `[warningCount, finishedAt, serverChecks, clientReports, runId]` — useful if
 scripting something that should wait for or react to the diagnostic pass.
+
+## Assistive hints
+
+Every `ERROR` check names the actual variable/function/file to go fix, not
+just that something is wrong — folded into the same `detail` text as
+`"; fix: <hint>"` (`Waldo_fnc_DiagnosticFoldHint`). When walking a user
+through a failing check, read and relay that `fix:` clause directly instead
+of guessing at a remediation — it's already written for a newcomer.
+`DISABLED`/`UNCONFIGURED` are expected, not failures, and never carry one.

--- a/.claude/skills/mission-pack-config/references/diagnostics.md
+++ b/.claude/skills/mission-pack-config/references/diagnostics.md
@@ -29,8 +29,10 @@ useful for the user to leave on while first configuring the pack.
 Distinguishes `LOADED`, `ACTIVE`, `DISABLED`, `UNCONFIGURED`,
 `UNAVAILABLE`, `ERROR`. Covers representative public APIs, mod dependencies,
 loadouts, configured classes, mission flow, MHQ, VVD, electronic warfare,
-party games, interaction equipment, Economy, Zeus registration, local HUD
-state, 3D markers, and ACE-vs-vanilla actions.
+party games, interaction equipment, Economy, Headless Client, Obituary,
+Zeus registration, the Feature Runtime Control snapshot handshake, Object
+Scaling, UI Theme, Accessibility, Emergency Dismount, Corpse Traps, local
+HUD state, 3D markers, and ACE-vs-vanilla actions.
 
 The latest report broadcasts as `Waldo_Diagnostics_LastReport`:
 `[warningCount, finishedAt, serverChecks, clientReports, runId]` — useful if

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -551,7 +551,18 @@ Runs a read-only server and client health check at mission start after the loado
 missionNamespace setVariable ["Waldo_RunDiagnostics", true, true];
 ```
 
-Checks distinguish `LOADED`, `ACTIVE`, `DISABLED`, `UNCONFIGURED`, `UNAVAILABLE`, and `ERROR`. Coverage includes representative public APIs, mod dependencies, loadouts, configured classes, mission flow, MHQ, VVD, electronic warfare, party games, interaction equipment, Economy, Zeus registration, local HUD state, 3D markers, and ACE versus vanilla actions. The latest report is broadcast in `Waldo_Diagnostics_LastReport` as `[warningCount, finishedAt, serverChecks, clientReports, runId]`. See `wiki/Mission-Diagnostics.md` for row contracts and filtering examples.
+Checks distinguish `LOADED`, `ACTIVE`, `DISABLED`, `UNCONFIGURED`, `UNAVAILABLE`, and `ERROR`. Coverage includes representative public APIs, mod dependencies, loadouts, configured classes, mission flow, MHQ, VVD, electronic warfare, party games, interaction equipment, Economy, Headless Client, Obituary, Zeus registration, the Feature Runtime Control snapshot handshake, Object Scaling bounds, UI Theme application, Accessibility self-interaction, Emergency Dismount, Corpse Traps, local HUD state, 3D markers, and ACE versus vanilla actions. The latest report is broadcast in `Waldo_Diagnostics_LastReport` as `[warningCount, finishedAt, serverChecks, clientReports, runId]`. See `wiki/Mission-Diagnostics.md` for row contracts and filtering examples.
+
+Every new module's diagnostics rows go through the same two primitives so RPT output never
+fragments into per-feature formats: `Waldo_fnc_DiagnosticLog` (the `[WMP DIAG]` frame shown above)
+and, for a feature large enough to own several rows, `Waldo_fnc_DiagnosticFeatureReport` (normalizes
+those rows into one `[featureName, checks]` result, each check being `[area, feature, state,
+detail]`). A single-flag optional feature typically adds one inline row directly in
+`runDiagnostics.sqf`/`runDiagnosticsClient.sqf` (see `corpse-traps` or `object-scaling`); a feature
+with real internal structure gets its own `*GetDiagnostics.sqf` consumed by both (see
+`Waldo_fnc_ObituaryGetDiagnostics`, `Waldo_fnc_HeadlessGetDiagnostics`). Either way the `area`/
+`feature` identifiers are the module's own name in kebab-case - never a free-text prefix - so every
+row stays searchable and consistent with the rest of the report.
 
 ### Headless Client Support (optional)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -564,6 +564,22 @@ with real internal structure gets its own `*GetDiagnostics.sqf` consumed by both
 `feature` identifiers are the module's own name in kebab-case - never a free-text prefix - so every
 row stays searchable and consistent with the rest of the report.
 
+Every check that can report `ERROR` also carries a short, plain-language remediation hint - not just
+*that* something is wrong, but *what to go and change* - so a newcomer reading `systemChat` or RPT
+never has to reverse-engineer the fix from a terse `state=`/`detail=` pair alone. Hints fold into the
+same `detail` text as `"; fix: <hint>"` via the shared `Waldo_fnc_DiagnosticFoldHint`, so the
+`[area, feature, state, detail]` shape every consumer reads never changes. `DISABLED` and
+`UNCONFIGURED` are not failures and never carry a hint; only `ERROR` (and, rarely, an `UNAVAILABLE`
+that reflects a real misconfiguration rather than an intentionally-absent optional mod) does. Use it
+the same way in a new check:
+
+```sqf
+private _hint = if (_valid) then {""} else {"Set Waldo_Example_Class to a real CfgVehicles class."};
+["area", "feature", _state, _detail, _hint] call Waldo_fnc_DiagnosticFoldHint; // feature-report files
+[_category, _name, _state, _detail, _warn, _hint] call _status;                // runDiagnostics.sqf
+[_area, _feature, _state, _detail, _hint] call _add;                           // runDiagnosticsClient.sqf
+```
+
 ### Headless Client Support (optional)
 
 Native, server-authoritative distribution of AI groups across connected headless clients. This

--- a/MissionScripts/EconomySystems/Core/getDiagnostics.sqf
+++ b/MissionScripts/EconomySystems/Core/getDiagnostics.sqf
@@ -1,14 +1,18 @@
 /* Author: WaldoTheWarfighter. Returns normalized Economy diagnostics. */
 private _enabled = missionNamespace getVariable ["Waldo_Economy_Enable", false];
 private _active = missionNamespace getVariable ["WaldoEcoCore_ModuleActive", false];
+private _coreDetail = format ["configured=%1 active=%2 commitment=%3", _enabled, _active, missionNamespace getVariable ["WaldoEcoCore_CommitmentMode", false]];
+if (_enabled && {!_active}) then {_coreDetail = [_coreDetail, "Waldo_Economy_Enable is true but Waldo_fnc_EcoInit never completed - confirm init.sqf actually spawns it, and check the RPT for [WMP ECO] errors."] call Waldo_fnc_DiagnosticFoldHint;};
 private _checks = [
-    ["economy", "core", if (!_enabled) then {"DISABLED"} else {if (_active) then {"ACTIVE"} else {"ERROR"}}, format ["configured=%1 active=%2 commitment=%3", _enabled, _active, missionNamespace getVariable ["WaldoEcoCore_CommitmentMode", false]]]
+    ["economy", "core", if (!_enabled) then {"DISABLED"} else {if (_active) then {"ACTIVE"} else {"ERROR"}}, _coreDetail]
 ];
 
 {
     _x params ["_name", "_variable"];
     private _loaded = missionNamespace getVariable [_variable, false];
-    _checks pushBack ["economy", _name, if (!_enabled) then {"DISABLED"} else {if (_loaded) then {"LOADED"} else {"ERROR"}}, format ["initialised=%1 variable=%2", _loaded, _variable]];
+    private _subDetail = format ["initialised=%1 variable=%2", _loaded, _variable];
+    if (_enabled && {!_loaded}) then {_subDetail = [_subDetail, format ["The %1 sub-system did not finish initialising - check the RPT for [WMP ECO] errors during Waldo_fnc_EcoInit's startup.", _name]] call Waldo_fnc_DiagnosticFoldHint;};
+    _checks pushBack ["economy", _name, if (!_enabled) then {"DISABLED"} else {if (_loaded) then {"LOADED"} else {"ERROR"}}, _subDetail];
 } forEach [
     ["resources", "WaldoEcoResource_SystemInitialized"],
     ["research", "WaldoEcoResearch_SystemInitialized"],
@@ -29,14 +33,20 @@ private _invalidBuy = _buy select {
     _className isEqualTo "" || {!(isClass (configFile >> "CfgVehicles" >> _className))}
 };
 _checks pushBack ["economy", "catalogs", if (_resources isEqualTo [] && {_research isEqualTo [] && {_build isEqualTo [] && {_buy isEqualTo []}}}) then {"UNCONFIGURED"} else {"LOADED"}, format ["resources=%1 research=%2 build=%3 purchases=%4", count _resources, count _research, count _build, count _buy]];
-_checks pushBack ["economy", "economy-build-classes", if (!(_invalidBuild isEqualTo [])) then {"ERROR"} else {if (_build isEqualTo []) then {"UNCONFIGURED"} else {"LOADED"}}, format ["entries=%1 invalidCfgVehicles=%2", count _build, _invalidBuild apply {_x param [0, "UNNAMED"]}]];
-_checks pushBack ["economy", "economy-purchase-classes", if (!(_invalidBuy isEqualTo [])) then {"ERROR"} else {if (_buy isEqualTo []) then {"UNCONFIGURED"} else {"LOADED"}}, format ["entries=%1 invalidCfgVehicles=%2", count _buy, _invalidBuy apply {_x param [0, "UNNAMED"]}]];
+private _buildDetail = format ["entries=%1 invalidCfgVehicles=%2", count _build, _invalidBuild apply {_x param [0, "UNNAMED"]}];
+if !(_invalidBuild isEqualTo []) then {_buildDetail = [_buildDetail, "One or more build catalogue entries reference a CfgVehicles class that doesn't exist - fix the classname in that entry's build definition (MissionConfig\economyConfig.sqf or the ZEN Build Setup Builder)."] call Waldo_fnc_DiagnosticFoldHint;};
+_checks pushBack ["economy", "economy-build-classes", if (!(_invalidBuild isEqualTo [])) then {"ERROR"} else {if (_build isEqualTo []) then {"UNCONFIGURED"} else {"LOADED"}}, _buildDetail];
+private _buyDetail = format ["entries=%1 invalidCfgVehicles=%2", count _buy, _invalidBuy apply {_x param [0, "UNNAMED"]}];
+if !(_invalidBuy isEqualTo []) then {_buyDetail = [_buyDetail, "One or more purchase catalogue entries reference a CfgVehicles class that doesn't exist - fix the classname in that entry's purchase definition (MissionConfig\economyConfig.sqf or the ZEN Purchasing Setup Builder)."] call Waldo_fnc_DiagnosticFoldHint;};
+_checks pushBack ["economy", "economy-purchase-classes", if (!(_invalidBuy isEqualTo [])) then {"ERROR"} else {if (_buy isEqualTo []) then {"UNCONFIGURED"} else {"LOADED"}}, _buyDetail];
 _checks pushBack ["economy", "runtime-registries", if (!_active) then {"DISABLED"} else {"LOADED"}, format ["zones=%1 buildings=%2 dropPoints=%3", count (missionNamespace getVariable ["WaldoEcoResource_ResourceZones", []]), count (missionNamespace getVariable ["WaldoEcoBuild_SpawnedBuildings", []]), count (missionNamespace getVariable ["WaldoEcoBuy_DropPoints", []])]];
 
 if (hasInterface) then {
     private _display = uiNamespace getVariable ["WaldoEcoCore_ActiveZeusPromptDisplay", displayNull];
     private _findings = if (isNull _display) then {[]} else {_display getVariable ["WaldoEcoCore_FitFindings", []]};
-    _checks pushBack ["world-ui", "economy-authoring-prompt", if (!(_findings isEqualTo [])) then {"ERROR"} else {if (isNull _display) then {"LOADED"} else {"ACTIVE"}}, format ["open=%1 fitComplete=%2 findings=%3", !isNull _display, !isNull _display && {_display getVariable ["WaldoEcoCore_FitComplete", false]}, _findings]];
+    private _promptDetail = format ["open=%1 fitComplete=%2 findings=%3", !isNull _display, !isNull _display && {_display getVariable ["WaldoEcoCore_FitComplete", false]}, _findings];
+    if !(_findings isEqualTo []) then {_promptDetail = [_promptDetail, "The open Economy authoring dialog reported layout findings - close and reopen it; if this persists, check the RPT for Waldo_fnc_EcoCore_fitPromptDisplay errors."] call Waldo_fnc_DiagnosticFoldHint;};
+    _checks pushBack ["world-ui", "economy-authoring-prompt", if (!(_findings isEqualTo [])) then {"ERROR"} else {if (isNull _display) then {"LOADED"} else {"ACTIVE"}}, _promptDetail];
 };
 
 ["economy", _checks] call Waldo_fnc_DiagnosticFeatureReport

--- a/MissionScripts/Headless/headlessGetDiagnostics.sqf
+++ b/MissionScripts/Headless/headlessGetDiagnostics.sqf
@@ -34,12 +34,16 @@ private _assigned = _managed select {(_x select 1) isEqualType 0 && {(_x select 
 private _mismatched = _assigned select {isNull (_x select 0) || {groupOwner (_x select 0) != (_x select 1)}};
 private _orphaned = _managed select {(_x select 1) isEqualType 0 && {!((_x select 1) in _clientOwnerIds)}};
 
+private _failedDetail = format ["failed=%1", count _failed];
+if (count _failed > 0) then {_failedDetail = [_failedDetail, "Check the RPT for [WMP HEADLESS] entries naming the failed group(s) and reason; a group can be pinned server-side with _group setVariable [""Waldo_Headless_ExcludeGroup"", true, true] if it should never migrate."] call Waldo_fnc_DiagnosticFoldHint;};
+private _consistencyDetail = format ["mismatched=%1 orphaned=%2", count _mismatched, count _orphaned];
+if (count _mismatched > 0 || {count _orphaned > 0}) then {_consistencyDetail = [_consistencyDetail, "The headless registry and actual group ownership have drifted apart - this should self-correct on the next rebalance pass; if it persists, check the RPT for [WMP HEADLESS] errors from Waldo_fnc_HeadlessMigrateGroup."] call Waldo_fnc_DiagnosticFoldHint;};
 private _checks = [
     ["headless", "headless-clients", if (count _clients > 0) then {"ACTIVE"} else {"UNCONFIGURED"}, format ["connected=%1", count _clients]],
     ["headless", "headless-managed-groups", if (count _assigned > 0) then {"ACTIVE"} else {"LOADED"}, format ["assigned=%1", count _assigned]],
     ["headless", "headless-excluded-groups", "LOADED", format ["excluded=%1 (reasons in Waldo_Headless_ExcludedGroups / RPT)", count _excluded]],
-    ["headless", "headless-failed-transfers", if (count _failed > 0) then {"ERROR"} else {"LOADED"}, format ["failed=%1", count _failed]],
-    ["headless", "headless-ownership-consistency", if (count _mismatched > 0 || {count _orphaned > 0}) then {"ERROR"} else {"LOADED"}, format ["mismatched=%1 orphaned=%2", count _mismatched, count _orphaned]],
+    ["headless", "headless-failed-transfers", if (count _failed > 0) then {"ERROR"} else {"LOADED"}, _failedDetail],
+    ["headless", "headless-ownership-consistency", if (count _mismatched > 0 || {count _orphaned > 0}) then {"ERROR"} else {"LOADED"}, _consistencyDetail],
     ["headless", "headless-migration-queue", if (count _queue > 0) then {"ACTIVE"} else {"LOADED"}, format ["queued=%1 workerActive=%2 startDelay=%3 minGroupAge=%4 pace=%5", count _queue, _workerActive, missionNamespace getVariable ["Waldo_Headless_StartDelaySeconds", 30], missionNamespace getVariable ["Waldo_Headless_MinGroupAgeSeconds", 10], missionNamespace getVariable ["Waldo_Headless_MigrationPaceSeconds", 3]]]
 ];
 

--- a/MissionScripts/InteractionsMinigames/Integration/miniGameInteractionGetDiagnostics.sqf
+++ b/MissionScripts/InteractionsMinigames/Integration/miniGameInteractionGetDiagnostics.sqf
@@ -22,7 +22,9 @@ private _checks = [];
     _x params ["_id", "_function"];
     private _api = !(isNil _function);
     private _registered = (_registry findIf {(_x param [0, ""]) == _id}) >= 0;
-    _checks pushBack ["interactions", format ["procedure-%1", _id], if (!_api) then {"ERROR"} else {if (_registered) then {"LOADED"} else {"UNCONFIGURED"}}, format ["function=%1 available=%2 locallyRegistered=%3", _function, _api, _registered]];
+    private _procDetail = format ["function=%1 available=%2 locallyRegistered=%3", _function, _api, _registered];
+    if !(_api) then {_procDetail = [_procDetail, format ["%1 is missing from this mission's copy of WMP - re-extract WaldosMissionPack\MissionScripts over this mission (or confirm WaldosFunctions.sqf wasn't edited) so it registers again.", _function]] call Waldo_fnc_DiagnosticFoldHint;};
+    _checks pushBack ["interactions", format ["procedure-%1", _id], if (!_api) then {"ERROR"} else {if (_registered) then {"LOADED"} else {"UNCONFIGURED"}}, _procDetail];
 } forEach _procedures;
 
 if (_objects isEqualTo [] && {hasInterface}) then {
@@ -43,6 +45,8 @@ private _invalidObjects = _objects select {
     private _ace = _featureOwned || {!_aceLoaded} || {!hasInterface} || {_x getVariable ["Waldo_MG_Int_ACEActionInstalled", false]};
     !_known || {!_vanilla} || {!_ace}
 };
-_checks pushBack ["interactions", "configured-equipment", if (!(_invalidObjects isEqualTo [])) then {"ERROR"} else {if (_objects isEqualTo []) then {"UNCONFIGURED"} else {if ((_objects findIf {(_x getVariable ["Waldo_MG_InteractionState", "IDLE"]) == "RUNNING"}) >= 0) then {"ACTIVE"} else {"LOADED"}}}, format ["objects=%1 invalid=%2 ACE=%3 vanillaRequired=%4", count _objects, count _invalidObjects, _aceLoaded, hasInterface]];
+private _equipmentDetail = format ["objects=%1 invalid=%2 ACE=%3 vanillaRequired=%4", count _objects, count _invalidObjects, _aceLoaded, hasInterface];
+if !(_invalidObjects isEqualTo []) then {_equipmentDetail = [_equipmentDetail, "A configured object references an unknown challenge id, or is missing its expected ACE/vanilla action - check the RPT for errors from Waldo_fnc_MiniGameInteractionSetup on the affected object(s)."] call Waldo_fnc_DiagnosticFoldHint;};
+_checks pushBack ["interactions", "configured-equipment", if (!(_invalidObjects isEqualTo [])) then {"ERROR"} else {if (_objects isEqualTo []) then {"UNCONFIGURED"} else {if ((_objects findIf {(_x getVariable ["Waldo_MG_InteractionState", "IDLE"]) == "RUNNING"}) >= 0) then {"ACTIVE"} else {"LOADED"}}}, _equipmentDetail];
 
 ["interaction-procedures", _checks] call Waldo_fnc_DiagnosticFeatureReport

--- a/MissionScripts/MedicalSystems/Obituary/obituaryGetDiagnostics.sqf
+++ b/MissionScripts/MedicalSystems/Obituary/obituaryGetDiagnostics.sqf
@@ -1,0 +1,40 @@
+/*
+ * Author: WaldoTheWarfighter
+ * Returns normalized Obituary / confirmed-death reporting diagnostics: mission-maker config state,
+ * the ACE medical/ACE interact-menu dependency the medic-only "Pronounce Dead" action needs, the
+ * broadcast confirmed-death ledger (entries/version/AAR tally), and - on an interface client only -
+ * whether this machine actually finished installing the action and its diary render loop.
+ * Locality and authority: read-only, safe on server or client. The first two checks read only
+ * broadcast/config state (Waldo_Obituary_Enable/Entries/Version/Text, Waldo_AAR_Obituary) so they
+ * report identically wherever they are called from. The third check is interface-only: it reads
+ * Waldo_Obituary_Started/RenderRunning, which Waldo_fnc_ObituaryInit only ever sets on the machine
+ * that ran it, matching the client-local rows added by Waldo_fnc_SafeStartGetDiagnostics /
+ * Waldo_fnc_ENDEXGetDiagnostics.
+ *
+ * Arguments: None
+ * Return Value: HashMap - the Waldo_fnc_DiagnosticFeatureReport shape for area "obituary"
+ * Example: [] call Waldo_fnc_ObituaryGetDiagnostics;
+ * Current callers: Waldo_fnc_RunDiagnostics, Waldo_fnc_RunDiagnosticsClient.
+ * Wiki: https://github.com/AdamWaldie/WaldosMissionPack/wiki/Mission-Diagnostics
+ */
+
+private _enabled = missionNamespace getVariable ["Waldo_Obituary_Enable", true];
+private _aceMedical = isClass (configFile >> "CfgPatches" >> "ace_medical");
+private _aceInteract = isClass (configFile >> "CfgPatches" >> "ace_interact_menu");
+private _dependenciesOk = _aceMedical && _aceInteract;
+private _entries = missionNamespace getVariable ["Waldo_Obituary_Entries", []];
+private _version = missionNamespace getVariable ["Waldo_Obituary_Version", 0];
+private _obitTally = missionNamespace getVariable ["Waldo_AAR_Obituary", []];
+
+private _checks = [
+    ["medical", "obituary-dependencies", if (!_enabled) then {"DISABLED"} else {if (_dependenciesOk) then {"LOADED"} else {"ERROR"}}, format ["enabled=%1 aceMedical=%2 aceInteractMenu=%3", _enabled, _aceMedical, _aceInteract]],
+    ["medical", "obituary-ledger", if (!_enabled) then {"DISABLED"} else {if (count _entries > 0) then {"ACTIVE"} else {"LOADED"}}, format ["entries=%1 version=%2 confirmedVictims=%3 chatAnnounce=%4", count _entries, _version, count _obitTally, missionNamespace getVariable ["Waldo_Obituary_ChatAnnounce", true]]]
+];
+
+if (hasInterface) then {
+    private _started = missionNamespace getVariable ["Waldo_Obituary_Started", false];
+    private _rendering = missionNamespace getVariable ["Waldo_Obituary_RenderRunning", false];
+    _checks pushBack ["medical", "obituary-client-action", if (!_enabled) then {"DISABLED"} else {if (!_dependenciesOk) then {"UNAVAILABLE"} else {if (_started && {_rendering}) then {"LOADED"} else {"ERROR"}}}, format ["actionInstalled=%1 diaryRenderLoop=%2", _started, _rendering]];
+};
+
+["obituary", _checks] call Waldo_fnc_DiagnosticFeatureReport

--- a/MissionScripts/MedicalSystems/Obituary/obituaryGetDiagnostics.sqf
+++ b/MissionScripts/MedicalSystems/Obituary/obituaryGetDiagnostics.sqf
@@ -26,15 +26,19 @@ private _entries = missionNamespace getVariable ["Waldo_Obituary_Entries", []];
 private _version = missionNamespace getVariable ["Waldo_Obituary_Version", 0];
 private _obitTally = missionNamespace getVariable ["Waldo_AAR_Obituary", []];
 
+private _dependenciesDetail = format ["enabled=%1 aceMedical=%2 aceInteractMenu=%3", _enabled, _aceMedical, _aceInteract];
+if (_enabled && {!_dependenciesOk}) then {_dependenciesDetail = [_dependenciesDetail, "Waldo_Obituary_Enable is true but ACE medical and/or ACE interact menu is not loaded - load both, or set Waldo_Obituary_Enable to false in MissionConfig\interfaceConfig.sqf."] call Waldo_fnc_DiagnosticFoldHint;};
 private _checks = [
-    ["medical", "obituary-dependencies", if (!_enabled) then {"DISABLED"} else {if (_dependenciesOk) then {"LOADED"} else {"ERROR"}}, format ["enabled=%1 aceMedical=%2 aceInteractMenu=%3", _enabled, _aceMedical, _aceInteract]],
+    ["medical", "obituary-dependencies", if (!_enabled) then {"DISABLED"} else {if (_dependenciesOk) then {"LOADED"} else {"ERROR"}}, _dependenciesDetail],
     ["medical", "obituary-ledger", if (!_enabled) then {"DISABLED"} else {if (count _entries > 0) then {"ACTIVE"} else {"LOADED"}}, format ["entries=%1 version=%2 confirmedVictims=%3 chatAnnounce=%4", count _entries, _version, count _obitTally, missionNamespace getVariable ["Waldo_Obituary_ChatAnnounce", true]]]
 ];
 
 if (hasInterface) then {
     private _started = missionNamespace getVariable ["Waldo_Obituary_Started", false];
     private _rendering = missionNamespace getVariable ["Waldo_Obituary_RenderRunning", false];
-    _checks pushBack ["medical", "obituary-client-action", if (!_enabled) then {"DISABLED"} else {if (!_dependenciesOk) then {"UNAVAILABLE"} else {if (_started && {_rendering}) then {"LOADED"} else {"ERROR"}}}, format ["actionInstalled=%1 diaryRenderLoop=%2", _started, _rendering]];
+    private _clientActionDetail = format ["actionInstalled=%1 diaryRenderLoop=%2", _started, _rendering];
+    if (_enabled && {_dependenciesOk} && {!(_started && {_rendering})}) then {_clientActionDetail = [_clientActionDetail, "The 'Pronounce Dead' action and/or diary render loop failed to install on this client - check the RPT for errors from Waldo_fnc_ObituaryInit."] call Waldo_fnc_DiagnosticFoldHint;};
+    _checks pushBack ["medical", "obituary-client-action", if (!_enabled) then {"DISABLED"} else {if (!_dependenciesOk) then {"UNAVAILABLE"} else {if (_started && {_rendering}) then {"LOADED"} else {"ERROR"}}}, _clientActionDetail];
 };
 
 ["obituary", _checks] call Waldo_fnc_DiagnosticFeatureReport

--- a/MissionScripts/MissionFlowAndUi/diagnosticFoldHint.sqf
+++ b/MissionScripts/MissionFlowAndUi/diagnosticFoldHint.sqf
@@ -1,0 +1,25 @@
+/*
+ * Author: WaldoTheWarfighter
+ * Folds an optional plain-language remediation hint into a diagnostic check's detail text, using
+ * the one "; fix: <hint>" convention every WMP diagnostic check - server, client, and every
+ * *GetDiagnostics.sqf feature report - shares. Centralising the exact phrasing here keeps a check
+ * authored anywhere in the pack assistive in the same wording instead of each call site
+ * hand-formatting its own variant.
+ * Locality and authority: none. Pure, unscheduled string formatting; safe anywhere.
+ *
+ * Arguments:
+ * 0: detail text <STRING>
+ * 1: hint <STRING> (optional, default "" - no hint folded in)
+ *
+ * Return Value:
+ * String - _detail unchanged, or "_detail; fix: _hint" when a hint was supplied
+ *
+ * Example:
+ * private _fullDetail = ["state=ERROR class=foo", "Set Logi_SupplyBoxClass to a real CfgVehicles class."]
+ *     call Waldo_fnc_DiagnosticFoldHint;
+ * Current callers: Waldo_fnc_RunDiagnostics' _status helper, Waldo_fnc_RunDiagnosticsClient's _add
+ * helper, and every *GetDiagnostics.sqf feature report that builds its own check rows directly.
+ */
+
+params [["_detail", "", [""]], ["_hint", "", [""]]];
+if (_hint == "") then {_detail} else {format ["%1; fix: %2", _detail, _hint]}

--- a/MissionScripts/MissionFlowAndUi/endexGetDiagnostics.sqf
+++ b/MissionScripts/MissionFlowAndUi/endexGetDiagnostics.sqf
@@ -9,7 +9,9 @@ private _checks = [
 if (hasInterface) then {
     private _fired = !isNil "Waldo_PreventWeaponsFireEventHandler";
     private _protected = _fired && {!(isDamageAllowed player)};
-    _checks pushBack ["mission-flow", "endex-client-protection", if (_active && {!_protected}) then {"ERROR"} else {if (_active) then {"ACTIVE"} else {"LOADED"}}, format ["firedHandler=%1 damageAllowed=%2 safetyClaims=%3", _fired, isDamageAllowed player, player getVariable ["Waldo_WMPProtection_SafetyClaims", []]]];
+    private _detail = format ["firedHandler=%1 damageAllowed=%2 safetyClaims=%3", _fired, isDamageAllowed player, player getVariable ["Waldo_WMPProtection_SafetyClaims", []]];
+    if (_active && {!_protected}) then {_detail = [_detail, "ENDEX is active but this client's weapon-safety protection isn't in place - check the RPT for errors from Waldo_fnc_ENDEX, or rejoin."] call Waldo_fnc_DiagnosticFoldHint;};
+    _checks pushBack ["mission-flow", "endex-client-protection", if (_active && {!_protected}) then {"ERROR"} else {if (_active) then {"ACTIVE"} else {"LOADED"}}, _detail];
 };
 
 ["endex-aar", _checks] call Waldo_fnc_DiagnosticFeatureReport

--- a/MissionScripts/MissionFlowAndUi/runDiagnostics.sqf
+++ b/MissionScripts/MissionFlowAndUi/runDiagnostics.sqf
@@ -45,7 +45,7 @@ private _section = {
 // something is wrong, a hint tells you *what to do about it*.
 private _status = {
     params ["_category", "_name", "_state", ["_detail", ""], ["_warn", false], ["_hint", ""]];
-    private _fullDetail = if (_hint == "") then {_detail} else {format ["%1; fix: %2", _detail, _hint]};
+    private _fullDetail = [_detail, _hint] call Waldo_fnc_DiagnosticFoldHint;
     _report pushBack [_category, _name, _state, _fullDetail];
     [if (_warn) then {"ERROR"} else {"INFO"}, _category, _name, "CHECK", format ["state=%1 detail=%2", _state, _fullDetail]] call _log;
     if (_warn) then {_warnings = _warnings + 1;};
@@ -66,7 +66,7 @@ private _consumeFeatureReport = {
 {
     _x params ["_area", "_feature", "_function"];
     private _available = !(isNil _function);
-    [_area, _feature, if (_available) then {"LOADED"} else {"ERROR"}, format ["function=%1", _function], !_available] call _status;
+    [_area, _feature, if (_available) then {"LOADED"} else {"ERROR"}, format ["function=%1", _function], !_available, if (_available) then {""} else {format ["%1 is missing from this mission's copy of WMP - re-extract WaldosMissionPack\MissionScripts over this mission (or confirm WaldosFunctions.sqf wasn't edited) so it registers again.", _function]}] call _status;
 } forEach [
     ["mission-flow", "safestart-api", "Waldo_fnc_SafeStart"],
     ["mission-flow", "aar-endex-api", "Waldo_fnc_ENDEX"],
@@ -99,7 +99,7 @@ private _consumeFeatureReport = {
 {
     _x params ["_patch", "_label", "_required"];
     private _loaded = isClass (configFile >> "CfgPatches" >> _patch);
-    ["dependency", _label, if (_loaded) then {"LOADED"} else {if (_required) then {"ERROR"} else {"UNAVAILABLE"}}, format ["CfgPatches >> %1", _patch], _required && {!_loaded}] call _status;
+    ["dependency", _label, if (_loaded) then {"LOADED"} else {if (_required) then {"ERROR"} else {"UNAVAILABLE"}}, format ["CfgPatches >> %1", _patch], _required && {!_loaded}, if (_loaded || {!_required}) then {""} else {format ["%1 is required by WMP but is not loaded - add it to this mission's mod list and launch parameters.", _label]}] call _status;
 } forEach [
     ["cba_main", "CBA_A3", true],
     ["ace_main", "ACE3", true],
@@ -124,7 +124,7 @@ waitUntil {
     missionNamespace getVariable ["Logi_MissionScanComplete", false] || {diag_tickTime >= _scanDeadline}
 };
 private _scanComplete = missionNamespace getVariable ["Logi_MissionScanComplete", false];
-["logistics", "mission-loadout-scan", if (_scanComplete) then {"LOADED"} else {"UNAVAILABLE"}, if (_scanComplete) then {"Mission loadout arrays published"} else {"Loadout scan did not complete within 10 seconds"}, !_scanComplete] call _status;
+["logistics", "mission-loadout-scan", if (_scanComplete) then {"LOADED"} else {"UNAVAILABLE"}, if (_scanComplete) then {"Mission loadout arrays published"} else {"Loadout scan did not complete within 10 seconds"}, !_scanComplete, if (_scanComplete) then {""} else {"Waldo_fnc_SideBaseLoadoutSetup did not finish - check the RPT for errors, and confirm mission.sqm is not binarized (Eden Editor > mission Properties > uncheck Binarize)."}] call _status;
 
 private _flattenReal = {
     params ["_array"];
@@ -157,11 +157,11 @@ private _loadoutRoot = missionConfigFile >> "MissionSQM" >> "Mission" >> "Entiti
         ["logistics", format ["%1-loadout", _label], "UNCONFIGURED", "No authored mission-config playable slots use this side", false] call _status;
     } else {
         if (_count > 0) then {_configuredLoadoutSides = _configuredLoadoutSides + 1};
-        ["logistics", format ["%1-loadout", _label], if (_count > 0) then {"LOADED"} else {"ERROR"}, format ["%1 authored playable slot(s), %2 unique mission-scraped item(s)", _slotCount, _count], _count == 0] call _status;
+        ["logistics", format ["%1-loadout", _label], if (_count > 0) then {"LOADED"} else {"ERROR"}, format ["%1 authored playable slot(s), %2 unique mission-scraped item(s)", _slotCount, _count], _count == 0, if (_count > 0) then {""} else {format ["%1 has playable units placed but no scanned loadout items - open each of this side's playable units in ACE Arsenal at least once and save; a vanilla default loadout produces empty crates.", _label]}] call _status;
     };
 } forEach [["West", "West", "BLUFOR"], ["East", "East", "OPFOR"], ["Independent", "Ind", "INDEP"], ["Civilian", "Civ", "CIV"]];
 if (_configuredLoadoutSides == 0) then {
-    ["logistics", "playable-slots", "ERROR", "No authored playable inventories were found in mission configuration; logistics crates cannot derive mission equipment", true] call _status;
+    ["logistics", "playable-slots", "ERROR", "No authored playable inventories were found in mission configuration; logistics crates cannot derive mission equipment", true, "Place at least one playable unit per side you want logistics support for, and configure its loadout in ACE Arsenal (not vanilla defaults)."] call _status;
 };
 
 // Configured classes. Blank values are unconfigured; bad non-blank values are errors.
@@ -184,10 +184,10 @@ if (_configuredLoadoutSides == 0) then {
         ["configuration", _label, if (_valid) then {"LOADED"} else {"ERROR"}, format ["%1 = %2", _variable, _class], !_valid, _resolvedHint] call _status;
     };
 } forEach [
-    ["Logi_SupplyBoxClass", "supply-box"],
-    ["Logi_MedicalBoxClass", "medical-box"],
-    ["WALDO_STATIC_STATICCHUTE", "static-line-parachute"],
-    ["WALDO_PARA_HALOCHUTE", "halo-parachute"]
+    ["Logi_SupplyBoxClass", "supply-box", "Set Logi_SupplyBoxClass in initServer.sqf to a real CfgVehicles crate class, e.g. ""B_supplyCrate_F""."],
+    ["Logi_MedicalBoxClass", "medical-box", "Set Logi_MedicalBoxClass in initServer.sqf to a real CfgVehicles crate class, e.g. ""ACE_medicalSupplyCrate_advanced""."],
+    ["WALDO_STATIC_STATICCHUTE", "static-line-parachute", "Set WALDO_STATIC_STATICCHUTE in MissionConfig\airOperationsConfig.sqf to a real parachute class, e.g. the vanilla ""NonSteerable_Parachute_F""."],
+    ["WALDO_PARA_HALOCHUTE", "halo-parachute", "Set WALDO_PARA_HALOCHUTE in MissionConfig\airOperationsConfig.sqf to a real parachute class, e.g. the vanilla ""B_Parachute""."]
 ];
 
 private _minAltitude = missionNamespace getVariable ["WALDO_STATIC_MINALTITUDE", 180];
@@ -214,10 +214,10 @@ if (_acreLoaded) then {
     private _sidePlans = if (_planValid) then {_acrePlan select 2} else {[]};
     private _groupCount = 0;
     {_groupCount = _groupCount + count (_x param [3, []]);} forEach _sidePlans;
-    ["radio", "acre-config", if (!_acreEnabled) then {"DISABLED"} else {if (count _acreConfig == 0) then {"ERROR"} else {"LOADED"}}, format ["enabled=%1 strict=%2 presetPolicy=%3 namedDisplays=%4", _acreEnabled, _acreConfig getOrDefault ["strict", true], _acreConfig getOrDefault ["prc343PresetPolicy", "MISSING"], _acreConfig getOrDefault ["namedDisplays", false]], _acreEnabled && {count _acreConfig == 0}] call _status;
-    ["radio", "acre-authoritative-plan", if (!_acreEnabled) then {"DISABLED"} else {if (_planValid && {_groupCount > 0}) then {"LOADED"} else {"ERROR"}}, format ["schema=%1 revision=%2 sides=%3 groups=%4 diagnostics=%5", if (count _acrePlan > 0) then {_acrePlan select 0} else {-1}, _revision, count _sidePlans, _groupCount, if (_planValid) then {_acrePlan select 3} else {[]}], _acreEnabled && {!_planValid || {_groupCount == 0}}] call _status;
+    ["radio", "acre-config", if (!_acreEnabled) then {"DISABLED"} else {if (count _acreConfig == 0) then {"ERROR"} else {"LOADED"}}, format ["enabled=%1 strict=%2 presetPolicy=%3 namedDisplays=%4", _acreEnabled, _acreConfig getOrDefault ["strict", true], _acreConfig getOrDefault ["prc343PresetPolicy", "MISSING"], _acreConfig getOrDefault ["namedDisplays", false]], _acreEnabled && {count _acreConfig == 0}, if (!_acreEnabled || {count _acreConfig > 0}) then {""} else {"Waldo_ACRE2_Config is empty even though ACRE2 presetting is enabled - confirm MissionConfig\acreConfig.sqf actually defines a config and initServer.sqf calls Waldo_fnc_ACRE2Init."}] call _status;
+    ["radio", "acre-authoritative-plan", if (!_acreEnabled) then {"DISABLED"} else {if (_planValid && {_groupCount > 0}) then {"LOADED"} else {"ERROR"}}, format ["schema=%1 revision=%2 sides=%3 groups=%4 diagnostics=%5", if (count _acrePlan > 0) then {_acrePlan select 0} else {-1}, _revision, count _sidePlans, _groupCount, if (_planValid) then {_acrePlan select 3} else {[]}], _acreEnabled && {!_planValid || {_groupCount == 0}}, if (!_acreEnabled || {_planValid && {_groupCount > 0}}) then {""} else {"The server has not published a valid ACRE radio plan, or it has zero groups - check that MissionConfig\acreConfig.sqf's group callsigns match the Eden editor group IDs exactly (an @Callsign leader-role suffix is reconciled first)."}] call _status;
     private _babel = _acreConfig getOrDefault ["babel", createHashMap];
-    ["radio", "acre-babel", if !(_babel getOrDefault ["enabled", false]) then {"DISABLED"} else {if (count (_babel getOrDefault ["languages", []]) > 0) then {"LOADED"} else {"ERROR"}}, format ["enabled=%1 languages=%2", _babel getOrDefault ["enabled", false], count (_babel getOrDefault ["languages", []])], (_babel getOrDefault ["enabled", false]) && {count (_babel getOrDefault ["languages", []]) == 0}] call _status;
+    ["radio", "acre-babel", if !(_babel getOrDefault ["enabled", false]) then {"DISABLED"} else {if (count (_babel getOrDefault ["languages", []]) > 0) then {"LOADED"} else {"ERROR"}}, format ["enabled=%1 languages=%2", _babel getOrDefault ["enabled", false], count (_babel getOrDefault ["languages", []])], (_babel getOrDefault ["enabled", false]) && {count (_babel getOrDefault ["languages", []]) == 0}, if !((_babel getOrDefault ["enabled", false]) && {count (_babel getOrDefault ["languages", []]) == 0}) then {""} else {"Babel is enabled in MissionConfig\acreConfig.sqf but defines no languages - add at least one entry to its babel languages array."}] call _status;
 
     // Vehicle radio racks: a vehicle only appears here once Waldo_fnc_ACRE2RackSetup has actually
     // been called on it (no rack scan runs otherwise). "pending" covers both an in-progress bounded
@@ -307,7 +307,7 @@ if (count (keys _dropZoneRegistry) == 0) then {
 
 private _partyEnabled = missionNamespace getVariable ["Waldo_MiniGames_Enable", false];
 private _partyLoaded = missionNamespace getVariable ["Waldo_MG_SystemInitialized", false];
-["system", "party-games", if (_partyLoaded) then {"ACTIVE"} else {if (_partyEnabled) then {"ERROR"} else {"DISABLED"}}, format ["configured=%1 catalogue=%2", _partyEnabled, count (missionNamespace getVariable ["Waldo_MG_Games", []])], _partyEnabled && {!_partyLoaded}] call _status;
+["system", "party-games", if (_partyLoaded) then {"ACTIVE"} else {if (_partyEnabled) then {"ERROR"} else {"DISABLED"}}, format ["configured=%1 catalogue=%2", _partyEnabled, count (missionNamespace getVariable ["Waldo_MG_Games", []])], _partyEnabled && {!_partyLoaded}, if (!_partyEnabled || {_partyLoaded}) then {""} else {"Waldo_MiniGames_Enable is true but Waldo_fnc_MiniGamesInit never completed - confirm init.sqf actually calls it, and check the RPT for errors from the party-games engine install."}] call _status;
 
 private _jammingEnabled = missionNamespace getVariable ["Waldo_Jamming_Enable", false];
 private _tfarLoaded = isClass (configFile >> "CfgPatches" >> "task_force_radio") || {isClass (configFile >> "CfgPatches" >> "tfar_core")};
@@ -316,7 +316,7 @@ private _jammerCount = count (missionNamespace getVariable ["Waldo_Jamming_Regis
 private _jammingState = if (!_jammingEnabled) then {"DISABLED"} else {
     if (!_jammingUsable) then {"ERROR"} else {if (_jammerCount > 0) then {"ACTIVE"} else {"LOADED"}}
 };
-["system", "radio-jamming", _jammingState, format ["ACRE2=%1 TFAR=%2 registeredJammers=%3", _acreLoaded, _tfarLoaded, _jammerCount], _jammingEnabled && {!_jammingUsable}] call _status;
+["system", "radio-jamming", _jammingState, format ["ACRE2=%1 TFAR=%2 registeredJammers=%3", _acreLoaded, _tfarLoaded, _jammerCount], _jammingEnabled && {!_jammingUsable}, if (!_jammingEnabled || {_jammingUsable}) then {""} else {"Waldo_Jamming_Enable is true but neither ACRE2 nor TFAR is loaded, so jamming has no radio engine to act on - load one of those mods, or set Waldo_Jamming_Enable to false."}] call _status;
 
 private _markerCount = count (missionNamespace getVariable ["Waldo_3DMarker_Registry", []]);
 ["system", "custom-3d-markers", if (_markerCount > 0) then {"ACTIVE"} else {"LOADED"}, format ["%1 registered marker(s); client renderer state is reported by client audit", _markerCount], false] call _status;
@@ -355,13 +355,13 @@ private _virtualPackages = 0;
 {_attachedPackages = _attachedPackages + count ((_x getVariable ["Waldo_Recovery_AttachedPackages", []]) select {!isNull _x}); _virtualPackages = _virtualPackages + count ((_x getVariable ["Waldo_Recovery_VirtualPackages", []]) select {!isNull _x});} forEach _recoveryCarriers;
 private _recoveryConfigured = !(_recoveryWorkshops isEqualTo []) || {!(_recoveryVehicles isEqualTo [])};
 private _recoveryBroken = !(_recoveryPackages isEqualTo []) && {_recoveryWorkshops isEqualTo []};
-["logistics", "vehicle-recovery", if (!_recoveryConfigured) then {"UNCONFIGURED"} else {if (_recoveryBroken) then {"ERROR"} else {if (_recoveryPackages isEqualTo []) then {"LOADED"} else {"ACTIVE"}}}, format ["workshops=%1 vehicles=%2 carriers=%3 packages=%4 attached=%5 virtual=%6 monitor=%7", count _recoveryWorkshops, count _recoveryVehicles, count _recoveryCarriers, count _recoveryPackages, _attachedPackages, _virtualPackages, missionNamespace getVariable ["Waldo_Recovery_MonitorRunning", false]], _recoveryBroken] call _status;
+["logistics", "vehicle-recovery", if (!_recoveryConfigured) then {"UNCONFIGURED"} else {if (_recoveryBroken) then {"ERROR"} else {if (_recoveryPackages isEqualTo []) then {"LOADED"} else {"ACTIVE"}}}, format ["workshops=%1 vehicles=%2 carriers=%3 packages=%4 attached=%5 virtual=%6 monitor=%7", count _recoveryWorkshops, count _recoveryVehicles, count _recoveryCarriers, count _recoveryPackages, _attachedPackages, _virtualPackages, missionNamespace getVariable ["Waldo_Recovery_MonitorRunning", false]], _recoveryBroken, if (!_recoveryBroken) then {""} else {"Recovery packages exist but no workshop is registered - call Waldo_fnc_RecoveryRegisterWorkshop (or place the Vehicle Recovery Workshop composition) so recovered vehicles have somewhere to return to."}] call _status;
 
 private _tacticalDisplays = _missionObjects select {_x getVariable ["Waldo_TacticalDisplay_Registered", false]};
 ["interface", "tactical-displays", if (_tacticalDisplays isEqualTo []) then {"UNCONFIGURED"} else {"LOADED"}, format ["registered=%1", count _tacticalDisplays], false] call _status;
 private _hazardZones = missionNamespace getVariable ["Waldo_Hazard_Zones", []];
 private _hazardEnabled = missionNamespace getVariable ["Waldo_Hazard_Enable", false];
-["environment", "hazard-zones", if (!_hazardEnabled) then {"DISABLED"} else {if (_hazardZones isEqualTo []) then {"ERROR"} else {"ACTIVE"}}, format ["enabled=%1 zones=%2", _hazardEnabled, count _hazardZones], _hazardEnabled && {_hazardZones isEqualTo []}] call _status;
+["environment", "hazard-zones", if (!_hazardEnabled) then {"DISABLED"} else {if (_hazardZones isEqualTo []) then {"ERROR"} else {"ACTIVE"}}, format ["enabled=%1 zones=%2", _hazardEnabled, count _hazardZones], _hazardEnabled && {_hazardZones isEqualTo []}, if (!_hazardEnabled || {!(_hazardZones isEqualTo [])}) then {""} else {"Waldo_Hazard_Enable is true but no zone is registered - call Waldo_fnc_HazardRegisterZone/RegisterPresetZone/RegisterEmitter (or place a Hazard composition), or set Waldo_Hazard_Enable to false if this mission doesn't use hazards."}] call _status;
 private _transportEnabled = missionNamespace getVariable ["Waldo_TransportServices_Enable", false];
 private _transportServices = missionNamespace getVariable ["Waldo_Transport_Services", createHashMap];
 private _transportPools = missionNamespace getVariable ["Waldo_Transport_Pools", createHashMapFromArray [["HELICOPTER", []], ["GROUND", []], ["BOAT", []]]];
@@ -375,7 +375,7 @@ private _transportIssues = [];
     if !(_x in (_transportPools getOrDefault [_type, []])) then {_transportIssues pushBack format ["%1 is absent from its typed pool", _x]};
 } forEach keys _transportServices;
 private _transportBroken = !(_transportIssues isEqualTo []);
-["logistics", "transport-services", if (!_transportEnabled) then {"DISABLED"} else {if (_transportBroken) then {"ERROR"} else {if (count (keys _transportServices) == 0) then {"UNCONFIGURED"} else {"ACTIVE"}}}, format ["registered=%1 helicopters=%2 ground=%3 boats=%4 issues=%5", count (keys _transportServices), count (_transportPools getOrDefault ["HELICOPTER", []]), count (_transportPools getOrDefault ["GROUND", []]), count (_transportPools getOrDefault ["BOAT", []]), _transportIssues], _transportBroken] call _status;
+["logistics", "transport-services", if (!_transportEnabled) then {"DISABLED"} else {if (_transportBroken) then {"ERROR"} else {if (count (keys _transportServices) == 0) then {"UNCONFIGURED"} else {"ACTIVE"}}}, format ["registered=%1 helicopters=%2 ground=%3 boats=%4 issues=%5", count (keys _transportServices), count (_transportPools getOrDefault ["HELICOPTER", []]), count (_transportPools getOrDefault ["GROUND", []]), count (_transportPools getOrDefault ["BOAT", []]), _transportIssues], _transportBroken, if (!_transportBroken) then {""} else {"A registered transport service is inconsistent with its typed pool - this usually means something mutated Waldo_Transport_Services directly instead of going through Waldo_fnc_TransportRegister; re-register the affected vehicle(s) instead of editing the registry by hand."}] call _status;
 private _resupplyHubs = _missionObjects select {_x getVariable ["Waldo_FieldResupply_Hub", false]};
 // Waldo_FieldResupply_MaxCrates > 0 is the real "is this player an assigned carrier" predicate used
 // throughout the feature (Waldo_fnc_FieldResupplyServerHandle's own _isCarrier, Waldo_fnc_FieldResupplyInit's
@@ -391,7 +391,7 @@ private _resupplyCarriers = allPlayers select {(_x getVariable ["Waldo_FieldResu
     private _serverCount = count (keys _serverRegistry);
     private _publicCount = count _publicSystems;
     private _consistent = _serverCount == _publicCount;
-    ["runtime-system", _feature, if (_serverCount == 0) then {"UNCONFIGURED"} else {if (_consistent) then {"ACTIVE"} else {"ERROR"}}, format ["server=%1 publicJip=%2", _serverCount, _publicCount], !_consistent] call _status;
+    ["runtime-system", _feature, if (_serverCount == 0) then {"UNCONFIGURED"} else {if (_consistent) then {"ACTIVE"} else {"ERROR"}}, format ["server=%1 publicJip=%2", _serverCount, _publicCount], !_consistent, if (_consistent) then {""} else {format ["The %1 server registry and its broadcast JIP list have drifted apart, so a JIP client may not see every system - this usually means something mutated the registry directly instead of going through the feature's own create/destroy functions.", _feature]}] call _status;
 } forEach [
     // paradrop-drop-zones is intentionally not repeated here - the dedicated Paradrop section above
     // already reports Waldo_Paradrop_DropZones/PublicDropZones with a specific remediation hint.
@@ -403,14 +403,14 @@ private _resupplyCarriers = allPlayers select {(_x getVariable ["Waldo_FieldResu
 private _zenLoaded = isClass (configFile >> "CfgPatches" >> "zen_main");
 ["integration", "ACE and Zeus integration"] call _section;
 private _zenApi = !(isNil "zen_custom_modules_fnc_register");
-["integration", "zen-modules", if (!_zenLoaded) then {"UNAVAILABLE"} else {if (_zenApi) then {"LOADED"} else {"ERROR"}}, format ["ZEN loaded=%1 registration API=%2", _zenLoaded, _zenApi], _zenLoaded && {!_zenApi}] call _status;
-["integration", "ace-actions", if (isClass (configFile >> "CfgPatches" >> "ace_main")) then {"LOADED"} else {"ERROR"}, "Dependency state only; object action installation is checked by the client audit", !(isClass (configFile >> "CfgPatches" >> "ace_main"))] call _status;
+["integration", "zen-modules", if (!_zenLoaded) then {"UNAVAILABLE"} else {if (_zenApi) then {"LOADED"} else {"ERROR"}}, format ["ZEN loaded=%1 registration API=%2", _zenLoaded, _zenApi], _zenLoaded && {!_zenApi}, if (!_zenLoaded || {_zenApi}) then {""} else {"ZEN is loaded but zen_custom_modules_fnc_register is unavailable - this usually means Zeus Enhanced failed to fully initialise; check the RPT for ZEN errors or an incompatible ZEN version."}] call _status;
+["integration", "ace-actions", if (isClass (configFile >> "CfgPatches" >> "ace_main")) then {"LOADED"} else {"ERROR"}, "Dependency state only; object action installation is checked by the client audit", !(isClass (configFile >> "CfgPatches" >> "ace_main")), if (isClass (configFile >> "CfgPatches" >> "ace_main")) then {""} else {"ACE3 is required by WMP but is not loaded - see the ace_main dependency check above."}] call _status;
 
 ["optional-features", "Optional feature configuration"] call _section;
 private _persistenceEnabled = missionNamespace getVariable ["Waldo_Persistence_Enable", false];
 private _persistencePatches = missionNamespace getVariable ["Waldo_Persistence_PatchNames", ["inidbi2", "inidbi2_main", "inidbi2_core", "inidbi"]];
 private _persistenceRuntime = [] call Waldo_fnc_PersistenceDependencyAvailable;
-["optional-feature", "persistence-runtime", if (!_persistenceEnabled) then {"DISABLED"} else {if (_persistenceRuntime) then {"LOADED"} else {"ERROR"}}, format ["enabled=%1 runtimeDetected=%2", _persistenceEnabled, _persistenceRuntime], _persistenceEnabled && {!_persistenceRuntime}] call _status;
+["optional-feature", "persistence-runtime", if (!_persistenceEnabled) then {"DISABLED"} else {if (_persistenceRuntime) then {"LOADED"} else {"ERROR"}}, format ["enabled=%1 runtimeDetected=%2", _persistenceEnabled, _persistenceRuntime], _persistenceEnabled && {!_persistenceRuntime}, if (!_persistenceEnabled || {_persistenceRuntime}) then {""} else {"Waldo_Persistence_Enable is true but the server did not detect a loaded INIDBI2 extension - install/enable INIDBI2 on the server, or set Waldo_Persistence_Enable to false in MissionConfig\persistenceConfig.sqf if you don't need persistence."}] call _status;
 
 private _breachingEnabled = missionNamespace getVariable ["Waldo_Breaching_Enable", false];
 private _breachingDependency = isClass (configFile >> "CfgPatches" >> "ace_explosives");
@@ -461,22 +461,22 @@ private _breachingProfileCount = count (keys _breachingProfiles);
 private _breachingValid = _breachingDependency && {_breachingProfileCount > 0} && {_breachingIssues isEqualTo []};
 private _breachingDetail = format ["enabled=%1 aceExplosives=%2 profiles=%3", _breachingEnabled, _breachingDependency, _breachingProfileCount];
 if !(_breachingIssues isEqualTo []) then {_breachingDetail = _breachingDetail + "; " + (_breachingIssues joinString "; ")};
-["optional-feature", "explosive-breaching", if (!_breachingEnabled) then {"DISABLED"} else {if (_breachingValid) then {"LOADED"} else {"ERROR"}}, _breachingDetail, _breachingEnabled && {!_breachingValid}] call _status;
+["optional-feature", "explosive-breaching", if (!_breachingEnabled) then {"DISABLED"} else {if (_breachingValid) then {"LOADED"} else {"ERROR"}}, _breachingDetail, _breachingEnabled && {!_breachingValid}, if (!_breachingEnabled || {_breachingValid}) then {""} else {"Fix the listed issue(s) in Waldo_Breaching_Profiles / Waldo_Breaching_ExplosiveStrengths (usually set from MissionConfig or a ZEN Breaching module), or confirm ace_explosives is loaded."}] call _status;
 
 private _treatmentEnabled = missionNamespace getVariable ["Waldo_TreatmentFeedback_Enable", false];
 private _treatmentDependency = isClass (configFile >> "CfgPatches" >> "ace_medical");
-["optional-feature", "treatment-feedback", if (!_treatmentEnabled) then {"DISABLED"} else {if (_treatmentDependency) then {"LOADED"} else {"ERROR"}}, format ["enabled=%1 aceMedical=%2", _treatmentEnabled, _treatmentDependency], _treatmentEnabled && {!_treatmentDependency}] call _status;
+["optional-feature", "treatment-feedback", if (!_treatmentEnabled) then {"DISABLED"} else {if (_treatmentDependency) then {"LOADED"} else {"ERROR"}}, format ["enabled=%1 aceMedical=%2", _treatmentEnabled, _treatmentDependency], _treatmentEnabled && {!_treatmentDependency}, if (!_treatmentEnabled || {_treatmentDependency}) then {""} else {"Waldo_TreatmentFeedback_Enable is true but ace_medical is not loaded - load ACE medical, or set Waldo_TreatmentFeedback_Enable to false."}] call _status;
 
 private _resupplyEnabled = missionNamespace getVariable ["Waldo_FieldResupply_Enable", false];
 private _resupplyClass = missionNamespace getVariable ["Waldo_FieldResupply_CrateClass", "Box_NATO_Ammo_F"];
 private _resupplyValid = isClass (configFile >> "CfgVehicles" >> _resupplyClass);
-["optional-feature", "field-resupply", if (!_resupplyEnabled) then {"DISABLED"} else {if (_resupplyValid) then {"LOADED"} else {"ERROR"}}, format ["enabled=%1 crateClass=%2", _resupplyEnabled, _resupplyClass], _resupplyEnabled && {!_resupplyValid}] call _status;
+["optional-feature", "field-resupply", if (!_resupplyEnabled) then {"DISABLED"} else {if (_resupplyValid) then {"LOADED"} else {"ERROR"}}, format ["enabled=%1 crateClass=%2", _resupplyEnabled, _resupplyClass], _resupplyEnabled && {!_resupplyValid}, if (!_resupplyEnabled || {_resupplyValid}) then {""} else {"Waldo_FieldResupply_CrateClass does not resolve to a real CfgVehicles class - fix it in MissionConfig\logisticsConfig.sqf, or leave it unset to use the default Box_NATO_Ammo_F."}] call _status;
 
 private _rallyEnabled = missionNamespace getVariable ["Waldo_Rally_Enable", false];
 private _rallyClass = missionNamespace getVariable ["Waldo_Rally_ObjectClass", "Land_SatelliteAntenna_01_F"];
 private _rallyClassValid = isClass (configFile >> "CfgVehicles" >> _rallyClass);
 private _activeRallies = {_x getVariable ["Waldo_Rally_Active", false]} count allGroups;
-["optional-feature", "squad-rally-points", if (!_rallyEnabled) then {"DISABLED"} else {if (!_rallyClassValid) then {"ERROR"} else {if (_activeRallies > 0) then {"ACTIVE"} else {"LOADED"}}}, format ["enabled=%1 objectClass=%2 activeGroups=%3", _rallyEnabled, _rallyClass, _activeRallies], _rallyEnabled && {!_rallyClassValid}] call _status;
+["optional-feature", "squad-rally-points", if (!_rallyEnabled) then {"DISABLED"} else {if (!_rallyClassValid) then {"ERROR"} else {if (_activeRallies > 0) then {"ACTIVE"} else {"LOADED"}}}, format ["enabled=%1 objectClass=%2 activeGroups=%3", _rallyEnabled, _rallyClass, _activeRallies], _rallyEnabled && {!_rallyClassValid}, if (!_rallyEnabled || {_rallyClassValid}) then {""} else {"Waldo_Rally_ObjectClass does not resolve to a real CfgVehicles class - fix it wherever Rally Points was configured (RALLY_CONFIG via Feature Runtime Control, or MissionConfig), or leave it unset to use the default Land_SatelliteAntenna_01_F."}] call _status;
 
 private _gunshipEnabled = missionNamespace getVariable ["Waldo_Gunship_Enable", false];
 private _gunshipAltitude = missionNamespace getVariable ["Waldo_Gunship_DefaultAltitude", 700];
@@ -486,12 +486,12 @@ private _invalidGunshipClasses = [];
 private _gunshipPools = missionNamespace getVariable ["Waldo_Gunship_SideAircraftPools", createHashMap];
 {{if !(isClass (configFile >> "CfgVehicles" >> _x) && {_x isKindOf "Air"}) then {_invalidGunshipClasses pushBackUnique _x;};} forEach (_gunshipPools get _x);} forEach keys _gunshipPools;
 private _gunshipValid = _gunshipBoundsValid && {_invalidGunshipClasses isEqualTo []};
-["optional-feature", "airborne-gunship", if (!_gunshipEnabled) then {"DISABLED"} else {if (_gunshipValid) then {"LOADED"} else {"ERROR"}}, format ["enabled=%1 altitude=%2 radius=%3 invalidClasses=%4", _gunshipEnabled, _gunshipAltitude, _gunshipRadius, _invalidGunshipClasses], _gunshipEnabled && {!_gunshipValid}] call _status;
+["optional-feature", "airborne-gunship", if (!_gunshipEnabled) then {"DISABLED"} else {if (_gunshipValid) then {"LOADED"} else {"ERROR"}}, format ["enabled=%1 altitude=%2 radius=%3 invalidClasses=%4", _gunshipEnabled, _gunshipAltitude, _gunshipRadius, _invalidGunshipClasses], _gunshipEnabled && {!_gunshipValid}, if (!_gunshipEnabled || {_gunshipValid}) then {""} else {"Check that Waldo_Gunship_DefaultAltitude/Radius sit within Waldo_Gunship_MaximumAltitude/Radius, and that every class listed in Waldo_Gunship_SideAircraftPools is a real Air-kind CfgVehicles class."}] call _status;
 
 {
     private _aaPool = [createHashMap, _x] call Waldo_fnc_DynamicAAResolveAssetPool;
     private _emptyCategories = ["radarClasses", "staticSitePools", "mobileClasses", "fighterClasses"] select {count (_aaPool getOrDefault [_x, []]) == 0};
-    ["optional-feature", format ["dynamic-aa-%1", _x], if (_emptyCategories isEqualTo []) then {"LOADED"} else {"ERROR"}, format ["source=%1 emptyCategories=%2", _aaPool getOrDefault ["source", str _x], _emptyCategories], !(_emptyCategories isEqualTo [])] call _status;
+    ["optional-feature", format ["dynamic-aa-%1", _x], if (_emptyCategories isEqualTo []) then {"LOADED"} else {"ERROR"}, format ["source=%1 emptyCategories=%2", _aaPool getOrDefault ["source", str _x], _emptyCategories], !(_emptyCategories isEqualTo []), if (_emptyCategories isEqualTo []) then {""} else {format ["Waldo_fnc_DynamicAAResolveAssetPool found no %1 for this side - add classes to that side's Dynamic AA asset pool in MissionConfig\airOperationsConfig.sqf, or load the mod that provides them.", _emptyCategories joinString ", "]}] call _status;
 } forEach [west, east, independent];
 
 private _treeEnabled = missionNamespace getVariable ["Waldo_TreeFelling_Enable", false];
@@ -543,12 +543,12 @@ if !(_treeEfficiencies isEqualType createHashMap) then {
 private _treeValid = _treeIssues isEqualTo [];
 private _treeDetail = format ["enabled=%1 patterns=%2 direction=%3", _treeEnabled, _treePatterns, _treeDirection];
 if (!_treeValid) then {_treeDetail = _treeDetail + "; " + (_treeIssues joinString "; ")};
-["optional-feature", "tree-felling", if (!_treeEnabled) then {"DISABLED"} else {if (_treeValid) then {"LOADED"} else {"ERROR"}}, _treeDetail, _treeEnabled && {!_treeValid}] call _status;
+["optional-feature", "tree-felling", if (!_treeEnabled) then {"DISABLED"} else {if (_treeValid) then {"LOADED"} else {"ERROR"}}, _treeDetail, _treeEnabled && {!_treeValid}, if (!_treeEnabled || {_treeValid}) then {""} else {"Fix the listed configuration issue(s) in the Tree Felling settings (Waldo_TreeFelling_* variables, usually set via the Feature Runtime Control TREE_CONFIG bridge or MissionConfig)."}] call _status;
 
 private _corpseTrapEnabled = missionNamespace getVariable ["Waldo_CorpseTraps_Enable", false];
 private _corpseTrapDependency = isClass (configFile >> "CfgPatches" >> "ace_interact_menu");
 private _corpseTrapRigged = _missionObjects select {(_x getVariable ["Waldo_CorpseTrap_State", ""]) != ""};
-["optional-feature", "corpse-traps", if (!_corpseTrapEnabled) then {"DISABLED"} else {if (!_corpseTrapDependency) then {"ERROR"} else {if (count _corpseTrapRigged > 0) then {"ACTIVE"} else {"LOADED"}}}, format ["enabled=%1 aceInteractMenu=%2 rigged=%3", _corpseTrapEnabled, _corpseTrapDependency, count _corpseTrapRigged], _corpseTrapEnabled && {!_corpseTrapDependency}] call _status;
+["optional-feature", "corpse-traps", if (!_corpseTrapEnabled) then {"DISABLED"} else {if (!_corpseTrapDependency) then {"ERROR"} else {if (count _corpseTrapRigged > 0) then {"ACTIVE"} else {"LOADED"}}}, format ["enabled=%1 aceInteractMenu=%2 rigged=%3", _corpseTrapEnabled, _corpseTrapDependency, count _corpseTrapRigged], _corpseTrapEnabled && {!_corpseTrapDependency}, if (!_corpseTrapEnabled || {_corpseTrapDependency}) then {""} else {"Waldo_CorpseTraps_Enable is true but ace_interact_menu is not loaded - load ACE interaction menu, or set Waldo_CorpseTraps_Enable to false in MissionConfig\missionSystemsConfig.sqf."}] call _status;
 
 // Ask every interface client for local UI, mod and action state. The server retains authority over
 // the final report and accepts a response only from its claimed network owner.

--- a/MissionScripts/MissionFlowAndUi/runDiagnostics.sqf
+++ b/MissionScripts/MissionFlowAndUi/runDiagnostics.sqf
@@ -72,19 +72,25 @@ private _consumeFeatureReport = {
     ["mission-flow", "aar-endex-api", "Waldo_fnc_ENDEX"],
     ["mission-flow", "objectives-api", "Waldo_fnc_CreateObjective"],
     ["world-ui", "custom-3d-marker-api", "Waldo_fnc_Create3DMarker"],
+    ["interface", "ui-theme-api", "Waldo_fnc_UiTheme"],
+    ["interface", "accessibility-api", "Waldo_fnc_AccessibilitySelfInteractionInit"],
     ["logistics", "mhq-api", "Waldo_fnc_MHQSetup"],
     ["logistics", "vvd-api", "Waldo_fnc_VVDInit"],
+    ["object-transforms", "object-scaling-api", "Waldo_fnc_ObjectScale"],
+    ["runtime-control", "feature-runtime-api", "Waldo_fnc_FeatureRuntimeApply"],
     ["electronic-warfare", "jammer-api", "Waldo_fnc_Jammer"],
     ["electronic-warfare", "emp-api", "Waldo_fnc_EMP"],
     ["electronic-warfare", "tracker-api", "Waldo_fnc_Tracker"],
     ["party-games", "party-table-api", "Waldo_fnc_MiniGamesInit"],
     ["interactions", "equipment-api", "Waldo_fnc_MiniGameInteractionSetup"],
     ["economy", "economy-api", "Waldo_fnc_EcoInit"],
+    ["medical", "obituary-api", "Waldo_fnc_ObituaryPronounce"],
     ["mission-flow", "safestart-diagnostics-api", "Waldo_fnc_SafeStartGetDiagnostics"],
     ["mission-flow", "endex-diagnostics-api", "Waldo_fnc_ENDEXGetDiagnostics"],
     ["interactions", "equipment-diagnostics-api", "Waldo_fnc_MiniGameInteractionGetDiagnostics"],
     ["economy", "economy-diagnostics-api", "Waldo_fnc_EcoCore_getDiagnostics"],
-    ["headless", "headless-diagnostics-api", "Waldo_fnc_HeadlessGetDiagnostics"]
+    ["headless", "headless-diagnostics-api", "Waldo_fnc_HeadlessGetDiagnostics"],
+    ["medical", "obituary-diagnostics-api", "Waldo_fnc_ObituaryGetDiagnostics"]
 ];
 
 // Required and optional dependencies are deliberately distinct. Optional
@@ -101,6 +107,14 @@ private _consumeFeatureReport = {
     ["acre_main", "ACRE2", false],
     ["task_force_radio", "TFAR", false]
 ];
+
+// The ordered runtime-feature snapshot (Waldo_fnc_FeatureRuntimeRequestState/ReceiveState) is the
+// handshake JIP and headless clients use before activating locality-sensitive optional features
+// (Obituary, Emergency Dismount, Treatment Feedback, Rally Points, Tree Felling, Persistence, ...)
+// against the server's actual current settings instead of local defaults. If initServer.sqf never
+// published readiness, every one of those client-side installers is stuck waiting indefinitely.
+private _runtimeControlReady = missionNamespace getVariable ["Waldo_FeatureRuntimeStateReady", false];
+["runtime-control", "runtime-control-authority", if (_runtimeControlReady) then {"ACTIVE"} else {"ERROR"}, format ["ready=%1", _runtimeControlReady], !_runtimeControlReady, if (_runtimeControlReady) then {""} else {"initServer.sqf did not publish Waldo_FeatureRuntimeStateReady - JIP and headless clients cannot request the authoritative runtime snapshot, so locality-sensitive optional features gated on it will never activate for them."}] call _status;
 
 // Loadout scan: do not wait forever when the subsystem was not loaded.
 ["logistics", "Loadouts and configured logistics classes"] call _section;
@@ -289,6 +303,7 @@ if (count (keys _dropZoneRegistry) == 0) then {
 [call Waldo_fnc_ENDEXGetDiagnostics] call _consumeFeatureReport;
 [call Waldo_fnc_MiniGameInteractionGetDiagnostics] call _consumeFeatureReport;
 [call Waldo_fnc_HeadlessGetDiagnostics] call _consumeFeatureReport;
+[call Waldo_fnc_ObituaryGetDiagnostics] call _consumeFeatureReport;
 
 private _partyEnabled = missionNamespace getVariable ["Waldo_MiniGames_Enable", false];
 private _partyLoaded = missionNamespace getVariable ["Waldo_MG_SystemInitialized", false];
@@ -315,6 +330,15 @@ private _deployedMhqs = {_x getVariable ["Waldo_MHQ_Status", false]} count _mhqO
 ["logistics", "mhq-runtime", if (_mhqObjects isEqualTo []) then {"UNCONFIGURED"} else {if (_deployedMhqs > 0) then {"ACTIVE"} else {"LOADED"}}, format ["configured=%1 deployed=%2", count _mhqObjects, _deployedMhqs], false] call _status;
 private _vvdPads = _missionObjects select {_x getVariable ["Waldo_VVD_ServerConfigured", false]};
 ["logistics", "vvd-runtime", if (_vvdPads isEqualTo []) then {"UNCONFIGURED"} else {"LOADED"}, format ["configuredSpawnPads=%1", count _vvdPads], false] call _status;
+
+// Object scaling is callable and server-validated with no background initializer of its own, so
+// there is no "enabled" state to report - only whether the configured bounds are sane and how many
+// objects in the mission currently carry a non-default scale.
+private _scaleMinimum = missionNamespace getVariable ["Waldo_ObjectScaling_Minimum", 0.1];
+private _scaleMaximum = missionNamespace getVariable ["Waldo_ObjectScaling_Maximum", 10];
+private _scaleBoundsValid = _scaleMinimum > 0 && {_scaleMaximum > _scaleMinimum};
+private _scaledObjects = _missionObjects select {!isNil {_x getVariable "Waldo_ObjectScale"}};
+["object-transforms", "object-scaling", if (!_scaleBoundsValid) then {"ERROR"} else {if (count _scaledObjects > 0) then {"ACTIVE"} else {"LOADED"}}, format ["min=%1 max=%2 allowClientRequests=%3 scaledObjects=%4", _scaleMinimum, _scaleMaximum, missionNamespace getVariable ["Waldo_ObjectScaling_AllowClientRequests", false], count _scaledObjects], !_scaleBoundsValid, if (_scaleBoundsValid) then {""} else {"Waldo_ObjectScaling_Minimum must be greater than 0 and lower than Waldo_ObjectScaling_Maximum."}] call _status;
 private _aceMedicalLoaded = isClass (configFile >> "CfgPatches" >> "ace_medical");
 private _fieldHospitals = _missionObjects select {_x getVariable ["ace_medical_isMedicalFacility", false]};
 if (_fieldHospitals isEqualTo []) then {
@@ -520,6 +544,11 @@ private _treeValid = _treeIssues isEqualTo [];
 private _treeDetail = format ["enabled=%1 patterns=%2 direction=%3", _treeEnabled, _treePatterns, _treeDirection];
 if (!_treeValid) then {_treeDetail = _treeDetail + "; " + (_treeIssues joinString "; ")};
 ["optional-feature", "tree-felling", if (!_treeEnabled) then {"DISABLED"} else {if (_treeValid) then {"LOADED"} else {"ERROR"}}, _treeDetail, _treeEnabled && {!_treeValid}] call _status;
+
+private _corpseTrapEnabled = missionNamespace getVariable ["Waldo_CorpseTraps_Enable", false];
+private _corpseTrapDependency = isClass (configFile >> "CfgPatches" >> "ace_interact_menu");
+private _corpseTrapRigged = _missionObjects select {(_x getVariable ["Waldo_CorpseTrap_State", ""]) != ""};
+["optional-feature", "corpse-traps", if (!_corpseTrapEnabled) then {"DISABLED"} else {if (!_corpseTrapDependency) then {"ERROR"} else {if (count _corpseTrapRigged > 0) then {"ACTIVE"} else {"LOADED"}}}, format ["enabled=%1 aceInteractMenu=%2 rigged=%3", _corpseTrapEnabled, _corpseTrapDependency, count _corpseTrapRigged], _corpseTrapEnabled && {!_corpseTrapDependency}] call _status;
 
 // Ask every interface client for local UI, mod and action state. The server retains authority over
 // the final report and accepts a response only from its claimed network owner.

--- a/MissionScripts/MissionFlowAndUi/runDiagnosticsClient.sqf
+++ b/MissionScripts/MissionFlowAndUi/runDiagnosticsClient.sqf
@@ -22,10 +22,15 @@ params [["_runId", "", [""]]];
 if (_runId isEqualTo "") exitWith {false};
 
 private _checks = [];
+// _hint mirrors Waldo_fnc_RunDiagnostics' server-side _status helper: an optional, plain-language
+// remediation step folded into the same detail text via the shared Waldo_fnc_DiagnosticFoldHint, so
+// a client-local failure is just as assistive as a server one instead of only carrying a terse
+// state=/detail= pair.
 private _add = {
-    params ["_area", "_feature", "_state", ["_detail", ""]];
-    _checks pushBack [_area, _feature, _state, _detail];
-    [_area, _feature, if (_state == "ERROR") then {"ERROR"} else {"INFO"}, "CHECK", format ["state=%1 detail=%2", _state, _detail], _runId, format ["CLIENT:%1", clientOwner]] call Waldo_fnc_DiagnosticLog;
+    params ["_area", "_feature", "_state", ["_detail", ""], ["_hint", ""]];
+    private _fullDetail = [_detail, _hint] call Waldo_fnc_DiagnosticFoldHint;
+    _checks pushBack [_area, _feature, _state, _fullDetail];
+    [_area, _feature, if (_state == "ERROR") then {"ERROR"} else {"INFO"}, "CHECK", format ["state=%1 detail=%2", _state, _fullDetail], _runId, format ["CLIENT:%1", clientOwner]] call Waldo_fnc_DiagnosticLog;
 };
 private _consumeFeatureReport = {
     params ["_featureReport"];
@@ -40,7 +45,7 @@ private _consumeFeatureReport = {
 {
     _x params ["_patch", "_label", "_required"];
     private _loaded = isClass (configFile >> "CfgPatches" >> _patch);
-    ["dependencies", _label, if (_loaded) then {"LOADED"} else {if (_required) then {"ERROR"} else {"UNAVAILABLE"}}, format ["required=%1 patch=%2", _required, _patch]] call _add;
+    ["dependencies", _label, if (_loaded) then {"LOADED"} else {if (_required) then {"ERROR"} else {"UNAVAILABLE"}}, format ["required=%1 patch=%2", _required, _patch], if (_loaded || {!_required}) then {""} else {format ["%1 is required by WMP but is not loaded on this client - add it to this client's mod list.", _label]}] call _add;
 } forEach [
     ["cba_main", "CBA_A3", true],
     ["ace_main", "ACE3", true],
@@ -51,7 +56,7 @@ private _consumeFeatureReport = {
 
 private _runtimeSnapshotReceived = missionNamespace getVariable ["Waldo_FeatureRuntimeSnapshotReceived", false];
 private _runtimeSnapshotFailed = missionNamespace getVariable ["Waldo_FeatureRuntimeSnapshotFailed", false];
-["runtime-control", "runtime-control-snapshot", if (_runtimeSnapshotReceived) then {"ACTIVE"} else {if (_runtimeSnapshotFailed) then {"ERROR"} else {"LOADED"}}, format ["received=%1 failed=%2 requestInFlight=%3", _runtimeSnapshotReceived, _runtimeSnapshotFailed, missionNamespace getVariable ["Waldo_FeatureRuntimeRequestInFlight", false]]] call _add;
+["runtime-control", "runtime-control-snapshot", if (_runtimeSnapshotReceived) then {"ACTIVE"} else {if (_runtimeSnapshotFailed) then {"ERROR"} else {"LOADED"}}, format ["received=%1 failed=%2 requestInFlight=%3", _runtimeSnapshotReceived, _runtimeSnapshotFailed, missionNamespace getVariable ["Waldo_FeatureRuntimeRequestInFlight", false]], if (!_runtimeSnapshotFailed) then {""} else {"This client did not receive the authoritative runtime snapshot after repeated attempts - check this client's connection, and check the server RPT for [WMP RUNTIME] entries."}] call _add;
 
 // Waldo_fnc_FeatureRuntimeReceiveState calls UiThemeApplyLocal on every machine as part of the
 // runtime snapshot handshake, so Waldo_UI_ResolvedTheme should already match the authoritative
@@ -61,7 +66,7 @@ private _themeId = toUpperANSI (missionNamespace getVariable ["Waldo_UI_Theme", 
 private _resolvedTheme = uiNamespace getVariable ["Waldo_UI_ResolvedTheme", createHashMap];
 private _themeAppliedId = toUpperANSI (_resolvedTheme getOrDefault ["id", ""]);
 private _themeState = if (_themeAppliedId == "") then {if (_runtimeSnapshotReceived) then {"ERROR"} else {"LOADED"}} else {if (_themeAppliedId == _themeId) then {"LOADED"} else {"ERROR"}};
-["interface", "ui-theme", _themeState, format ["theme=%1 locallyApplied=%2 revision=%3", _themeId, if (_themeAppliedId == "") then {"NONE"} else {_themeAppliedId}, missionNamespace getVariable ["Waldo_UI_ThemeRevision", 0]]] call _add;
+["interface", "ui-theme", _themeState, format ["theme=%1 locallyApplied=%2 revision=%3", _themeId, if (_themeAppliedId == "") then {"NONE"} else {_themeAppliedId}, missionNamespace getVariable ["Waldo_UI_ThemeRevision", 0]], if (_themeState != "ERROR") then {""} else {"This client's applied theme does not match the authoritative Waldo_UI_Theme - reopen a WMP display or rejoin; if it persists, check the RPT for errors from Waldo_fnc_UiThemeApplyLocal."}] call _add;
 
 [call Waldo_fnc_SafeStartGetDiagnostics] call _consumeFeatureReport;
 [call Waldo_fnc_ENDEXGetDiagnostics] call _consumeFeatureReport;
@@ -108,7 +113,18 @@ if (_acreEnabled) then {
             }
         }
     }};
-    ["radio", "acre-player-presetting", _state, format ["finding=%1 rawGroup='%2' normalized=%3 side=%4 planRevision=%5 sideMatch=%6 groupMatch=%7 inventoryRadios=%8 currentRadios=%9 unique=%10 acreReady=%11 edenRadioSetup=%12 loadoutGeneration=%13 restoredGeneration=%14 lastApplication=%15 readinessFailure=%16", _plainFinding, _rawGroup, _groupKey, _sideKey, if (_planValid) then {_plan select 1} else {-1}, _sideIndex >= 0, _groupIndex >= 0, _inventoryRadios, _radios, count _unique, _acreApiReady, _edenRadioSetup, missionNamespace getVariable ["Waldo_ACRE2_LoadoutGeneration", -1], missionNamespace getVariable ["Waldo_ACRE2_RestoredRadioGeneration", -1], _last, missionNamespace getVariable ["Waldo_ACRE2_LastReadinessFailure", []]]] call _add;
+    private _presetHint = if (_state != "ERROR") then {""} else {
+        if !(_configValidation select 0) then {"Fix the listed acreConfig.sqf validation error(s)."} else {
+            if (!_planValid) then {"Confirm initServer.sqf calls Waldo_fnc_ACRE2Init and that MissionConfig\acreConfig.sqf is well-formed."} else {
+                if (_sideIndex < 0) then {"Add a matching side block for this player's side to MissionConfig\acreConfig.sqf."} else {
+                    if (_groupIndex < 0) then {format ["Add group '%1' to MissionConfig\acreConfig.sqf, or fix its callsign so it matches the Eden editor group ID exactly.", _rawGroup]} else {
+                        "ACRE has not finished converting radios to unique IDs, or the last apply attempt failed - check readinessFailure/lastApplication above and the RPT for [WMP ACRE] entries."
+                    }
+                }
+            }
+        }
+    };
+    ["radio", "acre-player-presetting", _state, format ["finding=%1 rawGroup='%2' normalized=%3 side=%4 planRevision=%5 sideMatch=%6 groupMatch=%7 inventoryRadios=%8 currentRadios=%9 unique=%10 acreReady=%11 edenRadioSetup=%12 loadoutGeneration=%13 restoredGeneration=%14 lastApplication=%15 readinessFailure=%16", _plainFinding, _rawGroup, _groupKey, _sideKey, if (_planValid) then {_plan select 1} else {-1}, _sideIndex >= 0, _groupIndex >= 0, _inventoryRadios, _radios, count _unique, _acreApiReady, _edenRadioSetup, missionNamespace getVariable ["Waldo_ACRE2_LoadoutGeneration", -1], missionNamespace getVariable ["Waldo_ACRE2_RestoredRadioGeneration", -1], _last, missionNamespace getVariable ["Waldo_ACRE2_LastReadinessFailure", []]], _presetHint] call _add;
     if !(_edenRadioSetup isEqualTo "") then {
         ["radio", "acre-eden-radio-attribute", "ERROR", format ["This unit has an Eden ACRE Radio Setup attribute (%1). It can overwrite acreConfig.sqf during startup. Clear that unit attribute and let WMP own the initial assignment.", _edenRadioSetup]] call _add;
     } else {
@@ -134,7 +150,14 @@ private _jamClientState = if (!_jamEnabled) then {"DISABLED"} else {
         }
     }
 };
-["electronic-warfare", "jamming-client", _jamClientState, format ["factor=%1 registry=%2 loop=%3 uiReady=%4 hud=%5", _jamFactor, count (missionNamespace getVariable ["Waldo_Jamming_Registry", []]), _jamLoopRunning, _jamUiReady, !isNull _jamCtrl && {ctrlShown _jamCtrl}]] call _add;
+private _jamHint = if (_jamClientState != "ERROR") then {""} else {
+    if (!_jamLoopRunning) then {
+        "Waldo_fnc_JammingInit did not start on this client - check the RPT for jamming-related errors during initPlayerLocal.sqf."
+    } else {
+        "The jamming HUD panel (IDC 5310) failed to show while this player is inside a jammer field - try the ACE self-action 'Clear Stuck WMP UI' (Waldo_fnc_ClearUiPanels)."
+    }
+};
+["electronic-warfare", "jamming-client", _jamClientState, format ["factor=%1 registry=%2 loop=%3 uiReady=%4 hud=%5", _jamFactor, count (missionNamespace getVariable ["Waldo_Jamming_Registry", []]), _jamLoopRunning, _jamUiReady, !isNull _jamCtrl && {ctrlShown _jamCtrl}], _jamHint] call _add;
 
 private _jumpCapableClasses = ["RHS_Mi24_base", "RHS_Mi8_base", "Heli_Transport_02_base_F", "RHS_C130J_Base", "B_T_VTOL_01_infantry_F"];
 private _jumpAircraft = (allMissionObjects "Air") select {
@@ -176,13 +199,13 @@ if (_jumpAircraft isEqualTo []) then {
     ["paradrop", "jump-actions-local", _jumpState, format [
         "aircraft=%1 ready=%2 pending=%3 missingExpectedActions=%4",
         count _jumpAircraft, (count _jumpAircraft) - _pendingJumpCount, _pendingJumpCount, _missingJumpCount
-    ]] call _add;
+    ], if (_missingJumpCount == 0) then {""} else {"An aircraft finished local jump setup but is still missing an expected static-line/HALO hold-action on this client - check the RPT for [WMP PARADROP] entries, and confirm the jump envelope thresholds (WALDO_STATIC_MIN/MAXALTITUDE, WALDO_STATIC_MAXSPEED, WALDO_PARA_HALOALTITUDE) aren't excluding both jump types."}] call _add;
 };
 
 private _zenLoaded = isClass (configFile >> "CfgPatches" >> "zen_main");
-["zeus", "core-modules", if (!_zenLoaded) then {"UNAVAILABLE"} else {if ((missionNamespace getVariable ["Waldo_ZenModuleCount", 0]) == 45) then {"LOADED"} else {"ERROR"}}, format ["registered=%1 expected=45", missionNamespace getVariable ["Waldo_ZenModuleCount", 0]]] call _add;
+["zeus", "core-modules", if (!_zenLoaded) then {"UNAVAILABLE"} else {if ((missionNamespace getVariable ["Waldo_ZenModuleCount", 0]) == 45) then {"LOADED"} else {"ERROR"}}, format ["registered=%1 expected=45", missionNamespace getVariable ["Waldo_ZenModuleCount", 0]], if (!_zenLoaded || {(missionNamespace getVariable ["Waldo_ZenModuleCount", 0]) == 45}) then {""} else {"Zeus Enhanced module registration count does not match the expected 45 - check the RPT for ZEN registration errors from Waldo_fnc_ZenInitModules, or confirm this client's WMP copy matches the server's."}] call _add;
 private _economyActive = missionNamespace getVariable ["WaldoEcoCore_ModuleActive", false];
-["zeus", "economy-modules", if (!_economyActive) then {"DISABLED"} else {if ((missionNamespace getVariable ["WaldoEcoCore_ZenModuleCount", 0]) == 19) then {"LOADED"} else {"ERROR"}}, format ["registered=%1 expected=19", missionNamespace getVariable ["WaldoEcoCore_ZenModuleCount", 0]]] call _add;
+["zeus", "economy-modules", if (!_economyActive) then {"DISABLED"} else {if ((missionNamespace getVariable ["WaldoEcoCore_ZenModuleCount", 0]) == 19) then {"LOADED"} else {"ERROR"}}, format ["registered=%1 expected=19", missionNamespace getVariable ["WaldoEcoCore_ZenModuleCount", 0]], if (!_economyActive || {(missionNamespace getVariable ["WaldoEcoCore_ZenModuleCount", 0]) == 19}) then {""} else {"Waldos Economy Systems is active but its 19 ZEN modules did not fully register - check the RPT for errors from Waldo_fnc_EcoCore_registerZenModules."}] call _add;
 
 private _markerHandler = missionNamespace getVariable ["Waldo_3DMarker_DrawHandler", -1];
 ["world-ui", "custom-3d-markers", if (_markerHandler >= 0) then {"LOADED"} else {"UNAVAILABLE"}, format ["drawHandler=%1 markers=%2", _markerHandler, count (missionNamespace getVariable ["Waldo_3DMarker_Registry", []])]] call _add;
@@ -194,32 +217,32 @@ private _aceInteractLoaded = isClass (configFile >> "CfgPatches" >> "ace_interac
 private _localObjects = allMissionObjects "All";
 private _tacticalDisplays = _localObjects select {_x getVariable ["Waldo_TacticalDisplay_Registered", false]};
 private _missingTacticalActions = _tacticalDisplays select {(_x getVariable ["Waldo_TacticalDisplay_LocalAction", -1]) < 0};
-["interface", "tactical-display-actions", if (_tacticalDisplays isEqualTo []) then {"UNCONFIGURED"} else {if (_missingTacticalActions isEqualTo []) then {"LOADED"} else {"ERROR"}}, format ["registered=%1 missingLocalAction=%2", count _tacticalDisplays, count _missingTacticalActions]] call _add;
+["interface", "tactical-display-actions", if (_tacticalDisplays isEqualTo []) then {"UNCONFIGURED"} else {if (_missingTacticalActions isEqualTo []) then {"LOADED"} else {"ERROR"}}, format ["registered=%1 missingLocalAction=%2", count _tacticalDisplays, count _missingTacticalActions], if (_missingTacticalActions isEqualTo []) then {""} else {"A registered Tactical Display is missing its local action on this client - reconnect, or check the RPT for errors from Waldo_fnc_TacticalDisplayRegister."}] call _add;
 private _hazardEnabled = missionNamespace getVariable ["Waldo_Hazard_Enable", false];
 private _hazardZones = missionNamespace getVariable ["Waldo_Hazard_Zones", []];
 private _hazardClient = missionNamespace getVariable ["Waldo_Hazard_ClientStarted", false];
 private _hazardEvaluation = missionNamespace getVariable ["Waldo_Hazard_LastEvaluation", []];
 private _hazardFresh = count _hazardEvaluation >= 3 && {(diag_tickTime - (_hazardEvaluation select 0)) <= ((missionNamespace getVariable ["Waldo_Hazard_Interval", 1]) max 0.25) * 3};
-["environment", "hazard-client", if (!_hazardEnabled) then {"DISABLED"} else {if (_hazardClient && {!(_hazardZones isEqualTo [])} && {_hazardFresh}) then {"ACTIVE"} else {"ERROR"}}, format ["enabled=%1 zones=%2 snapshot=%3 evaluator=%4 freshEvaluation=%5 lastEvaluation=%6", _hazardEnabled, count _hazardZones, missionNamespace getVariable ["Waldo_Hazard_SnapshotReceived", false], _hazardClient, _hazardFresh, _hazardEvaluation]] call _add;
+["environment", "hazard-client", if (!_hazardEnabled) then {"DISABLED"} else {if (_hazardClient && {!(_hazardZones isEqualTo [])} && {_hazardFresh}) then {"ACTIVE"} else {"ERROR"}}, format ["enabled=%1 zones=%2 snapshot=%3 evaluator=%4 freshEvaluation=%5 lastEvaluation=%6", _hazardEnabled, count _hazardZones, missionNamespace getVariable ["Waldo_Hazard_SnapshotReceived", false], _hazardClient, _hazardFresh, _hazardEvaluation], if (!_hazardEnabled || {_hazardClient && {!(_hazardZones isEqualTo [])} && {_hazardFresh}}) then {""} else {"Waldo_Hazard_Enable is true but this client's evaluator loop isn't producing fresh evaluations - check the RPT for hazard-related errors, and confirm the server actually published a zone snapshot."}] call _add;
 private _dismountEnabled = missionNamespace getVariable ["Waldo_EmergencyDismount_Enable", false];
 private _dismountStarted = missionNamespace getVariable ["Waldo_EmergencyDismount_ClientStarted", false];
 private _dismountHandle = missionNamespace getVariable ["Waldo_EmergencyDismount_ClientLoop", scriptNull];
 private _dismountRunning = _dismountStarted && {!(scriptDone _dismountHandle)};
-["interface", "emergency-dismount-client", if (!_dismountEnabled) then {"DISABLED"} else {if (_dismountRunning) then {"LOADED"} else {"ERROR"}}, format ["enabled=%1 started=%2 loopRunning=%3 interval=%4", _dismountEnabled, _dismountStarted, !(scriptDone _dismountHandle), missionNamespace getVariable ["Waldo_EmergencyDismount_Interval", 0.5]]] call _add;
+["interface", "emergency-dismount-client", if (!_dismountEnabled) then {"DISABLED"} else {if (_dismountRunning) then {"LOADED"} else {"ERROR"}}, format ["enabled=%1 started=%2 loopRunning=%3 interval=%4", _dismountEnabled, _dismountStarted, !(scriptDone _dismountHandle), missionNamespace getVariable ["Waldo_EmergencyDismount_Interval", 0.5]], if (!_dismountEnabled || {_dismountRunning}) then {""} else {"Waldo_EmergencyDismount_Enable is true but the local monitor loop isn't running - check the RPT for errors from Waldo_fnc_EmergencyDismountInit, or confirm the Feature Runtime Control snapshot actually reached this client."}] call _add;
 
 private _accessibilityInstalled = player getVariable ["Waldo_Accessibility_SelfInteractionInstalled", false];
 private _accessibilityMode = player getVariable ["Waldo_Accessibility_InteractionMode", ""];
 private _colourVisionId = profileNamespace getVariable ["Waldo_UI_ColourVisionProfile", "STANDARD"];
 private _colourVisionResolved = ([_colourVisionId] call Waldo_fnc_UiColourVisionProfile) getOrDefault ["id", "STANDARD"];
-["interface", "accessibility-self-interaction", if (_accessibilityInstalled) then {"LOADED"} else {"ERROR"}, format ["installed=%1 mode=%2 colourVisionProfile=%3", _accessibilityInstalled, _accessibilityMode, toUpperANSI _colourVisionResolved]] call _add;
+["interface", "accessibility-self-interaction", if (_accessibilityInstalled) then {"LOADED"} else {"ERROR"}, format ["installed=%1 mode=%2 colourVisionProfile=%3", _accessibilityInstalled, _accessibilityMode, toUpperANSI _colourVisionResolved], if (_accessibilityInstalled) then {""} else {"The Accessibility self-interaction menu failed to install on this client - check the RPT for errors from Waldo_fnc_AccessibilitySelfInteractionInit."}] call _add;
 
 private _hudEnabled = missionNamespace getVariable ["Waldo_WmpHud_Enable", false];
 private _hudEligible = if (_hudEnabled) then {[player] call Waldo_fnc_WmpHudEligible} else {false};
 private _hudStarted = missionNamespace getVariable ["Waldo_WmpHud_ClientStarted", false];
-["interface", "wmp-hud", if (!_hudEnabled) then {"DISABLED"} else {if (!_hudEligible) then {"UNCONFIGURED"} else {if (_hudStarted) then {"ACTIVE"} else {"ERROR"}}}, format ["enabled=%1 eligible=%2 clientStarted=%3 visible=%4", _hudEnabled, _hudEligible, _hudStarted, missionNamespace getVariable ["Waldo_WmpHud_Visible", false]]] call _add;
+["interface", "wmp-hud", if (!_hudEnabled) then {"DISABLED"} else {if (!_hudEligible) then {"UNCONFIGURED"} else {if (_hudStarted) then {"ACTIVE"} else {"ERROR"}}}, format ["enabled=%1 eligible=%2 clientStarted=%3 visible=%4", _hudEnabled, _hudEligible, _hudStarted, missionNamespace getVariable ["Waldo_WmpHud_Visible", false]], if (!_hudEnabled || {!_hudEligible} || {_hudStarted}) then {""} else {"Waldo_WmpHud_Enable is true and this player is eligible, but the HUD client loop never started - check the RPT for errors from Waldo_fnc_WmpHudInit."}] call _add;
 private _transportInstalled = player getVariable ["Waldo_Transport_InteractionsInstalled", false];
 private _transportAvailable = missionNamespace getVariable ["Waldo_HeliTransport_Available", false] || {missionNamespace getVariable ["Waldo_GroundTransport_Available", false]};
-["logistics", "transport-client-actions", if (!_transportAvailable) then {"UNCONFIGURED"} else {if (_transportInstalled) then {"LOADED"} else {"ERROR"}}, format ["available=%1 interactionsInstalled=%2", _transportAvailable, _transportInstalled]] call _add;
+["logistics", "transport-client-actions", if (!_transportAvailable) then {"UNCONFIGURED"} else {if (_transportInstalled) then {"LOADED"} else {"ERROR"}}, format ["available=%1 interactionsInstalled=%2", _transportAvailable, _transportInstalled], if (!_transportAvailable || {_transportInstalled}) then {""} else {"A transport service is available but this client's interaction menu wasn't installed - reconnect, or check the RPT for errors from the Transport Services client setup."}] call _add;
 private _mhqObjects = _localObjects select {_x getVariable ["Waldo_MHQ_ServerConfigured", false]};
 if (_mhqObjects isEqualTo []) then {
     ["logistics", "mhq-actions", "UNCONFIGURED", "No configured MHQ is present"] call _add;
@@ -232,7 +255,7 @@ if (_mhqObjects isEqualTo []) then {
             !(_x getVariable ["Waldo_MHQ_VanillaActionsInstalled", false])
         }}
     }) < 0;
-    ["logistics", "mhq-actions", if (_mhqValid) then {"LOADED"} else {"ERROR"}, format ["objects=%1 expectedMode=%2", count _mhqObjects, if (_aceInteractLoaded) then {"ACE"} else {"VANILLA"}]] call _add;
+    ["logistics", "mhq-actions", if (_mhqValid) then {"LOADED"} else {"ERROR"}, format ["objects=%1 expectedMode=%2", count _mhqObjects, if (_aceInteractLoaded) then {"ACE"} else {"VANILLA"}], if (_mhqValid) then {""} else {"A configured MHQ is missing its expected local action on this client - check the RPT for errors from Waldo_fnc_MHQSetupLocal, and confirm ACE Interact Menu is loaded if expectedMode=ACE."}] call _add;
 };
 
 private _vvdTerminals = _localObjects select {_x getVariable ["Waldo_VVD_TerminalConfigured", false]};
@@ -247,12 +270,12 @@ if (_vvdTerminals isEqualTo []) then {
             !(_x getVariable ["Waldo_VVD_VanillaActionsInstalled", false])
         }}
     }) < 0;
-    ["logistics", "vvd-actions", if (_vvdValid) then {"LOADED"} else {"ERROR"}, format ["terminals=%1 expectedMode=%2", count _vvdTerminals, if (_aceInteractLoaded) then {"ACE"} else {"VANILLA"}]] call _add;
+    ["logistics", "vvd-actions", if (_vvdValid) then {"LOADED"} else {"ERROR"}, format ["terminals=%1 expectedMode=%2", count _vvdTerminals, if (_aceInteractLoaded) then {"ACE"} else {"VANILLA"}], if (_vvdValid) then {""} else {"A configured VVD terminal is missing its expected local action on this client - check the RPT for errors from the VVD local setup, and confirm ACE Interact Menu is loaded if expectedMode=ACE."}] call _add;
 };
 
 private _corpseTrapEnabled = missionNamespace getVariable ["Waldo_CorpseTraps_Enable", false];
 private _corpseTrapInstalled = missionNamespace getVariable ["Waldo_CorpseTrap_Installed", false];
-["interactions", "corpse-trap-actions", if (!_corpseTrapEnabled) then {"DISABLED"} else {if (!_aceInteractLoaded) then {"UNAVAILABLE"} else {if (_corpseTrapInstalled) then {"LOADED"} else {"ERROR"}}}, format ["enabled=%1 aceInteractMenu=%2 installed=%3", _corpseTrapEnabled, _aceInteractLoaded, _corpseTrapInstalled]] call _add;
+["interactions", "corpse-trap-actions", if (!_corpseTrapEnabled) then {"DISABLED"} else {if (!_aceInteractLoaded) then {"UNAVAILABLE"} else {if (_corpseTrapInstalled) then {"LOADED"} else {"ERROR"}}}, format ["enabled=%1 aceInteractMenu=%2 installed=%3", _corpseTrapEnabled, _aceInteractLoaded, _corpseTrapInstalled], if (!_corpseTrapEnabled || {!_aceInteractLoaded} || {_corpseTrapInstalled}) then {""} else {"Waldo_CorpseTraps_Enable is true and ACE Interact Menu is loaded, but the 'Rig Corpse' action failed to install on this client - check the RPT for [WMP CORPSE TRAPS] entries."}] call _add;
 
 private _fieldHospitals = _localObjects select {_x getVariable ["ace_medical_isMedicalFacility", false]};
 if (_fieldHospitals isEqualTo []) then {
@@ -266,7 +289,7 @@ if (_fieldHospitals isEqualTo []) then {
         (_x getVariable ["Waldo_FieldHospital_VanillaActionId", -1]) < 0
         || {_aceInteractLoaded && {(_x getVariable ["Waldo_FieldHospital_AceActionPath", []]) isEqualTo []}}
     };
-    ["logistics", "field-hospital-actions", if (_fieldHospitalsMissingAction isEqualTo []) then {"LOADED"} else {"ERROR"}, format ["crates=%1 missingAction=%2 expectedMode=%3", count _fieldHospitals, count _fieldHospitalsMissingAction, if (_aceInteractLoaded) then {"ACE+VANILLA"} else {"VANILLA"}]] call _add;
+    ["logistics", "field-hospital-actions", if (_fieldHospitalsMissingAction isEqualTo []) then {"LOADED"} else {"ERROR"}, format ["crates=%1 missingAction=%2 expectedMode=%3", count _fieldHospitals, count _fieldHospitalsMissingAction, if (_aceInteractLoaded) then {"ACE+VANILLA"} else {"VANILLA"}], if (_fieldHospitalsMissingAction isEqualTo []) then {""} else {"A field hospital crate is missing its expected action on this client - check the RPT for errors from Waldo_fnc_MedicalCrateFacilityActionLocal."}] call _add;
 };
 
 private _warnings = {_x select 2 == "ERROR"} count _checks;

--- a/MissionScripts/MissionFlowAndUi/runDiagnosticsClient.sqf
+++ b/MissionScripts/MissionFlowAndUi/runDiagnosticsClient.sqf
@@ -49,9 +49,24 @@ private _consumeFeatureReport = {
     ["task_force_radio", "TFAR", false]
 ];
 
+private _runtimeSnapshotReceived = missionNamespace getVariable ["Waldo_FeatureRuntimeSnapshotReceived", false];
+private _runtimeSnapshotFailed = missionNamespace getVariable ["Waldo_FeatureRuntimeSnapshotFailed", false];
+["runtime-control", "runtime-control-snapshot", if (_runtimeSnapshotReceived) then {"ACTIVE"} else {if (_runtimeSnapshotFailed) then {"ERROR"} else {"LOADED"}}, format ["received=%1 failed=%2 requestInFlight=%3", _runtimeSnapshotReceived, _runtimeSnapshotFailed, missionNamespace getVariable ["Waldo_FeatureRuntimeRequestInFlight", false]]] call _add;
+
+// Waldo_fnc_FeatureRuntimeReceiveState calls UiThemeApplyLocal on every machine as part of the
+// runtime snapshot handshake, so Waldo_UI_ResolvedTheme should already match the authoritative
+// Waldo_UI_Theme by the time that snapshot has arrived. Before it arrives, no local application has
+// been attempted yet, which is expected and not an error.
+private _themeId = toUpperANSI (missionNamespace getVariable ["Waldo_UI_Theme", "DEFAULT"]);
+private _resolvedTheme = uiNamespace getVariable ["Waldo_UI_ResolvedTheme", createHashMap];
+private _themeAppliedId = toUpperANSI (_resolvedTheme getOrDefault ["id", ""]);
+private _themeState = if (_themeAppliedId == "") then {if (_runtimeSnapshotReceived) then {"ERROR"} else {"LOADED"}} else {if (_themeAppliedId == _themeId) then {"LOADED"} else {"ERROR"}};
+["interface", "ui-theme", _themeState, format ["theme=%1 locallyApplied=%2 revision=%3", _themeId, if (_themeAppliedId == "") then {"NONE"} else {_themeAppliedId}, missionNamespace getVariable ["Waldo_UI_ThemeRevision", 0]]] call _add;
+
 [call Waldo_fnc_SafeStartGetDiagnostics] call _consumeFeatureReport;
 [call Waldo_fnc_ENDEXGetDiagnostics] call _consumeFeatureReport;
 [call Waldo_fnc_EcoCore_getDiagnostics] call _consumeFeatureReport;
+[call Waldo_fnc_ObituaryGetDiagnostics] call _consumeFeatureReport;
 
 private _acreLoaded = isClass (configFile >> "CfgPatches" >> "acre_main");
 private _acreConfig = missionNamespace getVariable ["Waldo_ACRE2_Config", createHashMap];
@@ -186,6 +201,18 @@ private _hazardClient = missionNamespace getVariable ["Waldo_Hazard_ClientStarte
 private _hazardEvaluation = missionNamespace getVariable ["Waldo_Hazard_LastEvaluation", []];
 private _hazardFresh = count _hazardEvaluation >= 3 && {(diag_tickTime - (_hazardEvaluation select 0)) <= ((missionNamespace getVariable ["Waldo_Hazard_Interval", 1]) max 0.25) * 3};
 ["environment", "hazard-client", if (!_hazardEnabled) then {"DISABLED"} else {if (_hazardClient && {!(_hazardZones isEqualTo [])} && {_hazardFresh}) then {"ACTIVE"} else {"ERROR"}}, format ["enabled=%1 zones=%2 snapshot=%3 evaluator=%4 freshEvaluation=%5 lastEvaluation=%6", _hazardEnabled, count _hazardZones, missionNamespace getVariable ["Waldo_Hazard_SnapshotReceived", false], _hazardClient, _hazardFresh, _hazardEvaluation]] call _add;
+private _dismountEnabled = missionNamespace getVariable ["Waldo_EmergencyDismount_Enable", false];
+private _dismountStarted = missionNamespace getVariable ["Waldo_EmergencyDismount_ClientStarted", false];
+private _dismountHandle = missionNamespace getVariable ["Waldo_EmergencyDismount_ClientLoop", scriptNull];
+private _dismountRunning = _dismountStarted && {!(scriptDone _dismountHandle)};
+["interface", "emergency-dismount-client", if (!_dismountEnabled) then {"DISABLED"} else {if (_dismountRunning) then {"LOADED"} else {"ERROR"}}, format ["enabled=%1 started=%2 loopRunning=%3 interval=%4", _dismountEnabled, _dismountStarted, !(scriptDone _dismountHandle), missionNamespace getVariable ["Waldo_EmergencyDismount_Interval", 0.5]]] call _add;
+
+private _accessibilityInstalled = player getVariable ["Waldo_Accessibility_SelfInteractionInstalled", false];
+private _accessibilityMode = player getVariable ["Waldo_Accessibility_InteractionMode", ""];
+private _colourVisionId = profileNamespace getVariable ["Waldo_UI_ColourVisionProfile", "STANDARD"];
+private _colourVisionResolved = ([_colourVisionId] call Waldo_fnc_UiColourVisionProfile) getOrDefault ["id", "STANDARD"];
+["interface", "accessibility-self-interaction", if (_accessibilityInstalled) then {"LOADED"} else {"ERROR"}, format ["installed=%1 mode=%2 colourVisionProfile=%3", _accessibilityInstalled, _accessibilityMode, toUpperANSI _colourVisionResolved]] call _add;
+
 private _hudEnabled = missionNamespace getVariable ["Waldo_WmpHud_Enable", false];
 private _hudEligible = if (_hudEnabled) then {[player] call Waldo_fnc_WmpHudEligible} else {false};
 private _hudStarted = missionNamespace getVariable ["Waldo_WmpHud_ClientStarted", false];
@@ -222,6 +249,10 @@ if (_vvdTerminals isEqualTo []) then {
     }) < 0;
     ["logistics", "vvd-actions", if (_vvdValid) then {"LOADED"} else {"ERROR"}, format ["terminals=%1 expectedMode=%2", count _vvdTerminals, if (_aceInteractLoaded) then {"ACE"} else {"VANILLA"}]] call _add;
 };
+
+private _corpseTrapEnabled = missionNamespace getVariable ["Waldo_CorpseTraps_Enable", false];
+private _corpseTrapInstalled = missionNamespace getVariable ["Waldo_CorpseTrap_Installed", false];
+["interactions", "corpse-trap-actions", if (!_corpseTrapEnabled) then {"DISABLED"} else {if (!_aceInteractLoaded) then {"UNAVAILABLE"} else {if (_corpseTrapInstalled) then {"LOADED"} else {"ERROR"}}}, format ["enabled=%1 aceInteractMenu=%2 installed=%3", _corpseTrapEnabled, _aceInteractLoaded, _corpseTrapInstalled]] call _add;
 
 private _fieldHospitals = _localObjects select {_x getVariable ["ace_medical_isMedicalFacility", false]};
 if (_fieldHospitals isEqualTo []) then {

--- a/MissionScripts/MissionFlowAndUi/safeStartGetDiagnostics.sqf
+++ b/MissionScripts/MissionFlowAndUi/safeStartGetDiagnostics.sqf
@@ -11,7 +11,9 @@ if (hasInterface) then {
     private _loop = missionNamespace getVariable ["Waldo_SafeStart_LoopRunning", false];
     private _protectionPresent = !isNil "Waldo_SafeStart_FiredEH" && {!(isDamageAllowed player)};
     private _clientOk = !_active || {_loop && {_protectionPresent}};
-    _checks pushBack ["mission-flow", "safestart-client-protection", if (!_clientOk) then {"ERROR"} else {if (_active) then {"ACTIVE"} else {"LOADED"}}, format ["loop=%1 firedHandler=%2 damageAllowed=%3", _loop, !isNil "Waldo_SafeStart_FiredEH", isDamageAllowed player]];
+    private _detail = format ["loop=%1 firedHandler=%2 damageAllowed=%3", _loop, !isNil "Waldo_SafeStart_FiredEH", isDamageAllowed player];
+    if !(_clientOk) then {_detail = [_detail, "SafeStart is active but this client's protection loop or Fired handler isn't installed - check the RPT for errors from Waldo_fnc_SafeStartApply, or rejoin."] call Waldo_fnc_DiagnosticFoldHint;};
+    _checks pushBack ["mission-flow", "safestart-client-protection", if (!_clientOk) then {"ERROR"} else {if (_active) then {"ACTIVE"} else {"LOADED"}}, _detail];
     _checks pushBack ["world-ui", "safestart-hud", if (!_active) then {"LOADED"} else {if (!isNull _hud && {ctrlShown _hud}) then {"ACTIVE"} else {"ERROR"}}, format ["display46=%1 control=%2 shown=%3", !isNull (findDisplay 46), !isNull _hud, !isNull _hud && {ctrlShown _hud}]];
 };
 

--- a/MissionScripts/WaldosFunctions.sqf
+++ b/MissionScripts/WaldosFunctions.sqf
@@ -724,6 +724,7 @@ class CfgFunctions
             class ObituaryPronounce {file = "MissionScripts\MedicalSystems\Obituary\obituaryPronounce.sqf";};
             class ObituaryDiaryRenderLocal {file = "MissionScripts\MedicalSystems\Obituary\obituaryDiaryRenderLocal.sqf";};
             class ObituaryPad2 {file = "MissionScripts\MedicalSystems\Obituary\obituaryPad2.sqf";};
+            class ObituaryGetDiagnostics {file = "MissionScripts\MedicalSystems\Obituary\obituaryGetDiagnostics.sqf";};
         };
         class FieldResupply
         {

--- a/MissionScripts/WaldosFunctions.sqf
+++ b/MissionScripts/WaldosFunctions.sqf
@@ -289,6 +289,9 @@ class CfgFunctions
             class DiagnosticFeatureReport {
                 file = "MissionScripts\MissionFlowAndUi\diagnosticFeatureReport.sqf";
             };
+            class DiagnosticFoldHint {
+                file = "MissionScripts\MissionFlowAndUi\diagnosticFoldHint.sqf";
+            };
             class RunDiagnostics {
                 file = "MissionScripts\MissionFlowAndUi\runDiagnostics.sqf";
             };

--- a/wiki/Mission-Diagnostics.md
+++ b/wiki/Mission-Diagnostics.md
@@ -47,16 +47,19 @@ Each check reports one of these states in its message:
 
 The server report checks:
 
-- representative public APIs from mission flow, logistics, world UI, electronic warfare, party games, interaction equipment, and the economy;
+- representative public APIs from mission flow, logistics, world UI, electronic warfare, party games, interaction equipment, the economy, headless-client support, object scaling and the feature runtime control bridge;
 - required and optional mod patches;
 - mission loadout scraping and playable-side results;
 - configured crate, parachute, and paradrop values;
 - ACRE2 configuration, authoritative plan schema/revision, group counts and Babel readiness;
-- Economy, party-game, interaction-procedure, jamming, SafeStart, AAR/ENDEX, and custom 3D-marker state;
+- Economy, party-game, interaction-procedure, jamming, SafeStart, AAR/ENDEX, Obituary, headless-client, and custom 3D-marker state;
 - configured MHQ, VVD and Field Hospital equipment;
 - recovery workshops, carriers, attached/virtual package state, Field Resupply hubs/carriers and Tactical Displays;
 - Hazard evaluator/audio state, typed helicopter/ground transport registries, and server/JIP registry parity for Dynamic AA, Dynamic AO and gunships;
 - Paradrop, in its own dedicated section: static-line/HALO altitude and chute-class thresholds, how many auto-detected jump-capable aircraft in the mission carry a server-visible static/HALO hold-action versus neither, the split between `Waldo_fnc_AddVehicleFunctions` auto-detection and a mission maker's own explicit setup call, and Dynamic Drop Zone registry/JIP parity;
+- the Feature Runtime Control snapshot handshake (`Waldo_FeatureRuntimeStateReady`) that JIP and headless clients depend on before activating locality-sensitive optional features;
+- Object Scaling's configured min/max bounds and how many mission objects currently carry a non-default scale;
+- Corpse Traps' `Waldo_CorpseTraps_Enable` state, its ACE Interact dependency, and how many corpses in the mission are currently rigged;
 - ACE and Zeus integration availability.
 
 Each interface client reports:
@@ -67,8 +70,12 @@ Each interface client reports:
 - jamming factor, registry, client loop, and HUD;
 - core and Economy Zeus module registration counts;
 - the custom 3D-marker renderer;
-- ACE or vanilla interaction installation on registered audit fixtures.
-- Tactical Display actions, WMP HUD eligibility/runtime state, transport actions, Field Hospital action installation and Hazard snapshot/evaluator state.
+- ACE or vanilla interaction installation on registered audit fixtures;
+- Tactical Display actions, WMP HUD eligibility/runtime state, transport actions, Field Hospital action installation and Hazard snapshot/evaluator state;
+- whether the Feature Runtime Control snapshot has arrived on this machine, and whether the locally applied UI Theme matches the authoritative one it carries;
+- the Accessibility self-interaction menu's install mode (ACE/vanilla) and this player's resolved colour-vision profile;
+- the Emergency Dismount monitor loop and, when Corpse Traps is enabled, whether this client actually installed the "Rig Corpse" interaction;
+- Obituary's medic-only "Pronounce Dead" action install state and its local diary render loop.
 
 The server rejects stale reports and reports whose claimed owner does not match the sending client. Missing client responses become warnings after four seconds.
 
@@ -121,9 +128,20 @@ private _safeStart = [] call Waldo_fnc_SafeStartGetDiagnostics;
 private _endex = [] call Waldo_fnc_ENDEXGetDiagnostics;
 private _economy = [] call Waldo_fnc_EcoCore_getDiagnostics;
 private _equipment = [] call Waldo_fnc_MiniGameInteractionGetDiagnostics;
+private _headless = [] call Waldo_fnc_HeadlessGetDiagnostics;
+private _obituary = [] call Waldo_fnc_ObituaryGetDiagnostics;
 ```
 
 Each returns `[featureName, checks]`; every check is `[area, feature, state, detail]`. The interaction helper optionally accepts an array of configured equipment objects. `RunDiagnostics` consumes these same helpers, preventing its interpretation from drifting away from the feature's own health report.
+
+A feature small enough to be a single config flag (Corpse Traps, Object Scaling, Emergency
+Dismount's client loop, the Feature Runtime Control snapshot, UI Theme, Accessibility) does not need
+its own `*GetDiagnostics.sqf` - it adds one inline `[area, feature, state, detail]` row directly in
+`runDiagnostics.sqf` (server) or `runDiagnosticsClient.sqf` (interface client), through the same
+`_status`/`_add` helper every other row in that script already uses. Either shape ends up going
+through `Waldo_fnc_DiagnosticLog`'s frame, so a new module's rows read exactly like every other
+module's - the `area`/`feature` values are the only thing that should ever identify which module a
+line belongs to.
 
 ## Structured result
 

--- a/wiki/Mission-Diagnostics.md
+++ b/wiki/Mission-Diagnostics.md
@@ -81,13 +81,37 @@ The server rejects stale reports and reports whose claimed owner does not match 
 
 ## Assistive hints
 
-A check that fails or is unexpectedly unconfigured can carry a short, plain-language remediation
-hint alongside its terse `state=`/`detail=` pair - not just *that* something is wrong, but *what to
-go and change*. A hint is folded into the same `detail` text as `"; fix: <hint>"`, so it reaches
-every existing consumer (RPT, `Waldo_Diagnostics_LastReport`, the hosted-server `systemChat` line)
-without changing the `[area, feature, state, detail]` report shape. For example, an invalid
-`WALDO_STATIC_STATICCHUTE` pointing at the RHS-only default without RHS loaded reports the exact
-variable to change and the vanilla fallback class to use, instead of just "class not found".
+Every check that reports `ERROR` - across the server report, every interface client's report, and
+every feature's own `*GetDiagnostics.sqf` - carries a short, plain-language remediation hint
+alongside its terse `state=`/`detail=` pair: not just *that* something is wrong, but *what to go and
+change*. This is systematic, not opt-in: a check that reports "the ACE dependency this optional
+feature needs isn't loaded," "this client failed to install its local action," or "this registry and
+its JIP mirror have drifted apart" always names the actual variable, function, or file to look at
+next, aimed at a mission maker new to the pack rather than someone who already knows WMP's internals.
+`DISABLED` and `UNCONFIGURED` states are not failures and never carry a hint - only a genuine `ERROR`
+(or the rare `UNAVAILABLE` that reflects a real misconfiguration) does.
+
+A hint is folded into the same `detail` text as `"; fix: <hint>"` by the shared
+`Waldo_fnc_DiagnosticFoldHint` helper, so it reaches every existing consumer (RPT,
+`Waldo_Diagnostics_LastReport`, the hosted-server `systemChat` line) without changing the
+`[area, feature, state, detail]` report shape, and reads identically no matter which of the three
+call sites folded it in:
+
+```sqf
+// A check built directly in runDiagnostics.sqf (server) or runDiagnosticsClient.sqf (client) passes
+// the hint as the helper's own trailing argument:
+[_category, _name, _state, _detail, _warn, _hint] call _status;   // runDiagnostics.sqf
+[_area, _feature, _state, _detail, _hint] call _add;              // runDiagnosticsClient.sqf
+
+// A feature's own *GetDiagnostics.sqf builds its check rows directly, so it folds the hint into its
+// own detail string before pushing the row:
+if (!_valid) then {_detail = [_detail, "Set Waldo_Example_Class to a real CfgVehicles class."] call Waldo_fnc_DiagnosticFoldHint;};
+_checks pushBack ["area", "feature", _state, _detail];
+```
+
+For example, an invalid `WALDO_STATIC_STATICCHUTE` pointing at the RHS-only default without RHS
+loaded reports the exact variable to change and the vanilla fallback class to use, instead of just
+"class not found."
 
 ## Enabling diagnostics
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add `Waldo_fnc_ObituaryGetDiagnostics`, a feature report covering the Obituary ledger/dependency state (server) and the medic "Pronounce Dead" action + diary render loop install state (client), registered in `WaldosFunctions.sqf` and consumed by both `Waldo_fnc_RunDiagnostics` and `Waldo_fnc_RunDiagnosticsClient` — Obituary previously had zero diagnostics coverage.
- Add an inline `optional-feature` row for Corpse Traps (`Waldo_CorpseTraps_Enable`, ACE Interact dependency, rigged-corpse count) in `runDiagnostics.sqf`, plus a client-local row reporting whether the "Rig Corpse" interaction actually installed.
- Add an inline row for Object Scaling (configured min/max bounds validity, count of currently-scaled objects), matching the existing MHQ/VVD-runtime style.
- Add `runtime-control-authority` (server) and `runtime-control-snapshot` (client) rows for the Feature Runtime Control JIP/headless snapshot handshake that Obituary, Emergency Dismount, Treatment Feedback, Rally Points, Tree Felling and Persistence all depend on before activating — a stuck handshake previously had no diagnostic signal of its own.
- Add client-local rows for UI Theme application (locally-applied theme vs. the authoritative one), the Accessibility self-interaction menu (install mode + resolved colour-vision profile), and the Emergency Dismount monitor loop.
- Add `-api` availability rows for `Waldo_fnc_UiTheme`, `Waldo_fnc_AccessibilitySelfInteractionInit`, `Waldo_fnc_ObjectScale` and `Waldo_fnc_FeatureRuntimeApply` to the existing "Public API availability" section.
- Every new row goes through the same `Waldo_fnc_DiagnosticLog` / `Waldo_fnc_DiagnosticFeatureReport` primitives and `[area, feature, state, detail]` shape every existing diagnostic row already uses, so RPT output stays one consistent `[WMP DIAG]` frame with module/feature identifiers rather than a bespoke per-feature format.
- Include documentation to the standard upheld in existing files: update `CLAUDE.md`'s Mission Diagnostics section (coverage list + a short note on the shared row-formatting convention for future additions), `wiki/Mission-Diagnostics.md` (coverage bullets + feature diagnostic helpers example list), and the Claude Mission Config Skill's `references/diagnostics.md`.

Validated locally with `sqf_validator.py`, `config_style_checker.py`, `performance_audit.py` (+ its unit tests), and `zeus_script_parity_checker.py` — all pass with no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DjtixB91nhBkFpVi6wAXB6)_