### PR TITLE
Fix 3D marker vertical offset (getPosASL/ATLToASL)

### DIFF
--- a/MissionScripts/MissionFlowAndUi/init3DMarkers.sqf
+++ b/MissionScripts/MissionFlowAndUi/init3DMarkers.sqf
@@ -11,9 +11,9 @@ private _handler = addMissionEventHandler ["Draw3D", {
         ];
         if (_enabled) then {
             private _position = if (_anchor isEqualType objNull) then {
-                if (isNull _anchor) then {[]} else {(visiblePositionASL _anchor) vectorAdd _offset}
+                if (isNull _anchor) then {[]} else {(getPosASL _anchor) vectorAdd _offset}
             } else {
-                AGLToASL ((_anchor select [0, 3]) vectorAdd _offset)
+                ATLToASL ((_anchor select [0, 3]) vectorAdd _offset)
             };
             private _sideNames = _sides apply {if (_x isEqualType "") then {toUpper _x} else {toUpper str _x}};
             private _sideVisible = "ALL" in _sideNames || {_playerSide in _sideNames};


### PR DESCRIPTION
**When merged this pull request will:**
- Fix `Waldo_fnc_Create3DMarker`'s Draw3D renderer resolving object anchors with `visiblePositionASL` instead of `getPosASL` — `visiblePositionASL` can diverge sharply from an object's actual position on objects whose model.cfg defines a visual offset, producing large, object/terrain-dependent vertical offsets (reported as ~50m on Spearhead's Normandy).
- Fix the array-anchor branch resolving positions with `AGLToASL` instead of `ATLToASL` — `AGLToASL` treats the input height as relative to whatever surface (e.g. a rooftop) sits under the point rather than the terrain height, which doesn't match the function's own "ATL position" contract.
- Both anchor kinds now resolve consistently with the `getPosASL` convention used everywhere else in the codebase, and with the documented "object or ATL position" anchor contract in `wiki/Custom-3D-World-Markers.md`.

No behavior changes for the common case (flat terrain, ordinary objects) — this only affects positioning on objects/terrains where the previous calls diverged from plain ASL/ATL terrain-relative coordinates.

Validated locally:
- `python3 releaseVerificationAndDeployment/sqf_validator.py` — passed
- `python3 releaseVerificationAndDeployment/config_style_checker.py` — passed

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FVJq5LZe533APWNfgruAMm)_