### PR TITLE
Fix silent respawn-restore drop on transient non-locality

### DIFF
--- a/MissionScripts/Logistics/LogiHelpers/respawnRestoreLoadout.sqf
+++ b/MissionScripts/Logistics/LogiHelpers/respawnRestoreLoadout.sqf
@@ -21,8 +21,29 @@
  * CBA_fnc_addPlayerEventHandler "unit" handler.
  */
 params [["_unit", objNull, [objNull]]];
-if (isNull _unit || {!(local _unit)}) exitWith {false};
-if (_unit getVariable ["Waldo_RespawnRestoreHandled", false]) exitWith {false};
+if (isNull _unit) exitWith {diag_log "[WMP LOADOUT] RespawnRestoreLoadout skipped: called with a null unit."; false};
+if (_unit getVariable ["Waldo_RespawnRestoreHandled", false]) exitWith {
+    diag_log format ["[WMP LOADOUT] RespawnRestoreLoadout skipped for %1: already handled for this life.", _unit];
+    false
+};
+if !(local _unit) exitWith {
+    // A silent, single-shot drop here is exactly what left a respawn with no restore and no
+    // explanation in RPT even after the trigger fired - retry briefly instead of giving up on the
+    // first check. `player` can be reassigned to this unit fractionally before the engine's own
+    // locality bookkeeping catches up; this covers that gap without blocking the caller.
+    diag_log format ["[WMP LOADOUT] RespawnRestoreLoadout: %1 not yet local, retrying for up to 5s.", _unit];
+    [_unit] spawn {
+        params ["_unit"];
+        private _deadline = diag_tickTime + 5;
+        waitUntil {sleep 0.05; local _unit || {diag_tickTime >= _deadline}};
+        if (local _unit) then {
+            [_unit] call Waldo_fnc_RespawnRestoreLoadout;
+        } else {
+            diag_log format ["[WMP LOADOUT] RespawnRestoreLoadout: %1 never became local within 5s; giving up. This should not happen for a client's own respawned unit - report this RPT.", _unit];
+        };
+    };
+    false
+};
 _unit setVariable ["Waldo_RespawnRestoreHandled", true];
 
 private _sideKey = switch (side _unit) do {case west: {"WEST"}; case east: {"EAST"}; case independent: {"GUER"}; default {"CIV"}};

--- a/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/Logistics/LogiHelpers/respawnRestoreLoadout.sqf
+++ b/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/Logistics/LogiHelpers/respawnRestoreLoadout.sqf
@@ -21,8 +21,29 @@
  * CBA_fnc_addPlayerEventHandler "unit" handler.
  */
 params [["_unit", objNull, [objNull]]];
-if (isNull _unit || {!(local _unit)}) exitWith {false};
-if (_unit getVariable ["Waldo_RespawnRestoreHandled", false]) exitWith {false};
+if (isNull _unit) exitWith {diag_log "[WMP LOADOUT] RespawnRestoreLoadout skipped: called with a null unit."; false};
+if (_unit getVariable ["Waldo_RespawnRestoreHandled", false]) exitWith {
+    diag_log format ["[WMP LOADOUT] RespawnRestoreLoadout skipped for %1: already handled for this life.", _unit];
+    false
+};
+if !(local _unit) exitWith {
+    // A silent, single-shot drop here is exactly what left a respawn with no restore and no
+    // explanation in RPT even after the trigger fired - retry briefly instead of giving up on the
+    // first check. `player` can be reassigned to this unit fractionally before the engine's own
+    // locality bookkeeping catches up; this covers that gap without blocking the caller.
+    diag_log format ["[WMP LOADOUT] RespawnRestoreLoadout: %1 not yet local, retrying for up to 5s.", _unit];
+    [_unit] spawn {
+        params ["_unit"];
+        private _deadline = diag_tickTime + 5;
+        waitUntil {sleep 0.05; local _unit || {diag_tickTime >= _deadline}};
+        if (local _unit) then {
+            [_unit] call Waldo_fnc_RespawnRestoreLoadout;
+        } else {
+            diag_log format ["[WMP LOADOUT] RespawnRestoreLoadout: %1 never became local within 5s; giving up. This should not happen for a client's own respawned unit - report this RPT.", _unit];
+        };
+    };
+    false
+};
 _unit setVariable ["Waldo_RespawnRestoreHandled", true];
 
 private _sideKey = switch (side _unit) do {case west: {"WEST"}; case east: {"EAST"}; case independent: {"GUER"}; default {"CIV"}};


### PR DESCRIPTION
**When merged this pull request will:**

- Fix a real, field-observed gap in the dual-trigger respawn restore (#109): a second respawn in the same session logged `Player-unit-changed event received` (trigger 2 fired, `treatingAsRespawn=true`) and then produced **no further output at all** — no restore, no identity-mismatch line, nothing. `Waldo_fnc_RespawnRestoreLoadout` had two early-exit guards (not local yet, or already handled for this life) that both silently returned `false` with zero RPT output, making the two failure modes indistinguishable from each other and from success.
- Root-caused to the not-local case: the `player` variable can be reassigned to the new unit a moment before the engine's own locality bookkeeping catches up, so `local _unit` can transiently read `false` at the exact instant the `"unit"` player-changed event fires.
- Every exit path now logs distinctly (null unit / already handled / not yet local) instead of silently returning `false`.
- The not-local case now retries for up to 5 seconds (polling every 0.05s) instead of giving up on the first check.
- Also notable from the same RPT: trigger 1 (the `"CAManBase"/"Respawn"` extended event handler) never logged even once across two full death/respawn cycles — trigger 2 is the only thing actually doing the work in that environment, which is exactly why it needed a real fallback instead of a single silent attempt.
- Include documentation to the standard upheld in existing files.

`sqf_validator.py` (938 files), `config_style_checker.py`, `performance_audit.py`, `documentation_contract_checker.py`, and all 108 tests in `test_full_arma_audit.py` pass with no new findings.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BXJRyb7fEYtkcrY1cND13h

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXJRyb7fEYtkcrY1cND13h)_