### PR TITLE
Fix InfoText text reveal finishing before WALDO_INIT_COMPLETE clears

### DIFF
--- a/MissionScripts/MissionFlowAndUi/infoText.sqf
+++ b/MissionScripts/MissionFlowAndUi/infoText.sqf
@@ -240,10 +240,35 @@ _usedAnimation = switch (_animate) do {
     default {};
 };
 
+// This intro no longer gates WALDO_INIT_COMPLETE (init.sqf spawns it), so it can finish before
+// server/feature startup does on a fast-loading mission. Wait for that flag before the text reveal
+// starts (not just before control returns, as an earlier pass had it) - bounded so a mission that
+// never sets it (broken init.sqf) doesn't hold the intro forever.
+//
+// This ordering fix closes a real bug, root-caused from an actual playtest RPT, not a guess: the
+// text reveal below used to be spawned immediately here and run fully detached from control-return,
+// on BIS_fnc_typeText's own few-second timeline - deliberately, so reading it never delayed getting
+// control back. But init.sqf's own mandatory `sleep 10` before it sets WALDO_INIT_COMPLETE (a
+// pre-existing, unrelated buffer, well outside this script) reliably takes far longer than that
+// timeline. The detached text thread would start, run to completion and vanish while still blocked
+// waiting on this same flag lower down - "the text has already finished by the time the player is
+// actually there", confirmed against an RPT showing WMP's own init.sqf systems (jamming, ACRE, ZEN,
+// loadout, etc.) all completing within about a second of CBA's postinit, and Dynamic AA's queued
+// system materialising (gated on WALDO_INIT_COMPLETE) only firing roughly ten seconds later - the
+// exact width of that sleep 10, not real engine asset streaming. Starting the text reveal only once
+// this wait clears means it can no longer finish before the player has any chance to see it.
+private _featureInitDeadline = diag_tickTime + _featureInitTimeout;
+waitUntil {
+    uiSleep 0.2;
+    missionNamespace getVariable ["WALDO_INIT_COMPLETE", false] || {diag_tickTime >= _featureInitDeadline}
+};
+if !(missionNamespace getVariable ["WALDO_INIT_COMPLETE", false]) then {
+    diag_log "[WMP INFOTEXT] WALDO_INIT_COMPLETE never became true within the timeout; releasing player input anyway.";
+};
+
 // Text reveal is purely cosmetic and reads fine whether or not the player already has control back
-// (a title card over live gameplay is a normal pattern), so it runs on its own detached timeline
-// instead of blocking control return - the only thing that still needs to block is protecting a
-// chosen movement animation and giving feature init a chance to finish (both below). scriptDone on
+// (a title card over live gameplay is a normal pattern), so it still runs on its own detached
+// timeline rather than blocking control return below - only its START moved, not this. scriptDone on
 // the returned handle is polled further down purely to keep Waldo_InfoText_Active/Complete accurate
 // (gunshipNotifyLocal.sqf/fieldResupplyNotifyGrantLocal.sqf defer their own notices on it so nothing
 // draws over this text) - it is never waited on before returning control.
@@ -286,18 +311,6 @@ _animationDuration = _animationDurations getOrDefault [_animate, 0];
 _animationRemaining = _animationDuration - (diag_tickTime - _animationStart);
 if (_animationRemaining > 0) then {
     uiSleep _animationRemaining;
-};
-
-// This intro no longer gates WALDO_INIT_COMPLETE (init.sqf spawns it), so it can finish before
-// server/feature startup does on a fast-loading mission. Hold the lock until that flag is up too,
-// bounded so a mission that never sets it (broken init.sqf) doesn't lock the player out forever.
-private _featureInitDeadline = diag_tickTime + _featureInitTimeout;
-waitUntil {
-    uiSleep 0.2;
-    missionNamespace getVariable ["WALDO_INIT_COMPLETE", false] || {diag_tickTime >= _featureInitDeadline}
-};
-if !(missionNamespace getVariable ["WALDO_INIT_COMPLETE", false]) then {
-    diag_log "[WMP INFOTEXT] WALDO_INIT_COMPLETE never became true within the timeout; releasing player input anyway.";
 };
 
 if !(_skipFakeLoad) then {

--- a/wiki/Mission-Intro-Or-Title-Text.md
+++ b/wiki/Mission-Intro-Or-Title-Text.md
@@ -86,7 +86,7 @@ The intro is short by default: a quick fade in, the title text, then control ret
 - **No animation** (the default): control returns as soon as the fade-in finishes and the rest of the mission has started up. The title text keeps typing itself out in the background, so reading it doesn't hold up gameplay.
 - **An animation** (`WALK`, `SIT`, or `COFFIN`): control waits for that animation to finish, so the player never interrupts it mid-move. `WAKE` and `WAKESLOW` have no fixed length. Control returns for those once the rest of the sequence finishes.
 
-A player never gets control before the mission's own startup (crates, radios, and other features) has finished, even on a fast-loading mission.
+A player never gets control before the mission's own startup (crates, radios, and other features) has finished, even on a fast-loading mission. The title text doesn't start typing until that same point either. On a slower-starting mission, text that started earlier could finish and disappear before the player was ever able to see it.
 
 Arma has no way for a script to know when a specific player's own game has finished loading in. A heavy mod list or large terrain can leave a client streaming in models and textures for a few seconds after the mission has technically started. No script, including this one, can check for that finishing. The first couple of seconds before the title text appears cover that gap. If the world still looks like it's loading when the title text starts, raise it in `init.sqf`:
 


### PR DESCRIPTION
Root cause fix, not a workaround - diagnosed from an actual playtest RPT after `Waldo_InfoText_SkipFakeLoad` (#123) isolated the symptom.

**When merged this pull request will:**
- Move the `WALDO_INIT_COMPLETE` bounded wait to run *before* the text-reveal thread spawns, instead
  of after it.
- Update `wiki/Mission-Intro-Or-Title-Text.md`'s Timing section to describe the corrected behaviour.

**The bug:** the detached text-reveal thread (added so reading the intro text never delays control
return) was spawned immediately and ran to completion on `BIS_fnc_typeText`'s own timeline -
typically a few seconds. But `init.sqf` has a pre-existing, unrelated `sleep 10;` immediately before
it sets `WALDO_INIT_COMPLETE` (marked "DO NOT TOUCH", not something this PR changes). An RPT from a
real playtest showed WMP's own init.sqf systems (jamming, ACRE, ZEN, loadout, etc.) all completing
within about a second of CBA's postinit, and Dynamic AA's `WALDO_INIT_COMPLETE`-gated queued system
only materialising roughly ten seconds later - the exact width of that `sleep 10`, not real engine
asset streaming as an earlier pass on this branch had suspected. The detached text thread would run
and disappear entirely during that ten-second window, while the player was still locked out waiting
on that same flag further down the script: "the text has already finished by the time the player is
actually there."

**The fix:** text reveal still runs detached from control-return (so reading it still doesn't hold up
gameplay), it just no longer starts until `WALDO_INIT_COMPLETE` has actually cleared, so it can never
finish before the player has any chance to see it.

Verified with `sqf_validator.py` and the full `test_full_arma_audit.py` suite (123 tests).

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_016tpgwn5ELfHSAacPnHdBdN)_