### PR TITLE
Add Waldo_InfoText_SkipFakeLoad diagnostic toggle

### DIFF
--- a/MissionScripts/MissionFlowAndUi/infoText.sqf
+++ b/MissionScripts/MissionFlowAndUi/infoText.sqf
@@ -166,13 +166,24 @@ private _postLoadBuffer = 0.75;  // was 5 - lets the now-black screen settle bef
 private _blackInFade = 1;        // was 3
 private _featureInitTimeout = 60; // bounded safety cap on the WALDO_INIT_COMPLETE wait below
 
-["fauxLoad", ""] call BIS_fnc_startLoadingScreen;
-uiSleep _fakeLoadHold;
-["wakeUpID", false, _blackoutFade] call BIS_fnc_blackOut; // Fade screen out to black for intro sequence.
-uiSleep _postBlackoutBuffer;
-"fauxLoad" call BIS_fnc_endLoadingScreen; // End fake loading screen and begin displaying text.
-
-uiSleep _postLoadBuffer;
+// Waldo_InfoText_SkipFakeLoad (default false): skips the fake loading screen and both fades below
+// entirely, going straight from the readiness wait above into the text reveal drawn directly over
+// whatever is currently on screen. Primarily a diagnostic switch - it isolates whether streaming
+// pop-in is visible with none of WMP's own presentation covering it, useful for telling apart "our
+// transition is timed wrong" from "the world genuinely is not settled yet" - but also a legitimate
+// permanent choice for a mission maker who wants no loading-screen presentation at all. blackIn below
+// is skipped along with it, since it has no matching blackOut to reverse when this is set.
+private _skipFakeLoad = missionNamespace getVariable ["Waldo_InfoText_SkipFakeLoad", false];
+if (_skipFakeLoad) then {
+    diag_log "[WMP INFOTEXT] Waldo_InfoText_SkipFakeLoad is true - fake loading screen and fades skipped.";
+} else {
+    ["fauxLoad", ""] call BIS_fnc_startLoadingScreen;
+    uiSleep _fakeLoadHold;
+    ["wakeUpID", false, _blackoutFade] call BIS_fnc_blackOut; // Fade screen out to black for intro sequence.
+    uiSleep _postBlackoutBuffer;
+    "fauxLoad" call BIS_fnc_endLoadingScreen; // End fake loading screen and begin displaying text.
+    uiSleep _postLoadBuffer;
+};
 
 // ----- ANIMATION SETTING -----
 // Triggered here, in parallel with the text reveal below, instead of only after it - so total wait
@@ -289,7 +300,9 @@ if !(missionNamespace getVariable ["WALDO_INIT_COMPLETE", false]) then {
     diag_log "[WMP INFOTEXT] WALDO_INIT_COMPLETE never became true within the timeout; releasing player input anyway.";
 };
 
-["wakeUpID", true, _blackInFade] call BIS_fnc_blackIn;
+if !(_skipFakeLoad) then {
+    ["wakeUpID", true, _blackInFade] call BIS_fnc_blackIn;
+};
 disableUserInput false;
 
 // Active/Complete track the on-screen text, not player control - wait for the detached reveal above

--- a/wiki/Mission-Intro-Or-Title-Text.md
+++ b/wiki/Mission-Intro-Or-Title-Text.md
@@ -96,6 +96,14 @@ missionNamespace setVariable ["Waldo_InfoText_FakeLoadHold", 8]; // seconds; shi
 
 Want the rest of the intro shorter or longer? The remaining fade durations sit as named constants near the top of `infoText.sqf` (`_blackoutFade`, `_postLoadBuffer`, and so on), each with a comment explaining what it controls. The text itself waits on its own actual reveal animation finishing, not a guessed duration, so there's no separate hold time to tune for it.
 
+Want no fake loading screen at all? Set this in `init.sqf` to skip it (and both fades) entirely, so the title text draws straight over whatever is already on screen:
+
+```sqf
+missionNamespace setVariable ["Waldo_InfoText_SkipFakeLoad", true];
+```
+
+Useful for telling apart two different causes if the title text seems to appear too early or too late: our own transition timing, or the world itself not being ready yet. With it set, anything still streaming in is visible directly, with nothing covering it. If the text still cuts into an unsettled-looking world with this set, that's real streaming, not our transition. It's also a legitimate permanent choice if you don't want any loading-screen presentation.
+
 ---
 
 ## Related Functions


### PR DESCRIPTION
**When merged this pull request will:**
- Add `Waldo_InfoText_SkipFakeLoad` (default `false`). When set `true`, `infoText.sqf` skips its own
  fake loading screen and both fades entirely, going straight from the readiness wait into the text
  reveal drawn over whatever is already on screen. `BIS_fnc_blackIn` at the end is skipped along with
  it, since it has no matching `blackOut` to reverse when this is set.
- Document it in `wiki/Mission-Intro-Or-Title-Text.md`'s Timing section.

**Why:** diagnostic tool for "the loading screen is cutting into the intro text" - since it isn't
clear whether that's WMP's own fake loading screen/transition or the real engine loading screen still
settling underneath it. With this set, nothing WMP draws covers the real world, so it isolates which
one it is: if the text still cuts into a visibly unsettled world with this on, that's real engine
streaming lag (not something retiming our own transition can fix); if the cutting stops, it was our
own fake-screen sequencing. It's also a legitimate permanent choice for a mission maker who wants no
loading-screen presentation at all.

Verified with `sqf_validator.py` and the full `test_full_arma_audit.py` suite (123 tests).

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_016tpgwn5ELfHSAacPnHdBdN)_