### PR TITLE
Sync mission-pack-config skill with WMP UI settings/themes updates

### DIFF
--- a/.claude/skills/mission-pack-config/references/ui-notifications.md
+++ b/.claude/skills/mission-pack-config/references/ui-notifications.md
@@ -144,7 +144,31 @@ Repeat-safe local recovery of all WMP-owned overlays/displays — use this if
 a player's screen has a stuck WMP panel rather than trying to hunt down
 which specific feature left it there.
 
-Players get **WMP Interface > Clear Stuck WMP UI** as an ACE self-action
-already; vanilla `addAction` installs automatically only when ACE
-interaction is unavailable. No setup needed — it runs on JIP and respawn
-with no authority scheduler or public state to configure.
+Players get **WMP Options > Clear Stuck WMP UI** as an ACE self-action
+already (this launcher root was renamed from "WMP Interface"); vanilla
+`addAction` installs automatically only when ACE interaction is
+unavailable. No setup needed — it runs on JIP and respawn with no
+authority scheduler or public state to configure.
+
+## Player-local presentation (separate from mission config)
+
+Players can personalise how cards look for themselves — without any
+mission-maker config change — under **ACE Self Interact > WMP Options >
+Notification UI Settings**: a notification-only theme override (`Follow
+Mission` default, or any built-in/mission-custom theme), **Small/Medium/
+Large** card size, and **Normal/Reduced/Off** entry motion. Mission theme
+overrides and each player's colour-vision profile still apply on top —
+this never bypasses either. Purely local, never broadcast. See
+`ui-themes.md` for the full contract.
+
+## Lane/stacking behaviour (all six placements)
+
+Each placement holds up to three active cards. `TOP`/`CENTER` lanes keep
+the oldest card at the top and slide new ones in at the bottom; `BOTTOM_*`
+lanes keep the oldest at the bottom and slide new ones in at the top —
+either way, survivors close the gap toward the placement's anchor when a
+card expires. FIFO is per-channel: repeated updates on one channel queue
+and play in order rather than each claiming a lane; three different
+channels routed to the same placement is what actually forms a 3-card
+stack. `REPLACE` updates its channel's current card in place instead of
+adding a new one.

--- a/.claude/skills/mission-pack-config/references/ui-themes.md
+++ b/.claude/skills/mission-pack-config/references/ui-themes.md
@@ -9,10 +9,15 @@ tactical display, interaction equipment, Economy prompts, table-game chrome.
 ## Mission theme — config (`MissionConfig\interfaceConfig.sqf` — shared)
 
 ```sqf
-["Waldo_UI_Theme", "DEFAULT"],           // DEFAULT | WW2 | VIETNAM | SCIFI | PARCHMENT | MINIMAL | registered custom ID
+["Waldo_UI_Theme", "DEFAULT"],           // DEFAULT | WW2 | VIETNAM | SCIFI | PARCHMENT | MINIMAL | NAVAL |
+                                          // DESERT_STORM | INDUSTRIAL | EASTERN_BLOC | INTELLIGENCE | GRIMDARK |
+                                          // ATOMIC_AGE | WASTELAND | PMC | RETRO_COMMAND | DIESELPUNK |
+                                          // MERCENARY | PROPAGANDA | EMERGENCY | registered custom ID
 ["Waldo_UI_CustomThemes", createHashMap],    // ADVANCED: full named custom-theme definitions
 ["Waldo_UI_ThemeOverrides", createHashMap]   // ADVANCED: partial token overrides for the selected theme
 ```
+
+Twenty built-in themes:
 
 | ID | Presentation |
 |---|---|
@@ -20,12 +25,30 @@ tactical display, interaction equipment, Economy prompts, table-game chrome.
 | `WW2` | Olive field equipment, khaki paper/brass, War Department copy |
 | `VIETNAM` | Green phosphor/field-radio shell, amber controls, field-net copy |
 | `SCIFI` | Deep navy node display, cyan/magenta rails, bracketed titles |
-| `PARCHMENT` | Aged parchment and wax-seal red, gilt double rails, "Royal Chancery" proclamation copy, `PuristaLight`/`PuristaBold` font |
+| `PARCHMENT` | Aged parchment and wax-seal violet, gilt double rails, "Royal Chancery" proclamation copy, `PuristaLight`/`PuristaBold` font |
 | `MINIMAL` | Low-profile/no-frills style; also the one theme that sets the `compact` token (see below) |
+| `NAVAL` | Dark naval-blue Combat Information Centre panels, sea-green tracks, pale-blue trim, CIC contact-report copy |
+| `DESERT_STORM` | Charcoal/faded sand command equipment, amber CRT emphasis, CENTCOM tasking/SITREP copy |
+| `INDUSTRIAL` | Slate field-operations board, safety-yellow index tab, steel status rules, work-order copy |
+| `EASTERN_BLOC` | Gunmetal field apparatus, faded cream text, steel-blue controls, sector-command directive copy |
+| `INTELLIGENCE` | Restricted charcoal document panels, muted teal analysis controls, classification-violet trim |
+| `GRIMDARK` | Olive phosphor field display, amber controls, gothic framing, VOXCASTER traffic labels/vox-net copy |
+| `ATOMIC_AGE` | Pristine mint-and-cream 1950s retro-futurism, teal controls, gilt trim, civil-defence bulletin copy |
+| `WASTELAND` | Battered retro electronics, oxidised teal panels, amber gauges, faded phosphor text, salvage copy |
+| `PMC` | Light silver corporate equipment, cool-blue controls, restrained steel trim, verified-contract copy |
+| `RETRO_COMMAND` | Green-phosphor CRT panels, amber keys, scan rails, terse 1970s-80s command-terminal messages |
+| `DIESELPUNK` | Symmetrical brass-and-black ministry engine plate, steel braces, heavy-industry directives |
+| `MERCENARY` | Field-worn sand-and-olive contractor kit, muted brass controls, informal job/contract language |
+| `PROPAGANDA` | Monumental navy/cream/muted-gold broadcast panels, numbered state directives, oversized copy |
+| `EMERGENCY` | Dark incident-command panels, rescue-amber controls, cool-blue trim, active emergency-ops copy |
 
-Semantic success/warning/error colours, written state text, symbols and
-shapes remain distinct/present in every theme — interaction procedures
-never require colour recognition alone.
+WMP theme presentation never uses red anywhere (Arma reserves red as
+hostile/enemy language) — built-in themes use violet for danger, and the
+resolver normalises any red input (custom theme, override, or player
+colour-vision remap) to a safe blue/green/amber/violet fallback before
+drawing. Semantic success/warning/error colours, written state text,
+symbols and shapes remain distinct/present in every theme — interaction
+procedures never require colour recognition alone.
 
 ### The `compact` token — the one exception to "themes never change size"
 
@@ -40,11 +63,15 @@ a future theme also needs a smaller footprint.
 
 ## Personal colour-vision profile (per player, never set mission-wide)
 
-**ACE Self Interact > WMP Interface > Accessibility > Colour Vision
-Settings**: `STANDARD`, `RED_GREEN`, `PROTAN`, `TRITAN`, `HIGH_CONTRAST`.
-Stored in `profileNamespace` as `Waldo_UI_ColourVisionProfile`, applies
-immediately, persists per player, never broadcast — two players can run
-different colour-vision profiles under the same mission theme.
+**ACE Self Interact > WMP Options > Accessibility Settings**: `STANDARD`,
+`RED_GREEN`, `PROTAN`, `TRITAN`, `HIGH_CONTRAST`, plus a reduced-motion
+toggle shared with notification entry animation. Stored in
+`profileNamespace` as `Waldo_UI_ColourVisionProfile`, applies immediately,
+persists per player, never broadcast — two players can run different
+colour-vision profiles under the same mission theme. The profile remaps
+only semantic/focus tokens (accent, success, warning, danger + hex
+variants) — it never touches a theme's own panel/chrome/material/text
+colours.
 
 ```sqf
 ["RED_GREEN", true] call Waldo_fnc_UiColourVisionApplyLocal;   // local scripted selection only
@@ -52,6 +79,25 @@ different colour-vision profiles under the same mission theme.
 
 Do not publish this from `initServer.sqf` or overwrite it in `init.sqf` —
 it's intentionally different for each player.
+
+## Personal notification presentation (separate from the HUD and the mission theme)
+
+**ACE Self Interact > WMP Options > Notification UI Settings** — a
+player-local screen, independent of `Waldo_WmpHud_*` settings below and of
+the mission-wide `Waldo_UI_Theme`:
+
+- **Theme**: `Follow Mission` (default) or any built-in/mission-custom
+  theme ID — affects **notification cards only**, never the WMP HUD or
+  other panels.
+- **Size**: `Small` / `Medium` / `Large` card scale.
+- **Motion**: `Normal` / `Reduced` / `Off` entry animation.
+
+Mission theme-token overrides and the colour-vision profile are still
+applied on top — a player can't use this to bypass either. Apply restyles
+visible stacks immediately and reflows them in place; Cancel discards the
+pending form; Restore Defaults resets only the form, not other players.
+Never broadcast, never persisted mission-side — purely a local preference
+(`Waldo_fnc_UiNotificationSettingsApplyLocal`).
 
 ## Live Zeus QA switch
 
@@ -77,9 +123,15 @@ malformed palette from changing UI behaviour.
 ## Gotchas
 
 - Use `Waldo_fnc_UiThemeSetServer` for the mission-wide era,
-  `Waldo_fnc_UiColourVisionApplyLocal` only for local accessibility tooling
-  — don't mix them up.
+  `Waldo_fnc_UiColourVisionApplyLocal` only for local accessibility tooling,
+  `Waldo_fnc_UiNotificationSettingsApplyLocal` only for the personal
+  notification-only theme/size/motion screen — don't mix these up. Only the
+  first is mission-wide/authoritative; the other two are per-player and
+  never broadcast.
 - Concurrent HUD ownership (Safestart top-centre, EW lower-right, hazard
   lower-left) is handled via `Waldo_fnc_RegisterUiReservationLocal` — a new
   custom HUD plugin should register its region the same way rather than
   hand-rolling collision avoidance against Safestart/jammer/hazard panels.
+- The ACE Self Interact launcher category is **"WMP Options"** (renamed
+  from the old "WMP Interface"), covering Notification UI Settings, WMP
+  HUD (+ its own Settings), and Accessibility Settings.

--- a/.claude/skills/mission-pack-config/references/wmp-hud.md
+++ b/.claude/skills/mission-pack-config/references/wmp-hud.md
@@ -18,7 +18,7 @@ knowledge, or network state — pure client-local presentation.
 ["Waldo_WmpHud_NVGs", [ /* NVG/HMD classnames */ ]],
 ["Waldo_WmpHud_DefaultVisible", true],
 ["Waldo_WmpHud_AccessibilityDefaultVisible", true],
-["Waldo_WmpHud_AllowToggle", true],            // shows the WMP Interface self-action
+["Waldo_WmpHud_AllowToggle", true],            // shows the rapid Enable/Disable WMP HUD self-actions
 ["Waldo_WmpHud_Icon", "\a3\ui_f\data\igui\cfg\actions\getincommander_ca.paa"],
 ["Waldo_WmpHud_Colour", []],                   // [] follows colour-vision-aware theme; else RGBA 0-1
 ["Waldo_WmpHud_IconRange", 300], ["Waldo_WmpHud_NameRange", 50],
@@ -43,10 +43,25 @@ knowledge, or network state — pure client-local presentation.
 
 ## Player access
 
-Eligible users show/hide it via **ACE Self Interact > WMP Interface >
-Toggle WMP HUD** (blue vanilla `addAction` fallback without ACE). Colour-vision
-controls live separately under **WMP Interface > Accessibility** — see
-`ui-themes.md`.
+Eligible users get **ACE Self Interact > WMP Options > WMP HUD**: rapid,
+conditionally-shown **Enable WMP HUD** / **Disable WMP HUD** actions plus a
+**WMP HUD Settings** custom screen (blue vanilla `addAction` fallback
+without ACE). Colour-vision and reduced-motion controls live separately
+under **WMP Options > Accessibility Settings** — see `ui-themes.md`.
+
+### WMP HUD Settings (player-local, restriction-only)
+
+The settings screen can:
+- hide otherwise-permitted icons and/or names
+- choose **Small / Medium / Large** icon+text scale
+- choose **Low / Medium / High** opacity
+
+It can only ever make the HUD show **less** than mission configuration
+permits — it cannot expand `IconRange`/`NameRange`, reveal units the
+mission excludes, bypass LOS/equipment/UID gates, or override
+`AllowToggle`. It also explains in-place when the feature is mission-
+disabled or this player's eligibility isn't met. The choice survives
+respawn (`Waldo_fnc_WmpHudPreferences` / `Waldo_fnc_WmpHudSettingsApplyLocal`).
 
 ## Script API (local, no ZEN module)
 
@@ -55,6 +70,7 @@ controls live separately under **WMP Interface > Accessibility** — see
 [] call Waldo_fnc_WmpHudToggle;
 [] call Waldo_fnc_WmpHudStop;
 [unit] call Waldo_fnc_WmpHudEligible;
+[] call Waldo_fnc_WmpHudPreferences;            // reads this player's stored HUD content/scale/opacity prefs
 ```
 
 WMP HUD intentionally has **no ZEN module** — eligibility/presentation is


### PR DESCRIPTION
**When merged this pull request will:**
- List all 20 built-in `Waldo_UI_Theme` IDs in `references/ui-themes.md` (was documenting only the original 6)
- Document the ACE Self Interact launcher rename from "WMP Interface" to "WMP Options" across `references/ui-themes.md`, `references/wmp-hud.md` and `references/ui-notifications.md`
- Add the player-local **Notification UI Settings** screen (notification-only theme override, Small/Medium/Large size, Normal/Reduced/Off motion) to `references/ui-themes.md` and `references/ui-notifications.md`
- Add **WMP HUD Settings** (restriction-only content/scale/opacity preferences) and the rapid Enable/Disable WMP HUD actions to `references/wmp-hud.md`
- Add per-channel FIFO/lane stacking behaviour for all six notification placements to `references/ui-notifications.md`
- Note the no-red presentation rule in `references/ui-themes.md`

These skill reference files had not been touched since the skill's creation and had fallen behind two merged feature PRs (the six-theme addition and the player-configurable UI settings/notification-theme feature). Ran `releaseVerificationAndDeployment/claude_skill_validator.py` — passes.