### PR TITLE
Fix Minesweeper right-click flag routing

### DIFF
--- a/MissionScripts/InteractionsMinigames/Challenges/challengeMinesweeper.sqf
+++ b/MissionScripts/InteractionsMinigames/Challenges/challengeMinesweeper.sqf
@@ -1,6 +1,20 @@
 /*
- * Portable ordnance diagnostic-tablet matrix procedure.
- * Config: [size(4..8), mineCount, timeLimit, title]
+ * Author: WaldoTheWarfighter
+ * Purpose: Opens the local Minesweeper-style explosive-circuit challenge and routes complete
+ * pointer clicks so left click probes while right click only places or removes a marker.
+ * Locality/Authority: Interface-client only. The challenge resolver reports the final result to
+ * the calling interaction; this file does not perform authoritative world-state changes.
+ * Repeat/JIP Behaviour: A fresh display and private board state are created for every attempt.
+ * No state is persisted or replayed for JIP clients.
+ *
+ * Arguments:
+ * 0: Challenge config <ARRAY>, default []; [size 4..8, mine count, time limit, title].
+ * 1: Result resolver <CODE>, default {}; called once by the shared challenge UI.
+ *
+ * Return Value: Nothing <NIL>.
+ * Current Callers: Waldo_fnc_MiniGameChallenge and the interaction-equipment QA mission.
+ * Example: [[5, 5, 90, "TRIGGER ANALYSER"], {systemChat str _this}] call
+ *          Waldo_fnc_MiniGameMinesweeper;
  */
 disableSerialization;
 params [["_config", []], ["_resolve", {}]];
@@ -27,6 +41,19 @@ _display setVariable ["Waldo_MG_MS_Revealed", []];
 _display setVariable ["Waldo_MG_MS_Flags", []];
 _display setVariable ["Waldo_MG_MS_Generated", false];
 _display setVariable ["Waldo_MG_MS_Revealing", false];
+_display setVariable ["Waldo_MG_MS_HandlePointer", {
+    params ["_display", "_index", "_mouseButton"];
+    if (!(_display getVariable ["Waldo_IMG_Started", false]) || {_display getVariable ["Waldo_MG_UI_Done", false] || {_display getVariable ["Waldo_MG_MS_Revealing", false]}}) exitWith {true};
+    if (_mouseButton == 0) exitWith {
+        [_display, _index] call (_display getVariable ["Waldo_MG_MS_Reveal", {}]);
+        true
+    };
+    if (_mouseButton == 1) exitWith {
+        [_display, _index] call (_display getVariable ["Waldo_MG_MS_ToggleFlag", {}]);
+        true
+    };
+    false
+}];
 
 private _tablet = [_display, "RscText", [1.5, 3, 37, 20.5], "portable ordnance diagnostic tablet"] call Waldo_fnc_MiniGameEquipmentCreateControl;
 _tablet ctrlSetBackgroundColor [0.10, 0.12, 0.115, 1];
@@ -64,14 +91,11 @@ for "_row" from 0 to (_size - 1) do {
         _button ctrlSetTextColor [0.84, 0.88, 0.82, 1];
         _button ctrlSetTooltip format ["Circuit node %1-%2. LMB probe, RMB mark.", _row + 1, _column + 1];
         _button setVariable ["Waldo_MG_MS_Index", _index];
-        _button ctrlAddEventHandler ["MouseButtonDown", {
-            params ["_control", "_button"];
+        _button ctrlAddEventHandler ["MouseButtonClick", {
+            params ["_control", "_mouseButton"];
             private _display = ctrlParent _control;
-            if (!(_display getVariable ["Waldo_IMG_Started", false]) || {_display getVariable ["Waldo_MG_UI_Done", false] || {_display getVariable ["Waldo_MG_MS_Revealing", false]}}) exitWith {true};
             private _index = _control getVariable ["Waldo_MG_MS_Index", -1];
-            if (_button == 0) exitWith {[_display, _index] call (_display getVariable ["Waldo_MG_MS_Reveal", {}]); true};
-            if (_button == 1) exitWith {[_display, _index] call (_display getVariable ["Waldo_MG_MS_ToggleFlag", {}]); true};
-            false
+            [_display, _index, _mouseButton] call (_display getVariable ["Waldo_MG_MS_HandlePointer", {false}])
         }];
         _buttons pushBack _button;
     };

--- a/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/InteractionsMinigames/Challenges/challengeMinesweeper.sqf
+++ b/releaseVerificationAndDeployment/fullArmaAudit/WMP_FPA.VR/MissionScripts/InteractionsMinigames/Challenges/challengeMinesweeper.sqf
@@ -1,6 +1,20 @@
 /*
- * Portable ordnance diagnostic-tablet matrix procedure.
- * Config: [size(4..8), mineCount, timeLimit, title]
+ * Author: WaldoTheWarfighter
+ * Purpose: Opens the local Minesweeper-style explosive-circuit challenge and routes complete
+ * pointer clicks so left click probes while right click only places or removes a marker.
+ * Locality/Authority: Interface-client only. The challenge resolver reports the final result to
+ * the calling interaction; this file does not perform authoritative world-state changes.
+ * Repeat/JIP Behaviour: A fresh display and private board state are created for every attempt.
+ * No state is persisted or replayed for JIP clients.
+ *
+ * Arguments:
+ * 0: Challenge config <ARRAY>, default []; [size 4..8, mine count, time limit, title].
+ * 1: Result resolver <CODE>, default {}; called once by the shared challenge UI.
+ *
+ * Return Value: Nothing <NIL>.
+ * Current Callers: Waldo_fnc_MiniGameChallenge and the interaction-equipment QA mission.
+ * Example: [[5, 5, 90, "TRIGGER ANALYSER"], {systemChat str _this}] call
+ *          Waldo_fnc_MiniGameMinesweeper;
  */
 disableSerialization;
 params [["_config", []], ["_resolve", {}]];
@@ -27,6 +41,19 @@ _display setVariable ["Waldo_MG_MS_Revealed", []];
 _display setVariable ["Waldo_MG_MS_Flags", []];
 _display setVariable ["Waldo_MG_MS_Generated", false];
 _display setVariable ["Waldo_MG_MS_Revealing", false];
+_display setVariable ["Waldo_MG_MS_HandlePointer", {
+    params ["_display", "_index", "_mouseButton"];
+    if (!(_display getVariable ["Waldo_IMG_Started", false]) || {_display getVariable ["Waldo_MG_UI_Done", false] || {_display getVariable ["Waldo_MG_MS_Revealing", false]}}) exitWith {true};
+    if (_mouseButton == 0) exitWith {
+        [_display, _index] call (_display getVariable ["Waldo_MG_MS_Reveal", {}]);
+        true
+    };
+    if (_mouseButton == 1) exitWith {
+        [_display, _index] call (_display getVariable ["Waldo_MG_MS_ToggleFlag", {}]);
+        true
+    };
+    false
+}];
 
 private _tablet = [_display, "RscText", [1.5, 3, 37, 20.5], "portable ordnance diagnostic tablet"] call Waldo_fnc_MiniGameEquipmentCreateControl;
 _tablet ctrlSetBackgroundColor [0.10, 0.12, 0.115, 1];
@@ -64,14 +91,11 @@ for "_row" from 0 to (_size - 1) do {
         _button ctrlSetTextColor [0.84, 0.88, 0.82, 1];
         _button ctrlSetTooltip format ["Circuit node %1-%2. LMB probe, RMB mark.", _row + 1, _column + 1];
         _button setVariable ["Waldo_MG_MS_Index", _index];
-        _button ctrlAddEventHandler ["MouseButtonDown", {
-            params ["_control", "_button"];
+        _button ctrlAddEventHandler ["MouseButtonClick", {
+            params ["_control", "_mouseButton"];
             private _display = ctrlParent _control;
-            if (!(_display getVariable ["Waldo_IMG_Started", false]) || {_display getVariable ["Waldo_MG_UI_Done", false] || {_display getVariable ["Waldo_MG_MS_Revealing", false]}}) exitWith {true};
             private _index = _control getVariable ["Waldo_MG_MS_Index", -1];
-            if (_button == 0) exitWith {[_display, _index] call (_display getVariable ["Waldo_MG_MS_Reveal", {}]); true};
-            if (_button == 1) exitWith {[_display, _index] call (_display getVariable ["Waldo_MG_MS_ToggleFlag", {}]); true};
-            false
+            [_display, _index, _mouseButton] call (_display getVariable ["Waldo_MG_MS_HandlePointer", {false}])
         }];
         _buttons pushBack _button;
     };

--- a/releaseVerificationAndDeployment/interactionEquipmentQA/InteractionEquipmentQA.VR/initPlayerLocal.sqf
+++ b/releaseVerificationAndDeployment/interactionEquipmentQA/InteractionEquipmentQA.VR/initPlayerLocal.sqf
@@ -81,6 +81,16 @@ private _exerciseProcedure = {
             [_display, 0] call (_display getVariable ["Waldo_MG_MS_Reveal", {}]);
             waitUntil {uiSleep 0.01; !(_display getVariable ["Waldo_MG_MS_Revealing", false])};
             private _mines = _display getVariable ["Waldo_MG_MS_Mines", []];
+            private _mineIndex = _mines param [0, -1];
+            if (_mineIndex >= 0) then {
+                [_display, _mineIndex, 1] call (_display getVariable ["Waldo_MG_MS_HandlePointer", {false}]);
+                private _rightClickSafe = _mineIndex in (_display getVariable ["Waldo_MG_MS_Flags", []])
+                    && {!(_mineIndex in (_display getVariable ["Waldo_MG_MS_Revealed", []]))}
+                    && {!(_display getVariable ["Waldo_MG_UI_Done", false])};
+                if (!_rightClickSafe) exitWith {
+                    [_display, false, "[X] QA RIGHT CLICK REVEALED A TRIGGER"] call (_display getVariable ["Waldo_MG_UI_Finish", {}]);
+                };
+            };
             private _cellCount = count (_display getVariable ["Waldo_MG_MS_Buttons", []]);
             for "_index" from 0 to (_cellCount - 1) do {
                 if !(_index in _mines) then {

--- a/releaseVerificationAndDeployment/test_full_arma_audit.py
+++ b/releaseVerificationAndDeployment/test_full_arma_audit.py
@@ -2281,6 +2281,32 @@ class FullAuditTests(unittest.TestCase):
             source = (ROOT / "MissionScripts" / "InteractionsMinigames" / relative).read_text(encoding="utf-8")
             self.assertIn("MiniGameEquipmentFitStructuredText", source, relative)
 
+    def test_minesweeper_right_click_routes_only_to_marker_toggle(self):
+        challenge = (
+            ROOT
+            / "MissionScripts"
+            / "InteractionsMinigames"
+            / "Challenges"
+            / "challengeMinesweeper.sqf"
+        ).read_text(encoding="utf-8")
+        qa_client = (
+            ROOT
+            / "releaseVerificationAndDeployment"
+            / "interactionEquipmentQA"
+            / "InteractionEquipmentQA.VR"
+            / "initPlayerLocal.sqf"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn('ctrlAddEventHandler ["MouseButtonClick"', challenge)
+        left_route = challenge.split('if (_mouseButton == 0) exitWith {', 1)[1].split("};", 1)[0]
+        right_route = challenge.split('if (_mouseButton == 1) exitWith {', 1)[1].split("};", 1)[0]
+        self.assertIn('getVariable ["Waldo_MG_MS_Reveal", {}]', left_route)
+        self.assertNotIn("Waldo_MG_MS_ToggleFlag", left_route)
+        self.assertIn('getVariable ["Waldo_MG_MS_ToggleFlag", {}]', right_route)
+        self.assertNotIn("Waldo_MG_MS_Reveal", right_route)
+        self.assertIn('[_display, _mineIndex, 1]', qa_client)
+        self.assertIn("QA RIGHT CLICK REVEALED A TRIGGER", qa_client)
+
     def test_zeus_economy_export_can_emit_paste_ready_world_setup(self):
         exporter = (ROOT / "MissionScripts" / "EconomySystems" / "Core" / "buildMissionSetupScript.sqf").read_text(encoding="utf-8")
         prompt = (ROOT / "MissionScripts" / "EconomySystems" / "Core" / "promptUnifiedSaveSystem.sqf").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Route Minesweeper cells through the button-specific complete-click event and a shared pointer dispatcher.
- Keep left click exclusive to probing and right click exclusive to placing or removing a marker.
- Extend automated interaction QA to right-click a known mine and fail if it is revealed or completes the procedure.
- Add a static regression contract and refresh the full-audit source mirror.

## Validation

- SQF validator: 999 files, 0 errors.
- Focused Minesweeper regression: passed.
- Interaction UI checker: 13 tests passed.
- Repository tests excluding the unchanged PR-audit baseline failure: 163 tests passed.
- Documentation contracts: passed.
- Zeus/script parity: 66 modules, 0 errors.
- Arma interaction QA: Automated, all four difficulties, 3840x2160, noBattlEye; 40 cases completed with WMP INTERACTION UI QA COMPLETE: 0 finding(s) [] and no SQF errors.

## Existing upstream test issue

The complete discovery run still reports the pre-existing test_dynamic_ao_runtime_generator_and_recent_regressions_are_wired assertion. The failing test and Dynamic AO sources are unchanged from origin/main and are outside this PR.