### PR TITLE
Replace init.sqf's blind sleep 10 with a bounded wait on Logi_MissionScanComplete

### DIFF
--- a/init.sqf
+++ b/init.sqf
@@ -257,7 +257,25 @@ waldos Init Completion flag
 
 ======DO NOT TOUCH!=====
 */
-sleep 10; // Buffer cycles for other inits to be completed - should not be removed
+// Was an unconditional `sleep 10;` ("buffer cycles for other inits to be completed"), not gated on
+// any actual check. Audited every WALDO_INIT_COMPLETE consumer in the pack: none of them actually
+// depend on this specific duration for correctness - the ones with a real data-readiness dependency
+// (starter/supply crates, limited arsenals) already double-check the broadcast
+// Logi_MissionScanComplete flag independently; Dynamic AA already has its own bounded queue/retry
+// worker; the rest (jamming HUD, safestart HUD) only use this flag as a presentation courtesy ("don't
+// draw over the intro"), not a safety dependency. A blind sleep with no check was strictly worse than
+// waiting on the real signal: it could still fire before the loadout scan finished on a slow server,
+// and it unconditionally cost ~10s even when the mission was ready in ~1s (confirmed against a real
+// playtest RPT). Bounded so a mission that somehow never completes the scan doesn't hang forever -
+// same 60s ceiling used for the WALDO_INIT_COMPLETE wait inside infoText.sqf.
+private _initCompleteScanDeadline = diag_tickTime + 60;
+waitUntil {
+    sleep 0.2;
+    missionNamespace getVariable ["Logi_MissionScanComplete", false] || {diag_tickTime >= _initCompleteScanDeadline}
+};
+if !(missionNamespace getVariable ["Logi_MissionScanComplete", false]) then {
+    diag_log "[WMP INIT] Logi_MissionScanComplete never became true within the timeout; setting WALDO_INIT_COMPLETE anyway.";
+};
 // A dedicated server has no local player. Waiting for one here prevented the pack's
 // completion flag and any post-start consumers from ever running on that machine.
 waitUntil {isDedicated || {!isNull player && {player == player}}};

--- a/releaseVerificationAndDeployment/test_full_arma_audit.py
+++ b/releaseVerificationAndDeployment/test_full_arma_audit.py
@@ -1101,7 +1101,7 @@ class FullAuditTests(unittest.TestCase):
             generated_server = (destination / "initServer.sqf").read_text(encoding="utf-8")
             generated_player = (destination / "initPlayerLocal.sqf").read_text(encoding="utf-8")
             self.assertIn('["",""] spawn Waldo_fnc_InfoText', generated_init)
-            self.assertIn("sleep 10", generated_init)
+            self.assertIn('missionNamespace getVariable ["Logi_MissionScanComplete", false]', generated_init)
             self.assertTrue(generated_init.rstrip().endswith('call compile preprocessFileLineNumbers "auditInit.sqf";'))
             self.assertTrue(generated_server.rstrip().endswith('call compile preprocessFileLineNumbers "auditInitServer.sqf";'))
             self.assertTrue(generated_player.rstrip().endswith('call compile preprocessFileLineNumbers "auditInitPlayerLocal.sqf";'))


### PR DESCRIPTION
Follow-up to #124 - answers "would removing the sleep 10 before WALDO_INIT_COMPLETE do any harm, are we protected?"

**When merged this pull request will:**
- Replace the unconditional `sleep 10;` before `WALDO_INIT_COMPLETE` is set with a bounded wait on
  `Logi_MissionScanComplete` (the same broadcast flag `doStarterCrate.sqf`/`doSupplyCrate.sqf`/
  `createLimitedAceArsenal.sqf` already double-check independently), capped at 60s.
- Update `test_full_arma_audit.py`'s assertion, which was only checking for the literal string
  `"sleep 10"` in generated `init.sqf` output - true only by coincidence once this line no longer
  contains a real `sleep 10;` statement.

**Why this is safe:** audited every `WALDO_INIT_COMPLETE` consumer in the pack before touching a line
explicitly marked `DO NOT TOUCH`. None of them actually depend on this specific duration for
correctness - the crate/arsenal scripts already have their own independent readiness check, Dynamic
AA already has its own bounded retry worker, and the jamming/safestart HUDs only use this flag as a
presentation courtesy, not a safety dependency (their own comments say so). The blind sleep was
strictly worse than waiting on the real signal: it could still fire before the loadout scan finished
on a slow server (nothing tied it to that), and it unconditionally cost ~10s even when the mission
was ready in ~1s - confirmed against a real playtest RPT from this session's debugging.

This also removes a real, now-identified floor from the InfoText intro's total time-to-visible-text
(#124 made the intro wait on `WALDO_INIT_COMPLETE` before starting).

Verified with `sqf_validator.py` and the full `test_full_arma_audit.py` suite (123 tests).

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_016tpgwn5ELfHSAacPnHdBdN)_