### PR TITLE
Fix hosted-server UI theme initialization

### DIFF
--- a/init.sqf
+++ b/init.sqf
@@ -34,6 +34,12 @@ missionNamespace setVariable ["Waldo_SharedFeatureConfigReady", true];
 if (isServer) then {
     missionNamespace setVariable ["Waldo_FeatureRuntimeSnapshotReceived", true];
     missionNamespace setVariable ["Waldo_FeatureRuntimeSnapshotFailed", false];
+    // A hosted server is both the authoritative server and an interface client. It does not pass
+    // through FeatureRuntimeReceiveState during initial startup, so apply the authoritative shared
+    // theme locally here. Dedicated servers skip this presentation-only work.
+    if (hasInterface) then {
+        [missionNamespace getVariable ["Waldo_UI_Theme", "DEFAULT"], false] call Waldo_fnc_UiThemeApplyLocal;
+    };
 } else {
     missionNamespace setVariable ["Waldo_FeatureRuntimeSnapshotReceived", false];
     missionNamespace setVariable ["Waldo_FeatureRuntimeSnapshotFailed", false];

--- a/releaseVerificationAndDeployment/test_pr_review_audit.py
+++ b/releaseVerificationAndDeployment/test_pr_review_audit.py
@@ -1034,6 +1034,14 @@ class PrReviewAuditTests(unittest.TestCase):
         self.assertIn('"Waldo_UI_Theme"', snapshot)
         self.assertIn('"Waldo_UI_ThemeRevision"', snapshot)
         self.assertIn("call Waldo_fnc_UiThemeApplyLocal", receive)
+        server_branch_start = root_init.index("if (isServer) then")
+        client_branch_start = root_init.index("} else {", server_branch_start)
+        server_branch = root_init[server_branch_start:client_branch_start]
+        self.assertIn("if (hasInterface) then", server_branch)
+        self.assertIn(
+            '[missionNamespace getVariable ["Waldo_UI_Theme", "DEFAULT"], false] call Waldo_fnc_UiThemeApplyLocal;',
+            server_branch,
+        )
 
     def test_recovery_notifications_use_actor_or_explicit_nearby_player_owners(self):
         root = ROOT / "MissionScripts" / "Logistics" / "VehicleRecovery"


### PR DESCRIPTION
## Summary
- apply the authoritative WMP UI theme locally when a hosted server also has an interface
- keep dedicated servers presentation-free and remote/JIP clients gated on their runtime snapshot
- add regression coverage for the hosted-server branch

## Validation
- SQF validator: 967 files, 0 errors
- config style checker: 15 files, 0 errors
- Zeus/script parity: 64 modules, 0 errors
- interaction UI and drawn UI validators: passed
- wiki assets, wiki structure, and documentation contracts: passed
- full-pack audit unit tests: 124 passed
- focused UI-theme regression test: passed
- diff whitespace check: passed

## Existing unrelated failure
The broader test_pr_review_audit.py run has one Dynamic AO expectation failure already present on current main: it expects configClasses for CfgFactionClasses in the Dynamic AO sources. The UI-theme regression in that suite passes.